### PR TITLE
Add an integrity checking view to the sync app to show which files appear missing/incomplete when syncing

### DIFF
--- a/tardis/apps/sync/admin.py
+++ b/tardis/apps/sync/admin.py
@@ -30,6 +30,7 @@
 #
 
 from django.contrib import admin
+from django.core.urlresolvers import reverse
 import models
 
 class SyncedExperimentAdmin(admin.ModelAdmin):
@@ -37,8 +38,9 @@ class SyncedExperimentAdmin(admin.ModelAdmin):
         exp = item.experiment
         admin_link = '../../%s/%s/%d/' % (
                 exp._meta.app_label, exp._meta.module_name, exp.id)
-        return '<a href="%s">%s</a> (<a href="%s">admin</a>)' % (
-                exp.get_absolute_url(), unicode(exp), admin_link)
+        integrity_link = reverse('sync-integrity', kwargs={ 'experiment_id': exp.id })
+        return '<a href="%s">%s</a> (<a href="%s">admin</a>) (<a href="%s">integrity check</a>)' % (
+                exp.get_absolute_url(), unicode(exp), admin_link, integrity_link)
     experiment_.allow_tags = True
 
     search_fields = [ 'uid', 'provider_url', 'experiment__id']

--- a/tardis/apps/sync/templates/sync/integrity.html
+++ b/tardis/apps/sync/templates/sync/integrity.html
@@ -1,0 +1,62 @@
+{% extends 'tardis_portal/data_browsing_template.html' %}
+
+{% block script %}
+{{ block.super }}
+<style type="text/css">
+    table th {
+        background-color: #a0a0a0;
+        color: white;
+        font-size: 1.2em;
+    }
+    table tr.odd {
+        background-color: #d0d0d0;
+    }
+    table tr.even {
+        background-color: #e0e0e0;
+    }
+    td.filename {
+        font-weight: bold;
+    }
+    td {
+        padding: 5px 10px 5px 10px;
+        text-align: right;
+    }
+    th {
+        padding: 10px;
+    }
+</style>
+{% endblock script %}
+
+{% block content %}
+
+<h1>Integrity check report for experiment {{ experiment_id }}</h1>
+<h3>
+    <table>
+        <tr><th>Complete</th><th>Incomplete</th><th>Missing</th></tr>
+        <tr class="odd"><td>{{ files_ok }}</td><td>{{ files_incomplete }}</td><td>{{ files_missing }}</td></tr>
+    </table>
+</h3>
+
+<br/>
+
+<table>
+{% spaceless %}
+    <tr>
+        <th>URL<br/>Filename</th>
+        <th>Expected size</th>
+        <th>Actual size</th>
+    </tr>
+    {% for id, df in datafiles.items %}
+    {% if not df.complete %}
+    <tr class="{% cycle 'odd' 'even'%}">
+        <td class="filename"><pre>{{ df.url }}
+{{ df.filename }}</pre></td>
+        <td>{{ df.expected_size }}</td>
+        <td>{{ df.size }}</td>
+    </tr>
+    {% endif %}
+{% endfor %}
+{% endspaceless %}
+</table>
+
+{% endblock content %}

--- a/tardis/apps/sync/urls.py
+++ b/tardis/apps/sync/urls.py
@@ -56,6 +56,7 @@ consumer_urls = patterns(
 interface_urls = patterns(
             'tardis.apps.sync.views',
             (r'^index/(?P<experiment_id>\d+)/$', 'index'),
+            url(r'^integrity/(?P<experiment_id>\d+)/$', 'integrity', name='sync-integrity'),
 )
 
 urlpatterns = patterns('',


### PR DESCRIPTION
I'm just creating this here as a reference - not suggesting it should be merged.

These changes make it easier to tell why a synced experiment has failed an integrity check.
