### PR TITLE
Implement comma separated ParameterName choices

### DIFF
--- a/tardis/tardis_portal/forms.py
+++ b/tardis/tardis_portal/forms.py
@@ -744,8 +744,17 @@ def create_parameterset_edit_form(parameterset, request=None):
             units = ""
             if parameter_name.units:
                 units = " (" + parameter_name.units + ")"
+                choices = parameter_name.get_choices()
                 # if not valid, spit back as exact
-                if parameter_name.isNumeric():
+                if choices:
+                    c = [("", "")] + zip(choices, choices)
+                    fields[key] = \
+                        forms.ChoiceField(label=parameter_name.full_name + units,
+                                          required=False,
+                                          choices=c,
+                                          initial=value,
+                                          )
+                elif parameter_name.isNumeric():
                     fields[key] = \
                         forms.DecimalField(label=parameter_name.full_name + units,
                                            required=False,
@@ -784,7 +793,18 @@ def create_parameterset_edit_form(parameterset, request=None):
 
             form_id = form_id.replace('/', '_s47_')
 
-            if dfp.name.isNumeric():
+            choices = dfp.name.get_choices()
+
+            if choices:
+                # Add an empty string to the start of the list to have an
+                # empty position in the choice box.
+                c = [("", "")] + zip(choices, choices)
+                fields[form_id] = \
+                    forms.ChoiceField(label=dfp.name.full_name + units,
+                                      required=False,
+                                      choices=c,
+                                      initial=dfp.string_value)
+            elif dfp.name.isNumeric():
                 fields[form_id] = \
                     forms.DecimalField(label=dfp.name.full_name + units,
                                        required=False,
@@ -851,8 +871,17 @@ def create_datafile_add_form(schema, parentObject, request=None):
                 if parameter_name.units:
                     units = " (" + parameter_name.units + ")"
 
+                choices = parameter_name.get_choices()
                 # if not valid, spit back as exact
-                if parameter_name.isNumeric():
+                if choices:
+                    c = [("", "")] + zip(choices, choices)
+                    fields[key] = \
+                        forms.ChoiceField(label=parameter_name.full_name + units,
+                                          required=False,
+                                          choices=c,
+                                          initial=value,
+                                          )
+                elif parameter_name.isNumeric():
                     fields[key] = \
                         forms.DecimalField(label=parameter_name.full_name + units,
                                            required=False,
@@ -893,7 +922,15 @@ def create_datafile_add_form(schema, parentObject, request=None):
 
             form_id = form_id.replace('/', '_s47_')
 
-            if dfp.isNumeric():
+            choices = dfp.get_choices()
+
+            if choices:
+                c = [("", "")] + zip(choices, choices)
+                fields[form_id] = \
+                    forms.ChoiceField(label=dfp.full_name + units,
+                                      required=False,
+                                      choices=c)
+            elif dfp.isNumeric():
                 fields[form_id] = \
                 forms.DecimalField(label=dfp.full_name + units,
                 required=False)

--- a/tardis/tardis_portal/models/parameters.py
+++ b/tardis/tardis_portal/models/parameters.py
@@ -209,6 +209,13 @@ class ParameterName(models.Model):
     def getUniqueShortName(self):
         return self.name + '_' + str(self.id)
 
+    def get_choices(self):
+        """Return list of choices derived from comma separated string.
+        rtype: list(str)
+        """
+        if self.choices != "":
+            return [choice.strip() for choice in str(self.choices).split(",")]
+
 
 def _getParameter(parameter):
 

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/parameteredit.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/parameteredit.html
@@ -4,7 +4,7 @@
 	Parameters saved successfully.
 
 {% else %}
-	<p><strong>Schema: </strong>{{schema.name}}</strong></p>
+	<p id="schemaselect" schema-id={{schema.id}}><strong>Schema: </strong>{{schema.name}}</strong></p>
 	<form id="edit_metadata_form" action='/ajax/edit_{{type}}_parameters/{{parameterset_id}}/' method='post'>{% csrf_token %}
 		{{ form.non_field_errors }}
 	    {% for field in form %}

--- a/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
@@ -32,10 +32,16 @@
         return new_name + "__" + i;
     }
 
-    function get_form_input_html(label, name, use_textarea)
+    function get_form_input_html(label, name, use_textarea, options)
     {
         var widget;
-        if (use_textarea) {
+        if (options) {
+            widget = '<select name="' + name + '">'
+            for (opt in options) {
+                widget += '<option value="' + opt + '">' + options[opt] + '</option>'
+            }
+            widget += '</select>'
+        } else if (use_textarea) {
             widget = '<textarea ' + 'name="' + name + '" id="' + name + '"/>';
         } else {
             widget = '<input type="text" name="' + name + '" value="" id="' + name + '" />';
@@ -59,16 +65,38 @@
         return false;
     });
 
-    $('#add_new_parameter').live('click', function(){
+    $('#add_new_parameter').live('click', function(e){
+        e.preventDefault();
+
+        var $this = $(this);
+        var $jqm_content_div = $this.closest('.modal-body');
+        var schema_id = $("#schemaselect").val() ? $("#schemaselect").val() : $("#schemaselect").attr("schema-id");
+        var parent_object_id = $this.parent().attr('data-parent_object_id');
+
         // assuming whenever add_new_parameter is clicked an option is selected
         var $selected_option = $("#parameternameselect > option:selected");
+
+        var href = "/ajax/json/parametername/" + schema_id + "/?paramname="
+                        + encodeURIComponent($selected_option.val());
         var is_long = $selected_option.attr('data-longstring');
         var new_element_name = get_new_parameter_name($selected_option.val());
 
         if($selected_option.text())
         {
-            $("#parameternameselect").before(get_form_input_html($selected_option.text(), new_element_name, is_long));
-            $("#" + new_element_name).focus();
+            $.ajax({
+                type: 'GET',
+                url: href,
+                success: function(data) {
+                    if(!jQuery.isEmptyObject(data)) {
+                        $("#parameternameselect").before(get_form_input_html($selected_option.text(), new_element_name, is_long, data));
+                        $("#" + new_element_name).focus();
+                    } else {
+                        $("#parameternameselect").before(get_form_input_html($selected_option.text(), new_element_name, is_long));
+                        $("#" + new_element_name).focus();
+                    }
+                },
+                async: false
+            });
         }
         else
         {

--- a/tardis/tardis_portal/views.py
+++ b/tardis/tardis_portal/views.py
@@ -834,6 +834,29 @@ def experiment_datasets(request, experiment_id):
         template_name='tardis_portal/ajax/experiment_datasets.html')
 
 
+def parametername_json(request, schema_id=None):
+    try:
+        schema = Schema.objects.get(id=schema_id)
+    except Schema.DoesNotExist:
+        return HttpResponseNotFound()
+
+    paramname_id = request.GET['paramname']
+
+    parameternames = ParameterName.objects.filter(
+        schema__namespace=schema.namespace, name=paramname_id)
+
+    if parameternames:
+        choices = parameternames[0].get_choices()
+        if choices:
+            pn_choices = dict()
+            for c in choices:
+                pn_choices[c] = c
+            return HttpResponse(json.dumps(pn_choices),
+                                mimetype='application/json')
+        else:
+            return HttpResponse(status=204)
+
+
 @never_cache  # too complex # noqa
 @authz.dataset_access_required
 def dataset_json(request, experiment_id=None, dataset_id=None):

--- a/tardis/urls.py
+++ b/tardis/urls.py
@@ -143,6 +143,7 @@ datafile_urls = patterns(
 json_urls = patterns(
     'tardis.tardis_portal.views',
     (r'^dataset/(?P<dataset_id>\d+)$', 'dataset_json'),
+    (r'^parametername/(?P<schema_id>\d+)/$', 'parametername_json'),
     (r'^experiment/(?P<experiment_id>\d+)/dataset/$',
      'experiment_datasets_json'),
     (r'^experiment/(?P<experiment_id>\d+)/dataset/(?P<dataset_id>\d+)$',


### PR DESCRIPTION
ParameterNames have a choices field that stores a string, presumably to list the available choices for a particular parameter name. For the most part this seems to be non-functional except for a breif reference in DataFile searching, which I believe is currently broken. This commit implements logic to extract comma separated choices from the choices string. It also implements logic for providing drop down boxes for choosing available choices in the add and edit metadata views.
