### PR TITLE
SECRET_KEY removed from settings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,10 @@ pip install -r requirements-osx.txt
 
 mkdir -p var/store
 
+# execute this wonderful command to have your settings.py created/updated
+# with a generated Django SECRET_KEY (required for MyTardis to run)
+python -c "import os; from random import choice; key_line = '%sSECRET_KEY=\"%s\"  # generated from build.sh\n' % ('from tardis.settings_changeme import * \n\n' if not os.path.isfile('tardis/settings.py') else '', ''.join([choice('abcdefghijklmnopqrstuvwxyz0123456789\\!@#$%^&*(-_=+)') for i in range(50)])); f=open('tardis/settings.py', 'a+'); f.write(key_line); f.close()"
+
 python test.py
 python mytardis.py collectstatic
 # for empty databases, sync all and fake migrate, otherwise run a real migration

--- a/tardis/settings_changeme.py
+++ b/tardis/settings_changeme.py
@@ -81,11 +81,7 @@ SITE_ID = 1
 
 USE_I18N = True
 
-SECRET_KEY = 'ij!%7-el^^rptw$b=iol%78okl10ee7zql-()z1r6e)gbxd3gl'
-'''
-Before running as production server Make this unique, and don't share it with
-anybody.
-'''
+# SECRET_KEY has been removed. Generate one by referring to build.sh
 
 ALLOWED_HOSTS = ['*']
 '''

--- a/tardis/test_settings.py
+++ b/tardis/test_settings.py
@@ -134,3 +134,5 @@ DEFAULT_ARCHIVE_FORMATS = ['tar', 'tgz']
 AUTOGENERATE_API_KEY = True
 
 MIDDLEWARE_CLASSES += ('tardis.tardis_portal.filters.FilterInitMiddleware',)
+
+SECRET_KEY = 'ij!%7-el^^rptw$b=iol%78okl10ee7zql-()z1r6e)gbxd3gl'


### PR DESCRIPTION
To fix issue https://github.com/mytardis/mytardis/issues/281

Removed hard-coded secret key and added doc for how to generate one on the fly.

Example command to execute added to build.sh. Command generates a SECRET_KEY for settings.py and either adds it if the file exists or creates a new settings.py with the key if it doesn't.