### PR TITLE
Allow checksumless files to be ingested

### DIFF
--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -160,12 +160,14 @@ class Dataset_File(models.Model):
 
     def get_file(self, requireVerified=True):
         if requireVerified and not self.verified:
-            print "Not verified"
+            logger.warn("get_file() called with requireVerified=True, but file '%s' is not verified. Aborting." % self.filename)
             return None
         try:
             return self.get_file_getter(requireVerified=requireVerified)()
         except:
-            print "Error in get_file: ", sys.exc_info()[0]
+            import sys, traceback
+            logger.error("Error in get_file(), getting file %s from %s  " % ( self.filename, self.url ))
+            traceback.print_exc(file=sys.stdout)
             return None
 
     def get_download_url(self):

--- a/tardis/tardis_portal/staging.py
+++ b/tardis/tardis_portal/staging.py
@@ -147,13 +147,14 @@ class StagingHook():
 def stage_file(datafile):
     from django.core.files.uploadedfile import TemporaryUploadedFile
     with TemporaryUploadedFile(datafile.filename, None, None, None) as tf:
-        if datafile.verify(tempfile=tf.file):
+        if datafile.verify(tempfile=tf.file, allowEmptyChecksums=True):
             tf.file.flush()
             datafile.url = write_uploaded_file_to_dataset(datafile.dataset, tf)
             datafile.protocol = ''
             datafile.save()
             return True
         else:
+            logger.warning("Stage_file failed to verify file %s " % datafile.filename)
             return False
 
 def get_sync_root(prefix = ''):


### PR DESCRIPTION
Not sure when this change was made that required checksums, but it breaks many configurations and is overkill in others. Checksums are useful when data is coming from an unreliable source, or via an unreliable route. They're not useful when data is coming from the same server as MyTardis is running on...
