### PR TITLE
Adding optional web worker to Foreman config

### DIFF
--- a/.foreman
+++ b/.foreman
@@ -1,0 +1,2 @@
+concurrency: uwsgi=1,web=0,celerybeat=1,celeryd=1
+port: 3031

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
-web: ./run_uwsgi.sh --socket 127.0.0.1:$PORT
+uwsgi: ./run_uwsgi.sh --socket 127.0.0.1:$PORT
+web: ./run_uwsgi.sh --http 127.0.0.1:8000
 celerybeat: bin/django celerybeat
 celeryd: bin/django celeryd --concurrency 5


### PR DESCRIPTION
This allows you to run a Django server and Celery queue in dev with:

```
foreman start -c web=1,celerybeat=1,celeryd=1
```

I think it's more convenient than opening a second console to run Celery.
