### PR TITLE
Login should generate 403 on failure, not 500

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/portal_template.html
+++ b/tardis/tardis_portal/templates/tardis_portal/portal_template.html
@@ -103,21 +103,15 @@
 
   <div id="page"> <!-- start page -->
     <div id="content-box">
-              <div class="jqmAlertStatus" id="jqmAlertStatus">
-                  <div class="jqmAlertWindowStatus">
-
-                    {% if error %}
-                    <div class="jqmAlertContentStatus" id="jqmAlertContentStatus"><a href="#" class="jqmClose"></a>
-                      <br/>{{status}}
-
-                    </div> <!-- statusBoxError -->
-                    {% else %}
-                    <div class="jqmAlertContentStatus" id="jqmAlertContentStatus"><a href="#" class="jqmClose"></a>
-                      <br/><span id="jqmStatusMessage">{{status}}</span>
-                    </div> <!-- statusBox -->
-                    {% endif %}
-                   </div> <!-- window -->
-               </div> <!-- status -->
+      <div class="jqmAlertStatus" id="jqmAlertStatus">
+        <div class="jqmAlertWindowStatus">
+          <div class="jqmAlertContentStatus" id="jqmAlertContentStatus">
+            <a href="#" class="jqmClose"></a>
+            <br/>
+            <span id="jqmStatusMessage">{{status}}</span>
+          </div> <!-- statusBox -->
+        </div> <!-- window -->
+      </div> <!-- status -->
       {% block content %}
       {% endblock content %}
 

--- a/tardis/tardis_portal/tests/test_authentication.py
+++ b/tardis/tardis_portal/tests/test_authentication.py
@@ -66,7 +66,7 @@ class AuthenticationTestCase(TestCase):
 
         response = self.client.post(self.loginUrl, {'username': username,
             'password': password, 'authMethod': authMethod})
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.status_code, 403)
 
         userAuth = UserAuthentication.objects.filter(
             username=username, authenticationMethod=authMethod)
@@ -79,7 +79,7 @@ class AuthenticationTestCase(TestCase):
 
         response = self.client.post(self.loginUrl, {'username': username,
             'password': password, 'authMethod': authMethod})
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.status_code, 403)
         self.client.logout()
 
     def testManageAuthMethods(self):

--- a/tardis/tardis_portal/views.py
+++ b/tardis/tardis_portal/views.py
@@ -51,7 +51,7 @@ from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import render_to_response
 from django.contrib.auth.models import User, Group, AnonymousUser
-from django.http import HttpResponseRedirect, HttpResponse
+from django.http import HttpResponseRedirect, HttpResponse, HttpResponseForbidden
 from django.contrib.auth.decorators import login_required, permission_required
 from django.core.urlresolvers import reverse
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
@@ -86,7 +86,7 @@ from tardis.tardis_portal.auth import decorators as authz
 from tardis.tardis_portal.auth import auth_service
 from tardis.tardis_portal.shortcuts import render_response_index, \
     return_response_error, return_response_not_found, \
-    return_response_error_message, render_response_search
+    render_response_search
 from tardis.tardis_portal.metsparser import parseMets
 from tardis.tardis_portal.creativecommonshandler import CreativeCommonsHandler
 from tardis.tardis_portal.hacks import oracle_dbops_hack
@@ -711,8 +711,8 @@ def login(request):
         c = Context({'status': "Sorry, username and password don't match.",
                      'error': True,
                      'loginForm': LoginForm()})
-        return return_response_error_message(
-            request, 'tardis_portal/login.html', c)
+        return HttpResponseForbidden( \
+                render_response_index(request, 'tardis_portal/login.html', c))
 
     c = Context({'loginForm': LoginForm()})
 


### PR DESCRIPTION
No, seriously, it should. This patch also contains a little neatening up that fixes error message display.
