### PR TITLE
Adding Django Sites plugin to `settings_changeme.py`.

### DIFF
--- a/tardis/settings_changeme.py
+++ b/tardis/settings_changeme.py
@@ -162,6 +162,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
+    'django.contrib.sites',
     'django.contrib.admin',
     'django.contrib.admindocs',
     'django.contrib.staticfiles',


### PR DESCRIPTION
It was already in `test_settings.py`, which is why all the unit tests passed.
