### PR TITLE
Correcting very poorly thought-out RIFCS hasCollector implementation.

### DIFF
--- a/tardis/apps/oaipmh/provider/experiment.py
+++ b/tardis/apps/oaipmh/provider/experiment.py
@@ -230,10 +230,7 @@ class RifCsExperimentProvider(AbstractExperimentProvider):
                     for ps in ExperimentParameterSet.objects\
                                                 .filter(experiment=experiment,
                                                         schema__namespace=ns)]
-        collectors = \
-            Author_Experiment.objects\
-              .exclude(experiment__public_access=Experiment.PUBLIC_ACCESS_NONE)\
-              .exclude(url='')
+        collectors = experiment.author_experiment_set.exclude(url='')
         return Metadata({
             '_writeMetadata': self._get_experiment_writer_func(),
             'id': experiment.id,


### PR DESCRIPTION
The diff really says it all - the previous implementation returned _all_ experiment authors, not just the one for the experiment in question!

Resolves bug introduced in #98.
