### PR TITLE
Added a 'runfilters' django command

### DIFF
--- a/tardis/tardis_portal/management/commands/runfilters.py
+++ b/tardis/tardis_portal/management/commands/runfilters.py
@@ -50,7 +50,11 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     args = '[<filter-no>] ...'
-    help = 'Run selected ingestion filters on all Datafiles.'
+    help = """Run selected ingestion filters on all Datafiles.  
+Note that a typical ingestion filter sets a 'flag' parameter in its 
+Datafile's parameter set to avoid adding multiple copies of the ingested 
+metadata parameters.  This command cannot override that flag to force 
+metadata to be reingested."""
     option_list = BaseCommand.option_list + (
         make_option('--dryRun', '-n',
                     action='store_true',
@@ -77,7 +81,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         filterIds = []
         self.availableFilters = settings.POST_SAVE_FILTERS
-        print 'Filters = %s\n' % self.availableFilters
         if options.get('list'):
             pass
         elif options.get('all'):
@@ -149,7 +152,7 @@ class Command(BaseCommand):
                     for filter in filters:
                         filter(sender=Dataset_File, instance=datafile, 
                                created=False, using='default')
-                    if options.get('dryRun'):
+                    if dryRun:
                         transaction.rollback(using=using)
                     else:
                         transaction.commit(using=using)


### PR DESCRIPTION
The command is pretty simple minded.  You can:
- use the --list option to list available filters (in POST_SAVE_SETTINGS)
- list one or more filters by 'id'
- use --all to run all available filters
- use --dryRun which doesn't commit database changes made by the filter or filters

Currently, we just run the filter, and rely on it to do "the appropriate thing" if it is run a second time.  The filters I've looked at handle this by setting a 'flag' parameter in the parameters set to determine if they have run before (successfully).  Ideally we'd like to 
be able to force filters to replace parameters ... but that would require support in each filter ... or a filter base-class.

Anyway. This command is useful in its current form. 
