### PR TITLE
The error pages aren't obnoxiously large now..

### DIFF
--- a/tardis/tardis_portal/templates/404.html
+++ b/tardis/tardis_portal/templates/404.html
@@ -1,4 +1,4 @@
 {% extends "tardis_portal/error_page.html" %}
 
-{% block error_code %}404{% endblock %}
-{% block error_message %}Page not found{% endblock %}
+{% block error_code %}Error Code: 404{% endblock %}
+{% block error_message %}The requested page was not found. We apologise for the inconvenience.{% endblock %}

--- a/tardis/tardis_portal/templates/500.html
+++ b/tardis/tardis_portal/templates/500.html
@@ -1,4 +1,4 @@
 {% extends "tardis_portal/error_page.html" %}
 
-{% block error_code %}500{% endblock %}
-{% block error_message %}Server Error{% endblock %}
+{% block error_code %}Error Code: 500{% endblock %}
+{% block error_message %}MyTardis has encountered a problem. We apologise for the inconvenience.{% endblock %}

--- a/tardis/tardis_portal/templates/tardis_portal/error_page.html
+++ b/tardis/tardis_portal/templates/tardis_portal/error_page.html
@@ -19,16 +19,5 @@ $(document).ready(function () {
   {% block error_message %}
   {% endblock %}</small>
 </h1>
-<script type="text/javascript">
-// Fit massive text to screen
-var resizeText = function(evt) {
-  var width = $('body').css('width');
-  var mainHeight = Math.floor(parseInt(width)/4);
-  var smallHeight = Math.floor(mainHeight/2);
-  $('h1.msg .main').css('font-size', mainHeight+'px');
-  $('h1.msg small').css('font-size', smallHeight+'px');
-};
-resizeText();
-$(window).resize(resizeText);
-</script>
+
 {% endblock %}


### PR DESCRIPTION
Example:

![screenie](https://dl.dropboxusercontent.com/u/172498/screenshots_host/Screenshot%202014-10-02%2015.40.15.png)

(by the way I cherry-picked this commit from another branch but I don't think this should adversely affect the tree)
