### PR TITLE
Tidy up the shortcuts.py

### DIFF
--- a/tardis/settings_changeme.py
+++ b/tardis/settings_changeme.py
@@ -98,6 +98,7 @@ TEMPLATE_CONTEXT_PROCESSORS = [
     'tardis.tardis_portal.context_processors.single_search_processor',
     'tardis.tardis_portal.context_processors.tokenuser_processor',
     'tardis.tardis_portal.context_processors.registration_processor',
+    'tardis.tardis_portal.context_processors.user_details_processor',
 ]
 
 TEMPLATE_LOADERS = (

--- a/tardis/tardis_portal/context_processors.py
+++ b/tardis/tardis_portal/context_processors.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from tardis.tardis_portal.staging import get_full_staging_path
 
 def single_search_processor(request):
 
@@ -29,3 +30,17 @@ def registration_processor(request):
             pass
         return False
     return {'registration_enabled': is_registration_enabled()}
+
+def user_details_processor(request):
+    is_authenticated = request.user.is_authenticated()
+    if is_authenticated:
+        is_superuser = request.user.is_superuser
+        username = request.user.username
+    else:
+        is_superuser = False
+        username = None
+    staging = True if get_full_staging_path(username) else False
+    return {'username': username,
+            'is_authenticated': is_authenticated,
+            'is_superuser': is_superuser, 
+            'has_staging_access': staging}

--- a/tardis/tardis_portal/shortcuts.py
+++ b/tardis/tardis_portal/shortcuts.py
@@ -10,52 +10,17 @@ from django.http import HttpResponse, \
 from tardis.tardis_portal.models import \
     ExperimentParameterSet, Schema
 from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
-from tardis.tardis_portal.staging import get_full_staging_path
 
 from django.template.loader import render_to_string
 
 
 def render_response_index(request, *args, **kwargs):
-
-    is_authenticated = request.user.is_authenticated()
-    if is_authenticated:
-        is_superuser = request.user.is_superuser
-        username = request.user.username
-    else:
-        is_superuser = False
-        username = None
-
-    if ('context_instance' in kwargs):
-        kwargs['context_instance'] = RequestContext(request,
-                                                    kwargs['context_instance'])
-    else:
-        kwargs['context_instance'] = RequestContext(request)
-    kwargs['context_instance']['is_authenticated'] = is_authenticated
-    kwargs['context_instance']['is_superuser'] = is_superuser
-    kwargs['context_instance']['username'] = username
-
-    staging = get_full_staging_path(
-                                username)
-    if staging:
-        kwargs['context_instance']['has_staging_access'] = True
-    else:
-        kwargs['context_instance']['has_staging_access'] = False
-
     return render(request, *args, **kwargs)
 
 
-def render_response_search(request, *args, **kwargs):
+def render_response_search(request, url, c):
 
     from tardis.tardis_portal.views import getNewSearchDatafileSelectionForm
-
-    is_authenticated = request.user.is_authenticated()
-    if is_authenticated:
-        is_superuser = request.user.is_superuser
-        username = request.user.username
-    else:
-        is_superuser = False
-        username = None
-
 
     links = {}
     for app in settings.INSTALLED_APPS:
@@ -66,22 +31,11 @@ def render_response_search(request, *args, **kwargs):
             except:
                 pass
 
-    kwargs['context_instance'] = RequestContext(request)
-    kwargs['context_instance']['is_authenticated'] = is_authenticated
-    kwargs['context_instance']['is_superuser'] = is_superuser
-    kwargs['context_instance']['username'] = username
-    kwargs['context_instance']['searchDatafileSelectionForm'] = \
+    c['searchDatafileSelectionForm'] = \
         getNewSearchDatafileSelectionForm(request.GET.get('type', None))
-    kwargs['context_instance']['links'] = links
+    c['links'] = links
 
-    staging = get_full_staging_path(
-                                username)
-    if staging:
-        kwargs['context_instance']['has_staging_access'] = True
-    else:
-        kwargs['context_instance']['has_staging_access'] = False
-
-    return render(request, *args, **kwargs)
+    return render(request, url, c)
 
 
 def return_response_not_found(request):

--- a/tardis/test_settings.py
+++ b/tardis/test_settings.py
@@ -99,6 +99,18 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.transaction.TransactionMiddleware'
 )
 
+TEMPLATE_CONTEXT_PROCESSORS = [
+    'django.core.context_processors.request',
+    'django.core.context_processors.static',
+    'django.contrib.auth.context_processors.auth',
+    'django.core.context_processors.debug',
+    'django.core.context_processors.i18n',
+    'tardis.tardis_portal.context_processors.single_search_processor',
+    'tardis.tardis_portal.context_processors.tokenuser_processor',
+    'tardis.tardis_portal.context_processors.registration_processor',
+    'tardis.tardis_portal.context_processors.user_details_processor',
+]
+
 TEMPLATE_LOADERS = (
     'tardis.template.loaders.app_specific.Loader',
     'django.template.loaders.app_directories.Loader',


### PR DESCRIPTION
Tidy up the `render_response_search` and `render_response_index` methods in `shortcuts.py` to do things the normal django way.  

The user name and access properties are handled by a new template context processor method, and the search related properties are added to the existing Context dictionary.
