### PR TITLE
Only run the datafile save filter if the datafile's preferred replica is verified.

### DIFF
--- a/tardis/tardis_portal/tests/filters/test_middleware.py
+++ b/tardis/tardis_portal/tests/filters/test_middleware.py
@@ -126,13 +126,9 @@ class FilterInitTestCase(TestCase):
 
             self.datafiles[1].save()
             t = Filter1.getTuples()
-            expect(len(t)).to_equal(1)
-            expect(t[0][0]).to_equal(self.datafiles[1])
-            expect(t[0][1]).to_be_none()
+            expect(len(t)).to_equal(0)
             t = Filter2.getTuples()
-            expect(len(t)).to_equal(1)
-            expect(t[0][0]).to_equal(self.datafiles[1])
-            expect(t[0][1]).to_be_none()
+            expect(len(t)).to_equal(0)
 
             self.datafiles[0].get_preferred_replica().save()
             t = Filter1.getTuples()


### PR DESCRIPTION
This avoid errors when a filter attempts to read the replica data of a replica that is yet to be uploaded.
