### PR TITLE
The license selection form changed the license prematurely

### DIFF
--- a/tardis/tardis_portal/jstemplates/tardis_portal/license_selector.html
+++ b/tardis/tardis_portal/jstemplates/tardis_portal/license_selector.html
@@ -1,7 +1,7 @@
 <div class="license-option control-group">
   <div class="control-label">
     <input type="hidden" class="license-id" value="{{ id }}"/>
-    <button type="submit" class="use-button btn btn-primary">
+    <button type="button" class="use-button btn btn-primary">
       Use
     </button>
   </div>


### PR DESCRIPTION
... due to the wrong kind of form button being used.  The net result was that the selected license was changing before the user got a chance to confirm that he/she understood the implications, etcetera.
