### PR TITLE
Remove a trace print and output how much space we are trying to reclaim

### DIFF
--- a/tardis/apps/migration/management/commands/migratefiles.py
+++ b/tardis/apps/migration/management/commands/migratefiles.py
@@ -349,6 +349,8 @@ class Command(BaseCommand):
     def _do_reclaim(self, required):
         scores = self._do_score_all()
         total = 0
+        if self.verbosity > 1:
+            self.stdout.write("Attempting to reclaim %s bytes\n" % required)
         for entry in scores:
             if total >= required:
                 break
@@ -364,11 +366,11 @@ class Command(BaseCommand):
                                           (replica.url, datafile.id, 
                                            datafile.size))
             if self.dryRun:
-                total += int(datafile.size) 
+                total += long(datafile.size) 
             else:
                 try:
                     if migrate_replica(replica, self.dest):
-                        total += int(datafile.size) 
+                        total += long(datafile.size) 
                         self.transfer_count += 1
                 except MigrationError as e:              
                     self.stderr.write(

--- a/tardis/apps/migration/scoring.py
+++ b/tardis/apps/migration/scoring.py
@@ -127,7 +127,6 @@ class MigrationScorer:
                                  self.file_size_threshold,
                                  self.file_size_weighting)
             if self.use_file_timestamps:
-                print 'filepath is %s\n' % datafile.get_absolute_filepath()
                 stat = os.stat(datafile.get_absolute_filepath())
                 # FIXME - it would be better to use creation / access 
                 # times maintained by MyTardis rather that file timestamps.

--- a/tardis/apps/migration/tests/test_command.py
+++ b/tardis/apps/migration/tests/test_command.py
@@ -455,6 +455,7 @@ class MigrateCommandTestCase(TestCase):
             pass
         out.seek(0)
         self.assertEquals(out.read(),
+                          'Attempting to reclaim 11 bytes\n'
                           'Would have migrated %s / %s saving 6 bytes\n'
                           'Would have migrated %s / %s saving 6 bytes\n'
                           'Would have reclaimed 12 bytes\n' %
@@ -467,6 +468,7 @@ class MigrateCommandTestCase(TestCase):
             pass
         out.seek(0)
         self.assertEquals(out.read(),
+                          'Attempting to reclaim 11 bytes\n'
                           'Migrating %s / %s saving 6 bytes\n'
                           'Migrating %s / %s saving 6 bytes\n'
                           'Reclaimed 12 bytes\n'


### PR DESCRIPTION
Some minor fixes to the migration app ... independent of other stuff.
