### PR TITLE
Restore directory structure in staging.py

### DIFF
--- a/tardis/tardis_portal/staging.py
+++ b/tardis/tardis_portal/staging.py
@@ -262,13 +262,20 @@ def write_uploaded_file_to_dataset(dataset, uploaded_file_post, filename=None):
 
     dataset_path = path.join(experiment_path, str(dataset.id))
 
-    if not path.exists(dataset_path):
-        makedirs(dataset_path)
-
-    copyto = path.join(dataset_path, path.basename(filename))
+    # Path on disk can contain subdirectories - but if the request gets tricky with "../" or "/var" or something
+    # we strip them out..
+    try:
+        from django.utils import _os
+        copyto = _os.safe_join(dataset_path, filename)
+    except ValueError:
+        copyto = path.join(dataset_path, path.basename(filename))
+    
+    if not path.exists(path.dirname(copyto)):
+        makedirs(path.dirname(copyto))
 
     copyto = duplicate_file_check_rename(copyto)
 
+    logging.getLogger(__name__).debug("Writing uploaded file {0} to dataset {1}".format(copyto, dataset))
     uploaded_file = open(copyto, 'wb+')
 
     try:


### PR DESCRIPTION
Restoring directory structure in staging.py while still preventing filenames submitted to staging.py containing dangerous paths.

Patch courtesy of @stevage.
