### PR TITLE
Fixing a potential security issue in `staging.py`

### DIFF
--- a/tardis/tardis_portal/staging.py
+++ b/tardis/tardis_portal/staging.py
@@ -265,7 +265,7 @@ def write_uploaded_file_to_dataset(dataset, uploaded_file_post, filename=None):
     if not path.exists(dataset_path):
         makedirs(dataset_path)
 
-    copyto = path.join(dataset_path, filename)
+    copyto = path.join(dataset_path, path.basename(filename))
 
     copyto = duplicate_file_check_rename(copyto)
 


### PR DESCRIPTION
The filename `write_uploaded_file_to_dataset()` uses is now striped to the path basename, which prevents absolute paths being used to write uploaded files to arbitrary filesystem locations.
