### PR TITLE
Adding Foreman templates so we don't need a patch to get MyTardis to stop

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -254,7 +254,9 @@ exporting system scripts:
     # Start with Foreman
     foreman start
     # Export Upstart start-up scripts (running as user "django")
-    sudo foreman export upstart /etc/init -u django -p 3031
+    # (We use a patched template while we wait for
+    # https://github.com/ddollar/foreman/pull/137 to be merged.)
+    sudo foreman export upstart /etc/init -u <mytardis_user> -p 3031 -t ./foreman
 
 
 Nginx should then be configured to send requests to the server::

--- a/foreman/master.conf.erb
+++ b/foreman/master.conf.erb
@@ -1,0 +1,8 @@
+pre-start script
+
+bash << "EOF"
+  mkdir -p <%= log_root %>
+  chown -R <%= user %> <%= log_root %>
+EOF
+
+end script

--- a/foreman/process.conf.erb
+++ b/foreman/process.conf.erb
@@ -1,0 +1,5 @@
+start on starting <%= app %>-<%= process.name %>
+stop on stopping <%= app %>-<%= process.name %>
+respawn
+
+exec su - <%= user %> --shell=/bin/bash -c 'cd <%= engine.directory %>; trap '\''kill $(jobs -p)'\'' EXIT; export PORT=<%= port %>;<% engine.environment.each_pair do |var,env| %> export <%= var.upcase %>=<%= env %>; <% end %> <%= process.command %> >> <%= log_root %>/<%=process.name%>-<%=num%>.log 2>&1'

--- a/foreman/process_master.conf.erb
+++ b/foreman/process_master.conf.erb
@@ -1,0 +1,2 @@
+start on starting <%= app %>
+stop on stopping <%= app %>


### PR DESCRIPTION
This change includes the changes in ddollar/foreman#137, so that the Upstart scripts will properly stop with a vanilla version of Foreman.
