### PR TITLE
Timezone handling

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -18,6 +18,8 @@ eggs =
     celery
     django-celery
     django-kombu
+    iso8601
+    pytz
 
 find-links =
     http://dist.plone.org/thirdparty/

--- a/tardis/test_settings.py
+++ b/tardis/test_settings.py
@@ -19,6 +19,10 @@ DATABASES = {
     }
 }
 
+# Test timezone is GMT+10:00
+# http://twiki.org/cgi-bin/xtra/tzdate?tz=Etc/GMT-10
+TIME_ZONE = 'Etc/GMT-10'
+
 # Celery queue uses Django for persistence
 BROKER_TRANSPORT = 'django'
 # During testing it's always eager


### PR DESCRIPTION
The Atom app needs a mechanism for properly handling dates with time zone information as parameters.

I've enhanced `ParameterSetManager` to convert all dates to timezone-aware local time before persisting and after retrieval. This should also handle the [Django "dev" behaviour](https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-USE_TZ) for `USE_TZ`, if we ever turn that on.
