### PR TITLE
Added back some dependencies that are needed for python 2.6 (at least)

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -17,7 +17,12 @@ eggs =
     compare
     django-jasmine
     html2text
+    django-mustachejs
+    pystache
+    rdflib
+    rdfextras
     poster
+    pyparsing
 find-links =
     http://dist.plone.org/thirdparty/
     https://github.com/russell/python-magic/tarball/master#egg=python-magic-0.4.0dev
@@ -31,6 +36,11 @@ PIL = 1.1.7
 lxml = 2.2.7
 python-magic = 0.4.0dev
 Wand = 0.1.10
+django-mustachejs = 0.6.0
+rdfextras = 0.2
+pystache = 0.5.2
+pyparsing = 1.5.6
+rdflib = 3.2.1
 
 [django]
 recipe = djangorecipe


### PR DESCRIPTION
Also freeze the version of pyparsing to avoid a bad one (2.0.0) with compilation errors.

It seems like the reworking of the buildout.cfg / version.cfg files on the 3.0 side was not trial built on python 2.6.  The build was failing on Travis and also on our private CI.  Either way, the version tweaks in this pull request are needed / sufficient to get the "master" build and tests to run clean on Travis.
