### PR TITLE
Fix permission string on the manage_groups view

### DIFF
--- a/tardis/tardis_portal/views.py
+++ b/tardis/tardis_portal/views.py
@@ -1761,7 +1761,7 @@ def retrieve_group_userlist(request, group_id):
 
 
 @never_cache
-@permission_required('tardis_portal.change_group')
+@permission_required('auth.change_group')
 @login_required()
 def manage_groups(request):
 


### PR DESCRIPTION
Currently non-superusers get redirected to the login page, even if they have the appropriate auth.change_group permission.
