### PR TITLE
Optional ldap test

### DIFF
--- a/tardis/tardis_portal/tests/test_ldap.py
+++ b/tardis/tardis_portal/tests/test_ldap.py
@@ -6,7 +6,14 @@ from django.test import TestCase
 from nose.plugins.skip import SkipTest
 server = None
 
+from django.utils.unittest import skipIf
+from django.conf import settings
 
+ldap_auth_provider = ('ldap', 'LDAP',
+                   'tardis.tardis_portal.auth.ldap_auth.ldap_auth')
+
+@skipIf(ldap_auth_provider not in settings.AUTH_PROVIDERS,
+        'ldap_auth is not enabled, skipping tests')
 class LDAPErrorTest(TestCase):
 
     def test_search(self):
@@ -15,6 +22,8 @@ class LDAPErrorTest(TestCase):
         self.assertEqual(l._query('', '', ''), None)
 
 
+@skipIf(ldap_auth_provider not in settings.AUTH_PROVIDERS, 
+        'ldap_auth is not enabled, skipping tests')
 class LDAPTest(TestCase):
     def setUp(self):
         from tardis.tardis_portal.tests.ldap_ldif import test_ldif

--- a/tardis/test_settings.py
+++ b/tardis/test_settings.py
@@ -78,10 +78,15 @@ AUTH_PROFILE_MODULE = 'tardis_portal.UserProfile'
 AUTH_PROVIDERS = (('localdb', 'Local DB',
                   'tardis.tardis_portal.auth.localdb_auth.DjangoAuthBackend'),
                   ('vbl', 'VBL',
-                   'tardis.tardis_portal.tests.mock_vbl_auth.MockBackend'),
-                  ('ldap', 'LDAP',
-                   'tardis.tardis_portal.auth.ldap_auth.ldap_auth'),
-)
+                   'tardis.tardis_portal.tests.mock_vbl_auth.MockBackend'))
+
+#if (optional) ldap doesn't exist then don't enable ldap auth
+try:
+    import ldap
+    AUTH_PROVIDERS += (('ldap', 'LDAP',
+                        'tardis.tardis_portal.auth.ldap_auth.ldap_auth'),)
+except ImportError:
+    pass
 
 NEW_USER_INITIAL_GROUPS = ['test-group']
 


### PR DESCRIPTION
Making LDAP tests skippable based presence of python-ldap

If python-ldap exists then test_settings.py has the core ldap auth service added to AUTH_PROVIDERS. If not, then it's optional and the ldap tests are skipped.

This is because python-ldap is optional for usage, and installs of it is problematic on some machines and non-standardised. Allows one to omit its installation entirely and unit tests will correctly pass.
