### PR TITLE
Fixes for file verification

### DIFF
--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -289,9 +289,14 @@ class Dataset_File(models.Model):
                                                              tempfile)
 
         if not (self.size and size == int(self.size)):
-            logger.warn("%s failed size check: %d != %s" %
-                         (self.url, size, self.size))
-            return False
+            if (self.sha512sum or self.md5sum) and not self.size: 
+                # If the size is missing but we have a checksum to check
+                # the missing size is harmless ... we will fill it in below.
+                logger.warn("%s size is missing" % (self.url))
+            else:
+                logger.error("%s failed size check: %d != %s" %
+                            (self.url, size, self.size))
+                return False
 
         if self.sha512sum and sha512sum.lower() != self.sha512sum.lower():
             logger.error("%s failed SHA-512 sum check: %s != %s" %
@@ -305,6 +310,7 @@ class Dataset_File(models.Model):
 
         self.md5sum = md5sum.lower()
         self.sha512sum = sha512sum.lower()
+        self.size = str(size)
         if not self.mimetype and len(mimetype_buffer) > 0:
             self.mimetype = Magic(mime=True).from_buffer(mimetype_buffer)
         self.verified = True


### PR DESCRIPTION
The first commit allows for SHA-512 or MD5 hashes for datafiles provided with uppercase hex encoding instead of the more conventional lowercase.  (The CMM data grabber atom feed does this ...)

The second commit allows the datafile size to be missing if there is a checksum, but reports an error (not a warning) if the missing size is fatal for verification.  (The CMM data grabber atom feed used to do this ... but I'm fixing it.)
