### PR TITLE
Add blocks to experiment description template for overriding to help red...

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_description.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_description.html
@@ -1,39 +1,50 @@
 {% load creativecommons %}
 <div id="experiment_description">
 
+  {% block authors %}
   <p>
     <strong>Authors: </strong><br/>
     {% for author in authors %}
       {{ author.author }}{% if not forloop.last %},{% endif %}
     {% endfor %}
   </p>
+  {% endblock authors %}
 
+  {% block abstract %}
   <p>
     <strong>Abstract: </strong>
     <div class="abstract">
       {{ experiment.description|safe }}
     </div>
   </p>
+  {% endblock abstract %}
 
+  {% block handle %}
   {% if experiment.handle %}
-    <p>
+  <p>
       <strong>Persistent Handle:</strong>
       <a href="http://hdl.handle.net/{{ experiment.handle }}">{{ experiment.handle }}</a><br/>
-    </p>
+  </p>
   {% endif %}
+  {% endblock handle %}
 
+  {% block institution %}
   <p>
     <strong>Institution:</strong>
     {{experiment.institution_name}}<br/>
   </p>
+  {% endblock institution %}
 
+  {% block start_end_time %}
   {% if experiment.start_time and experiment.end_time %}
     <p>
       <strong>Date:</strong>
       {{ experiment.start_time|date:"jS F Y H:i" }} - {{ experiment.end_time|date:"jS F Y H:i" }}<br/>
     </p>
   {% endif %}
+  {% endblock start_end_time %}
 
+  {% block experiment_metadata %}
   <p>
     <div class="experiment_md_container">
         <strong style="float:left; margin-right: 5px">Experiment Metadata</strong>
@@ -50,11 +61,13 @@
             <span class="ui-icon ui-icon-circle-triangle-e"></span>
             Show/Hide
         </a>
-	</div>
+    </div>
     <div style="clear:both;"></div>
     <div class="experiment_metadata" style="display:none;"></div>
   </p>
+  {% endblock experiment_metadata %}
 
+  {% block dataset_info %}
   <p>
     <strong>Dataset Information:</strong>
     <div>
@@ -67,56 +80,80 @@
       </div>
     </div>
   </p>
+  {% endblock dataset_info %}
 
+  {% block updated %}
   <p>
     <strong>Experiment Last Updated:</strong>
     {{ experiment.update_time|date:"jS F Y H:i" }}<br/>
   </p>
-	<p>
-	<strong>License: </strong>
-	<div class="license_box">{{experiment.id|show_cc_license|safe}}</div>
-	</p>
+  {% endblock updated %}
+
+  {% block license %}
+  <p>
+    <strong>License: </strong>
+    <div class="license_box">{{experiment.id|show_cc_license|safe}}</div>
+  </p>
+  {% endblock license %}
+
+  {% block extra_info %}
+  {% endblock extra_info %}
+
   <div class="download_entire_experiment">
+  {% block downloads %}
     {% for p in protocol %}
       <p>
-	{% if p.0 %}
-	  <strong><a href="{{p.1}}">Download Entire Experiment ({{p.0|upper}})</a></strong><br/>
-	{% else %}
-	  <strong><a href="{{p.1}}">Download Entire Experiment</a></strong><br/>
-	{% endif %}
+    {% if p.0 %}
+      <strong><a href="{{p.1}}">Download Entire Experiment ({{p.0|upper}})</a></strong><br/>
+    {% else %}
+      <strong><a href="{{p.1}}">Download Entire Experiment</a></strong><br/>
+    {% endif %}
       </p>
     {% endfor %}
-	{% if is_owner %}
-	<p>
-		<a href="{% url tardis.tardis_portal.views.choose_license experiment.id %}">Choose License</a>
-	</p>
-	{% if not experiment.public %}
-		<strong><a href="publish/">Publish Experiment</a></strong><br/>
-	{% endif %}
-	{% endif %}
+  {% endblock downloads %}
   </div>
 
-  <p align="right">
-    <br/>
-    {% if owners %}
-      <strong>Experiment Administrators </strong><br/>
-      {% for owner in owners %}
-        {% if owner.email %}
-          <a href="mailto:{{owner.email}}">{{ owner.email}}</a>
-        {% endif %}
-        ({{ owner.username }})
-        {% if not forloop.last %}
-          <br/>
-		{% endif %}
-		{% endfor %}
-	{% endif %}
-	</p>
-	<p align="right">
-	{% if experiment.public %}
-		<em>This experiment is public.</em>
-	{% endif %}
-      
-  </p>
+  {% block extra_content %}
+  {% endblock extra_content %}
+
+  {% block experiment_admin %}
+      {% block experiment_owners %}
+      {% if owners %}
+      <p>
+        <br/>
+        <strong>Experiment Administrators </strong><br/>
+        {% for owner in owners %}
+          {% if owner.email %}
+            <a href="mailto:{{owner.email}}">{{ owner.email}}</a>
+          {% endif %}
+          ({{ owner.username }})
+          {% if not forloop.last %}
+            <br/>
+          {% endif %}
+        {% endfor %}
+      </p>
+      {% endif %}
+      {% endblock experiment_owners %}
+
+      {% if experiment.public %}
+      <p>
+        <em>This experiment is public.</em>
+      </p>
+      {% endif %}
+
+      {% if is_owner %}
+      <p>
+        <a href="{% url tardis.tardis_portal.views.choose_license experiment.id %}">Choose License</a>
+      </p>
+      {% block publish_link %}
+      {% if not experiment.public %}
+      <p>
+        <strong><a href="publish/">Publish Experiment</a></strong><br/>
+      </p>
+      {% endif %}
+      {% endblock publish_link %}
+      {% endif %}
+  {% endblock experiment_admin %}
 
 </div>
 


### PR DESCRIPTION
...uce duplicate code in customised themes.

The Synchrotron and ANSTO deployments customise various bits of the experiment description page. This change will allow them to replace just the bits they need without copying the entire experiment_description.html template.

I have also moved the 'publish experiment' and 'choose license' links to the experiment admin section of the page.
