### PR TITLE
Support for initial groups when creating a user account.

### DIFF
--- a/tardis/settings_changeme.py
+++ b/tardis/settings_changeme.py
@@ -229,6 +229,8 @@ DEFAULT_AUTH = 'localdb'
 
 AUTH_PROFILE_MODULE = 'tardis_portal.UserProfile'
 
+# New users are added to these groups by default.
+NEW_USER_INITIAL_GROUPS = []
 
 ACCOUNT_ACTIVATION_DAYS = 3
 

--- a/tardis/tardis_portal/auth/httpbasicendpoint_auth.py
+++ b/tardis/tardis_portal/auth/httpbasicendpoint_auth.py
@@ -8,6 +8,7 @@ import urllib2
 from django.conf import settings
 from django.contrib.auth.models import User
 from tardis.tardis_portal.auth.interfaces import AuthProvider
+from tardis.tardis_portal.auth.utils import configure_user
 
 class HttpBasicEndpointAuth(AuthProvider):
     '''
@@ -58,6 +59,8 @@ class HttpBasicEndpointAuth(AuthProvider):
         except User.DoesNotExist:
             user = User.objects.create_user(username, '')
             user.save()
+            configure_user(user);
+            
         # We don't want a localdb user created, so don't use a dict
         return user
 

--- a/tardis/tardis_portal/tests/auth/test_httpbasicendpoint_auth.py
+++ b/tardis/tardis_portal/tests/auth/test_httpbasicendpoint_auth.py
@@ -5,7 +5,7 @@ Created on Dec 15, 2011
 '''
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 import base64
 import urllib2
 import tempfile
@@ -154,6 +154,15 @@ class HttpBasicEndpointAuthTestCase(TestCase):
         mockUserDao.should_receive('get').and_raise(User.DoesNotExist())
         mockUserDao.should_call('create_user').with_args(username, '')\
             .at_least.once
+        # Ditto for group object retrieval
+        group = Group.objects.create(name='test-group')
+        group.save();
+        mockGroupDao = flexmock(Group.objects)
+        mockGroupDao.should_receive('get').with_args(name='test-group')\
+            .and_return(group).at_least.once
+        mockGroupDao.should_receive('get').with_args(name='unknown-group')\
+            .and_raise(Group.DoesNotExist)
+        
         result = auth.authenticate(request)
         server.stop()
         self._checkResult(result, username)

--- a/tardis/test_settings.py
+++ b/tardis/test_settings.py
@@ -80,6 +80,9 @@ AUTH_PROVIDERS = (('localdb', 'Local DB',
                   ('ldap', 'LDAP',
                    'tardis.tardis_portal.auth.ldap_auth.ldap_auth'),
 )
+
+NEW_USER_INITIAL_GROUPS = ['test-group']
+
 DEFAULT_AUTH = 'localdb'
 
 USER_PROVIDERS = ('tardis.tardis_portal.auth.localdb_auth.DjangoUserProvider',)


### PR DESCRIPTION
Add a setting to allow newly created user account to be added to an initial set of groups.  The groups are specified by name, and if a named group is not found, it is silently ignored.  There is also a fix for a bug in the httpbasicendpoint code which wasn't creating a UserProfile ... and a unit test.
