### PR TITLE
Fix for userprofile not being created when users are added to the system

### DIFF
--- a/tardis/tardis_portal/auth/utils.py
+++ b/tardis/tardis_portal/auth/utils.py
@@ -47,7 +47,7 @@ def create_user(auth_method, user_id, email=''):
                                     password=password,
                                     email=email)
     user.save()
-    configure_user(user)
+    userProfile = configure_user(user)
     userAuth = UserAuthentication(userProfile=userProfile,
         username=user_id, authenticationMethod=auth_method)
     userAuth.save()
@@ -68,3 +68,4 @@ def configure_user(user):
             pass
     userProfile = UserProfile(user=user, isDjangoAccount=False)
     userProfile.save()
+    return userProfile


### PR DESCRIPTION
The UserAuthentication object expects a UserProfile to be created and associated with it. The UserProfiles were being created on new User creation but not handed to UserAuthentication, causing an error.
