### PR TITLE
Dataset list causing browser to seize up fix

### DIFF
--- a/tardis/tardis_portal/static/js/backbone-models.js
+++ b/tardis/tardis_portal/static/js/backbone-models.js
@@ -253,7 +253,8 @@ var MyTardis = (function(){
       }
     },
     render: function() {
-      // Wrap data with helper functions #steve
+      // This makes the rendering of badge data asynchronous
+      // A temporary fix to be changed when bootstrap.js is removed entirely..
       var el = $(this.el);
         $.ajax({
           url: '/ajax/json/dataset/' + this.model.id,


### PR DESCRIPTION
Issue: https://github.com/mytardis/mytardis/issues/254

My JQuery AJAX code that grabs each dataset's size and datafile count was not asynchronous. Therefore the more datasets in an experiment, the longer to load, and the browser would completely pause while doing so.

I'm not sure I like Backbone JS in general, and think I'll have it removed in favour of something else in the future (and reimplementing the transfer datasets functionality). More talk about this in the issue link above. So this is a temporary fix that makes the AJAX calls asynchronous (and living in the render part of Backbone's workflow) so they're loaded in a lazy fashion.
