### PR TITLE
Remove all primary keys from the tardis_portal initial_data.json

### DIFF
--- a/tardis/tardis_portal/fixtures/initial_data.json
+++ b/tardis/tardis_portal/fixtures/initial_data.json
@@ -1,6 +1,6 @@
 [
     {
-        "pk": 1,
+        "pk": null,
         "model": "tardis_portal.schema",
         "fields": {
             "type": 3,
@@ -10,7 +10,7 @@
         }
     },
     {
-        "pk": 2,
+        "pk": null,
         "model": "tardis_portal.schema",
         "fields": {
             "type": 2,
@@ -20,7 +20,7 @@
         }
     },
     {
-        "pk": 3,
+        "pk": null,
         "model": "tardis_portal.schema",
         "fields": {
             "type": 2,
@@ -30,7 +30,7 @@
         }
     },
     {
-        "pk": 4,
+        "pk": null,
         "model": "tardis_portal.schema",
         "fields": {
             "type": 3,
@@ -40,7 +40,7 @@
         }
     },
     {
-        "pk": 5,
+        "pk": null,
         "model": "tardis_portal.schema",
         "fields": {
             "type": 2,
@@ -50,7 +50,7 @@
         }
     },
     {
-        "pk": 6,
+        "pk": null,
         "model": "tardis_portal.schema",
         "fields": {
             "type": 2,
@@ -60,7 +60,7 @@
         }
     },
     {
-        "pk": 7,
+        "pk": null,
         "model": "tardis_portal.schema",
         "fields": {
             "type": 3,
@@ -70,7 +70,7 @@
         }
     },
     {
-        "pk": 8,
+        "pk": null,
         "model": "tardis_portal.schema",
         "fields": {
             "type": 1,
@@ -80,7 +80,7 @@
         }
     },
     {
-        "pk": 9,
+        "pk": null,
         "model": "tardis_portal.schema",
         "fields": {
             "type": 1,
@@ -90,7 +90,7 @@
         }
     },
     {
-        "pk": 89,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "BLOCKS",
@@ -108,7 +108,7 @@
         }
     },
     {
-        "pk": 114,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "ChemicalAmount",
@@ -126,7 +126,7 @@
         }
     },
     {
-        "pk": 116,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "ChemicalCAS",
@@ -144,7 +144,7 @@
         }
     },
     {
-        "pk": 115,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "ChemicalFormula",
@@ -162,7 +162,7 @@
         }
     },
     {
-        "pk": 112,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "ChemicalName",
@@ -180,7 +180,7 @@
         }
     },
     {
-        "pk": 113,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "ChemicalPercent",
@@ -198,7 +198,7 @@
         }
     },
     {
-        "pk": 91,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "DATATYPE",
@@ -216,7 +216,7 @@
         }
     },
     {
-        "pk": 92,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "DATE",
@@ -234,7 +234,7 @@
         }
     },
     {
-        "pk": 100,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "DELTAX",
@@ -252,7 +252,7 @@
         }
     },
     {
-        "pk": 103,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "EPN",
@@ -270,7 +270,7 @@
         }
     },
     {
-        "pk": 98,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "FIRSTX",
@@ -288,7 +288,7 @@
         }
     },
     {
-        "pk": 99,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "LASTX",
@@ -306,7 +306,7 @@
         }
     },
     {
-        "pk": 101,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "NPOINTS",
@@ -324,7 +324,7 @@
         }
     },
     {
-        "pk": 94,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "ORIGIN",
@@ -342,7 +342,7 @@
         }
     },
     {
-        "pk": 111,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "PEAK",
@@ -360,7 +360,7 @@
         }
     },
     {
-        "pk": 97,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "RESOLUTION",
@@ -378,7 +378,7 @@
         }
     },
     {
-        "pk": 93,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "SAMPLINGPROCEDURE",
@@ -396,7 +396,7 @@
         }
     },
     {
-        "pk": 107,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "SampleDescription",
@@ -414,7 +414,7 @@
         }
     },
     {
-        "pk": 110,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "SampleSafety",
@@ -432,7 +432,7 @@
         }
     },
     {
-        "pk": 90,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "TITLE",
@@ -450,7 +450,7 @@
         }
     },
     {
-        "pk": 95,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "XUNITS",
@@ -468,7 +468,7 @@
         }
     },
     {
-        "pk": 96,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "YUNITS",
@@ -486,7 +486,7 @@
         }
     },
     {
-        "pk": 38,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "anomMultiplicityAll",
@@ -504,7 +504,7 @@
         }
     },
     {
-        "pk": 40,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "anomMultiplicityHigh",
@@ -522,7 +522,7 @@
         }
     },
     {
-        "pk": 39,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "anomMultiplicityLow",
@@ -540,7 +540,7 @@
         }
     },
     {
-        "pk": 104,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "beamline",
@@ -558,7 +558,7 @@
         }
     },
     {
-        "pk": 28,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "cellA",
@@ -576,7 +576,7 @@
         }
     },
     {
-        "pk": 31,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "cellAlpha",
@@ -594,7 +594,7 @@
         }
     },
     {
-        "pk": 29,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "cellB",
@@ -612,7 +612,7 @@
         }
     },
     {
-        "pk": 32,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "cellBeta",
@@ -630,7 +630,7 @@
         }
     },
     {
-        "pk": 30,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "cellC",
@@ -648,7 +648,7 @@
         }
     },
     {
-        "pk": 33,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "cellGamma",
@@ -666,7 +666,7 @@
         }
     },
     {
-        "pk": 19,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "chiAngle",
@@ -684,7 +684,7 @@
         }
     },
     {
-        "pk": 1,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "collectionDate",
@@ -702,7 +702,7 @@
         }
     },
     {
-        "pk": 66,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "completeness",
@@ -720,7 +720,7 @@
         }
     },
     {
-        "pk": 41,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "completenessAll",
@@ -738,7 +738,7 @@
         }
     },
     {
-        "pk": 43,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "completenessHigh",
@@ -756,7 +756,7 @@
         }
     },
     {
-        "pk": 42,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "completenessLow",
@@ -774,7 +774,7 @@
         }
     },
     {
-        "pk": 79,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "countingSecs",
@@ -792,7 +792,7 @@
         }
     },
     {
-        "pk": 68,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "created",
@@ -810,7 +810,7 @@
         }
     },
     {
-        "pk": 17,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "crystalName",
@@ -828,7 +828,7 @@
         }
     },
     {
-        "pk": 35,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "delanomCorrelationBettweenHalfSetsAll",
@@ -846,7 +846,7 @@
         }
     },
     {
-        "pk": 37,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "delanomCorrelationBettweenHalfSetsHigh",
@@ -864,7 +864,7 @@
         }
     },
     {
-        "pk": 36,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "delanomCorrelationBettweenHalfSetsLow",
@@ -882,7 +882,7 @@
         }
     },
     {
-        "pk": 78,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "detang",
@@ -900,7 +900,7 @@
         }
     },
     {
-        "pk": 10,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "detectorDistance",
@@ -918,7 +918,7 @@
         }
     },
     {
-        "pk": 6,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "detectorSN",
@@ -936,7 +936,7 @@
         }
     },
     {
-        "pk": 15,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "diffractometerType",
@@ -954,7 +954,7 @@
         }
     },
     {
-        "pk": 8,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "directBeamXPos",
@@ -972,7 +972,7 @@
         }
     },
     {
-        "pk": 9,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "directBeamYPos",
@@ -990,7 +990,7 @@
         }
     },
     {
-        "pk": 5,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "exposureTime",
@@ -1008,7 +1008,7 @@
         }
     },
     {
-        "pk": 25,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "firstImage",
@@ -1026,7 +1026,7 @@
         }
     },
     {
-        "pk": 21,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "framesDir",
@@ -1044,7 +1044,7 @@
         }
     },
     {
-        "pk": 73,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "frleng",
@@ -1062,7 +1062,7 @@
         }
     },
     {
-        "pk": 71,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "frqimn",
@@ -1080,7 +1080,7 @@
         }
     },
     {
-        "pk": 75,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "frqimx",
@@ -1098,7 +1098,7 @@
         }
     },
     {
-        "pk": 77,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "frtype",
@@ -1116,7 +1116,7 @@
         }
     },
     {
-        "pk": 74,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "frwlen",
@@ -1134,7 +1134,7 @@
         }
     },
     {
-        "pk": 72,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "frxcen",
@@ -1152,7 +1152,7 @@
         }
     },
     {
-        "pk": 76,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "frycen",
@@ -1170,7 +1170,7 @@
         }
     },
     {
-        "pk": 64,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "highRes",
@@ -1188,7 +1188,7 @@
         }
     },
     {
-        "pk": 81,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "ibs",
@@ -1206,7 +1206,7 @@
         }
     },
     {
-        "pk": 82,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "ibsBgnd",
@@ -1224,7 +1224,7 @@
         }
     },
     {
-        "pk": 11,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "imageSizeX",
@@ -1242,7 +1242,7 @@
         }
     },
     {
-        "pk": 12,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "imageSizeY",
@@ -1260,7 +1260,7 @@
         }
     },
     {
-        "pk": 2,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "imageType",
@@ -1278,7 +1278,7 @@
         }
     },
     {
-        "pk": 83,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "io",
@@ -1296,7 +1296,7 @@
         }
     },
     {
-        "pk": 84,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "ioBgnd",
@@ -1314,7 +1314,7 @@
         }
     },
     {
-        "pk": 69,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "isigImage",
@@ -1332,7 +1332,7 @@
         }
     },
     {
-        "pk": 85,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "it",
@@ -1350,7 +1350,7 @@
         }
     },
     {
-        "pk": 86,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "itBgnd",
@@ -1368,7 +1368,7 @@
         }
     },
     {
-        "pk": 26,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "lastImage",
@@ -1386,7 +1386,7 @@
         }
     },
     {
-        "pk": 44,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "meanIOverSdIAll",
@@ -1404,7 +1404,7 @@
         }
     },
     {
-        "pk": 45,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "meanIOverSdILow",
@@ -1422,7 +1422,7 @@
         }
     },
     {
-        "pk": 70,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "mergeImage",
@@ -1440,7 +1440,7 @@
         }
     },
     {
-        "pk": 34,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "midslopeAnomNormProb",
@@ -1458,7 +1458,7 @@
         }
     },
     {
-        "pk": 18,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "mosaicSpread",
@@ -1476,7 +1476,7 @@
         }
     },
     {
-        "pk": 4,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "oscillationRangeEnd",
@@ -1494,7 +1494,7 @@
         }
     },
     {
-        "pk": 3,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "oscillationRangeStart",
@@ -1512,7 +1512,7 @@
         }
     },
     {
-        "pk": 62,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "pointlessLog",
@@ -1530,7 +1530,7 @@
         }
     },
     {
-        "pk": 80,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "positionerString",
@@ -1548,7 +1548,7 @@
         }
     },
     {
-        "pk": 87,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "positionerValues",
@@ -1566,7 +1566,7 @@
         }
     },
     {
-        "pk": 102,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "previewImage",
@@ -1584,7 +1584,7 @@
         }
     },
     {
-        "pk": 105,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "previewImage",
@@ -1602,7 +1602,7 @@
         }
     },
     {
-        "pk": 22,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "processingDir",
@@ -1620,7 +1620,7 @@
         }
     },
     {
-        "pk": 65,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "rMerge",
@@ -1638,7 +1638,7 @@
         }
     },
     {
-        "pk": 67,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "ranom",
@@ -1656,7 +1656,7 @@
         }
     },
     {
-        "pk": 14,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "resolutionLimit",
@@ -1674,7 +1674,7 @@
         }
     },
     {
-        "pk": 58,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "rmeasIplusAndIminusAll",
@@ -1692,7 +1692,7 @@
         }
     },
     {
-        "pk": 60,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "rmeasIplusAndIminusHigh",
@@ -1710,7 +1710,7 @@
         }
     },
     {
-        "pk": 59,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "rmeasIplusAndIminusLow",
@@ -1728,7 +1728,7 @@
         }
     },
     {
-        "pk": 23,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "rootName",
@@ -1746,7 +1746,7 @@
         }
     },
     {
-        "pk": 52,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "rpimIplusAndIminusAll",
@@ -1764,7 +1764,7 @@
         }
     },
     {
-        "pk": 54,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "rpimIplusAndIminusHigh",
@@ -1782,7 +1782,7 @@
         }
     },
     {
-        "pk": 53,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "rpimIplusAndIminusLow",
@@ -1800,7 +1800,7 @@
         }
     },
     {
-        "pk": 55,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "rpimWithinIplusAndIminusAll",
@@ -1818,7 +1818,7 @@
         }
     },
     {
-        "pk": 57,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "rpimWithinIplusAndIminusHigh",
@@ -1836,7 +1836,7 @@
         }
     },
     {
-        "pk": 56,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "rpimWithinIplusAndIminusLow",
@@ -1854,7 +1854,7 @@
         }
     },
     {
-        "pk": 24,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "runNumber",
@@ -1872,7 +1872,7 @@
         }
     },
     {
-        "pk": 63,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "scalaLog",
@@ -1890,7 +1890,7 @@
         }
     },
     {
-        "pk": 27,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "spacegroup",
@@ -1908,7 +1908,7 @@
         }
     },
     {
-        "pk": 88,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "timeStampString",
@@ -1926,7 +1926,7 @@
         }
     },
     {
-        "pk": 49,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "totalObsAll",
@@ -1944,7 +1944,7 @@
         }
     },
     {
-        "pk": 51,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "totalObsHigh",
@@ -1962,7 +1962,7 @@
         }
     },
     {
-        "pk": 50,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "totalObsLow",
@@ -1980,7 +1980,7 @@
         }
     },
     {
-        "pk": 46,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "totalUniqueAll",
@@ -1998,7 +1998,7 @@
         }
     },
     {
-        "pk": 48,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "totalUniqueHigh",
@@ -2016,7 +2016,7 @@
         }
     },
     {
-        "pk": 47,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "totalUniqueLow",
@@ -2034,7 +2034,7 @@
         }
     },
     {
-        "pk": 13,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "twoTheta",
@@ -2052,7 +2052,7 @@
         }
     },
     {
-        "pk": 61,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "xdsLog",
@@ -2070,7 +2070,7 @@
         }
     },
     {
-        "pk": 16,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "xraySource",
@@ -2088,7 +2088,7 @@
         }
     },
     {
-        "pk": 7,
+        "pk": null,
         "model": "tardis_portal.parametername",
         "fields": {
             "name": "xrayWavelength",
@@ -2107,16 +2107,22 @@
     },
     {
         "fields": {
-            "parameter_name": "103" 
-        }, 
-        "model": "tardis_portal.freetextsearchfield", 
+            "parameter_name": [
+                "http://www.tardis.edu.au/schemas/as/experiment/2010/09/21",
+                "EPN"
+            ]
+        },
+        "model": "tardis_portal.freetextsearchfield",
         "pk": 1
     },
     {
         "fields": {
-            "parameter_name": "104" 
-        }, 
-        "model": "tardis_portal.freetextsearchfield", 
+            "parameter_name": [
+                "http://www.tardis.edu.au/schemas/as/experiment/2010/09/21",
+                "beamline"
+            ]
+        },
+        "model": "tardis_portal.freetextsearchfield",
         "pk": 2
     }
 ]


### PR DESCRIPTION
This patch removes all primary keys from the `tardis_portal` `initial_data.json` fixture.

They clobber any data added by an app earlier in `INSTALLED_APPS`, and they're unnecessary through the use of natural keys.
