### PR TITLE
manage account form fix

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/manage_user_account.html
+++ b/tardis/tardis_portal/templates/tardis_portal/manage_user_account.html
@@ -4,7 +4,7 @@
 
 
 {% block content %}
-<form class="form-horizontal" method="post">{% csrf_token %}
+<form class="form-horizontal" method="post" action="">{% csrf_token %}
 {{ form|bootstrap }}
 
 <div class="form-actions">


### PR DESCRIPTION
The manage account page (/accounts/manage) requires an action attribute in the form tag to prevent angular from aborting the submission. This is a result of including angular.js in portal_template.html