### PR TITLE
Patch for "billiard.forking" problem etc.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -27,7 +27,7 @@ versions = versions
 
 [versions]
 coverage = 3.4
-django = 1.4
+django = 1.4.1
 PIL = 1.1.7
 lxml = 2.2.7
 python-magic = 0.4.0dev

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,14 @@ setup(
         'lxml',
         'feedparser',
         'elementtree',
-        'django==1.4',
+        'django==1.4.1',
         'django-registration',
         'django-extensions',
         'django-form-utils',
         'django-haystack',
         'django-bootstrap-form',
-        'celery',           # Delayed tasks and queues
-        'django-celery',
+        'celery==2.5.5',           # Delayed tasks and queues
+        'django-celery==2.5.5',
         'django-kombu',
         'pysolr',
         'beautifulsoup4',
@@ -47,6 +47,7 @@ setup(
         ],
     dependency_links = [
         'https://github.com/dahlia/wand/tarball/warning-bugfix#egg=Wand-0.1.10',
+        'https://github.com/UQ-CMM-Mirage/django-celery/tarball/2.5#egg=django-celery-2.5.5',
         'https://github.com/defunkt/pystache/tarball/v0.5.2#egg=pystache-0.5.2'
     ]
 )


### PR DESCRIPTION
Summary - version lock celery and django-celery to 2.5.5 to solve missing "billiard.forking", use a UQ-CMM fork of django-celery-2.5 with a bug fix for the 'utc key' bug, and bump / version lock django to 1.4.1.

The "billiard forking" problem started when our chef script did a build-out that upgraded the versions of
(I think) django and celery, and left us with an older version of celery that didn't work due to the way that it was calling python.  We developed a fix that involved getting buildout to creating a wrapper for python, but that was clunky, and fixed the billiard forking problem by rolling the versions forward.  But that exposed an incompatibility between celery 2.5.5 and django-celery 2.5.5 which manifested as an error complaining about an unknown key "utc".  It turned out that there is a fix for this, but that the fix had not been back-patched to the django-celery 2.5.  So I forked it into the UQ-CMM-Mirage project and applied the patch, and then modified the mytardis setup.py to use the patched version of django-celery.

I also rolled forward to django 1.4.1 because ... basically ... it seems to work.  I'm not sure about that part.
