### PR TITLE
The URLField verify_exist flag is deprecated because of security issues.

### DIFF
--- a/tardis/tardis_portal/models/experiment.py
+++ b/tardis/tardis_portal/models/experiment.py
@@ -246,7 +246,6 @@ class Author_Experiment(models.Model):
     author = models.CharField(max_length=255)
     order = models.PositiveIntegerField()
     url = models.URLField(
-        verify_exists=True,
         max_length=2000,
         blank=True,
         help_text="URL identifier for the author")


### PR DESCRIPTION
(And it is causing a unit test failure on our CI server due to some
unexplained interaction with proxying.)
