### PR TITLE
Improvements to the 'Create Experiment' interface

### DIFF
--- a/tardis/tardis_portal/static/css/default.css
+++ b/tardis/tardis_portal/static/css/default.css
@@ -665,7 +665,7 @@ table.experiment-table th {
 	font-weight: bold;
 	}
 
-	.my_files {
+	#create_experiment_form div.my_files {
 	padding: 5px 10px;
 	position: relative;
 	background-color: #dcdcdc;
@@ -674,8 +674,32 @@ table.experiment-table th {
 	font-size: 14px;
 	font-weight: bold;
 	}
+	
+    #file_select_container div.transfer_instructions
+    {
+        padding: 10px;
+    }
 
-	.add_new_dataset {
+    #create_experiment_form div.datasets
+    {
+        width: 520px;
+    }
+
+    #create_experiment_form div.floating_file_staging {
+    position:fixed;
+    width:400px;
+    z-index:100;
+    top: 27%;
+    left: auto;
+    right: 2%;
+    background-color: white;
+    border: 1px gray solid;
+    padding: 20px;
+    height: 360px;
+    overflow: auto;
+    }	
+
+	#create_experiment_form div.datasets .add_new_dataset {
 	padding: 5px 10px;
 	cursor: pointer;
 	position: relative;

--- a/tardis/tardis_portal/templates/tardis_portal/create_experiment.html
+++ b/tardis/tardis_portal/templates/tardis_portal/create_experiment.html
@@ -53,11 +53,15 @@
     }
 
     $(document).ready(function() {
-	{% if directory_listing %}
+    {% if directory_listing %}
         $("#demo1").jstree({
-	    core : { /* core options go here */ },
-	    plugins : [ "themes", "html_data", "checkbox" ]
-	});
+        core : { "initially_open" : ['phtml_1'] },
+        plugins : [ "themes", "html_data", "checkbox" ],
+    	checkbox : { 
+    	                two_state : true, 
+    					checked_parent_open: true,
+    	        },
+    });
 
 	//Get checked
 	$('.add_files').live('click', function(){
@@ -262,52 +266,59 @@
 		</div>
 	      </div>
         <form id="create_experiment_form" action="" method="POST">
+        <input type="hidden" name="username" value="{{username}}" id="username" />
           {{ form.non_field_errors }}
           <div class="msg_list">
-            <p class="exp_head">Experiment Information</p>
+            <p class="exp_head">Experiment Information
+                *<small>required</small></p>
             <div class="exp_body">
               <div class="fieldWrapper">
                 {{ form.title.errors }}
                 <label for="id_title">Title:</label><br/>
-                {{ form.title }}
+                {{ form.title }}*
               </div>
 
               <div class="fieldWrapper">
                 {{ form.authors.errors }}
                 <label for="id_title">Authors (comma separate):</label><br/>
-                {{ form.authors }}
+                {{ form.authors }}*
               </div>
 
               <div class="fieldWrapper">
                 {{ form.institution_name.errors }}
                 <label for="id_institution">Institution Name:</label><br/>
-                {{ form.institution_name }}
+                {{ form.institution_name }}*
               </div>
 
               <div class="fieldWrapper">
                 {{ form.description.errors }}
                 <label for="id_description">Description:</label><br/>
-                {{ form.description }}
+                {{ form.description }}*
               </div>
             </div>
 	    {% if directory_listing %}
-              <p class="my_files">My Files</p>
+	    <div id="file_select_container" class="floating_file_staging">
+        <div class="my_files">My Files</div>
 	      <div class="msg_body">
 		<p><strong>Select Files To Be Added To A Dataset:</strong></p>
-		<div id="demo1" class="demo">
-		  {{directory_listing|safe}}
-		</div>
-		<p>
-		To add files to 'My Files', mount the following file store via your operating system:
-		</p>
-		<p id="mountpath">
-		<strong>{{staging_mount_prefix}}{{username}}</strong>
-		</p>
-		<p>
-		<a href="#">User Guide</a>
-		</p>
+    		<div id="demo1" class="demo">
+    		  {{directory_listing|safe}}
+    		</div>
+    	</div>
+        	<div id="transfer_instructions">		
+    		<p>
+                To add files and folders to the 'Transfer Data' window, mount the following file store via your operating system:
+            </p>
+
+    		<p id="mountpath">
+    		<strong>{{staging_mount_prefix}}{{username}}</strong>
+    		</p>
+                {# <p> #}
+                {# <a href="#">User Guide</a> #}
+                {# </p> #}
+    		</div>
 		<br/>
-	      </div>
+	    </div>
 	    {% endif %}
 
 	    <div class="datasets">


### PR DESCRIPTION
I'm going to make and approve this pull request myself, as there are no internal logic changes, just interface changes to the Create Experiment page. It's not major, but I'd like this in before the 2.5 tag release.
- 'My Files' tree opens root node automatically
- 'My Files' box floats and is static as page scrolls (z-index)
- Slight css improvements

There'll be an upcoming, separate pull request for code I've written to enable asynchronous submission of the create/edit experiment form (as this process can be slow), and an option to only display folders, not files (for performance).
