### PR TITLE
For times when temporary files for downloads are too big for /tmp

### DIFF
--- a/tardis/settings_changeme.py
+++ b/tardis/settings_changeme.py
@@ -286,6 +286,10 @@ UPLOADIFY_UPLOAD_PATH = '%s/%s' % (MEDIA_URL, 'uploads')
 # Download size limit: zero means no limit
 DOWNLOAD_ARCHIVE_SIZE_LIMIT = 0
 
+# temporary download file location
+from tempfile import gettempdir
+DOWNLOAD_TEMP_DIR = gettempdir()
+
 # Safety margin for temporary space when downloading.  (Estimated archive
 # file size + safety_margin must be less that available disk space ...)
 DOWNLOAD_SPACE_SAFETY_MARGIN = 8388608

--- a/tardis/tardis_portal/download.py
+++ b/tardis/tardis_portal/download.py
@@ -48,7 +48,8 @@ class StreamingFile:
         # writer_callable outputs the file strictly sequentially.  If it seeks
         # backwards to back-fill details (like ZipFile does!), this can cause
         # a data race and can result in a corrupted download.
-        _, self.name = mkstemp()
+        _, self.name = mkstemp(
+            dir=getattr(settings, 'DOWNLOAD_TEMP_DIR', None))
         self.asynchronous = asynchronous_file_creation
         if asynchronous_file_creation:
             self.runnable = writer_callable
@@ -309,7 +310,9 @@ def _write_files_to_archive(write_func, files):
         if not fileObj:
             logger.debug('Skipping %s - file open failed.' % name)
             continue
-        with NamedTemporaryFile(prefix='mytardis_tmp_dl_') as fdst:
+        with NamedTemporaryFile(
+                prefix='mytardis_tmp_dl_',
+                dir=getattr(settings, 'DOWNLOAD_TEMP_DIR', None)) as fdst:
             try:
                 # Copy url to destination file
                 shutil.copyfileobj(fileObj, fdst)
@@ -396,11 +399,13 @@ def _estimate_archive_size(mapper, datafiles, comptype):
         estimate += 100
     return (count, estimate)
 
+
 def _get_free_temp_space():
     """ Return free space on the file system holding the temporary
     directory (in bytes)
     """
-    return get_free_space(gettempdir())
+    return get_free_space(getattr(settings, 'DOWNLOAD_TEMP_DIR', gettempdir()))
+
 
 def _check_download_limits(mapper, datafiles, comptype):
     (count, estimate) = _estimate_archive_size(mapper, datafiles, comptype)


### PR DESCRIPTION
Some datasets are huge, and big storage often external. With this change the location where the zips/tars are created for downloads can be changed in settings.py.
