### PR TITLE
Adding missed dependency for RIF-CS support.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -20,6 +20,7 @@ eggs =
     django-kombu
     iso8601
     pytz
+    html2text
 
 find-links =
     http://dist.plone.org/thirdparty/


### PR DESCRIPTION
Somehow the `html2text` dependency got missed for the existing RIF-CS support.

Even if I make that code redundant later, the dependency does actually provide some useful functionality which will get reused, so I'm adding it.
