### PR TITLE
Issue 326

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ exit
 # sudo apt-get install python-pip git libxml2-dev libxslt1-dev python-dev zlib1g-dev python-wand
 # sudo apt-get install python-virtualenv virtualenvwrapper python-psycopg2 python-yaml ipython
 # sudo apt-get install python-anyjson python-bs4 python-billiard python-feedparser python-html5lib
-# sudo apt-get install python-httplib2 python-pystache python-crypto python-flexmock
+# sudo apt-get install python-httplib2 python-pystache python-crypto python-flexmock python-dateutil
 
 . virtualenvwrapper.sh
 # . /usr/share/virtualenvwrapper/virtualenvwrapper.sh

--- a/requirements-osx.txt
+++ b/requirements-osx.txt
@@ -1,5 +1,6 @@
 psycopg2
 pystache
+python-dateutil
 mock
 beautifulsoup4
 flexmock

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ ecdsa==0.11 #apt: 0.10
 #elementtree
 gunicorn
 gevent
-iso8601==0.1.4 #apt: 0.1.10
 isodate==0.5.1 #apt: 0.4.6
 pyjwt==0.4.3
 kombu==3.0.24 #apt: 3.0.7

--- a/tardis/tardis_portal/forms.py
+++ b/tardis/tardis_portal/forms.py
@@ -860,6 +860,10 @@ def create_datafile_add_form(schema, parentObject, request=None):
                                            )
                 elif parameter_name.isLongString():
                     fields[key] = forms.CharField(widget=forms.Textarea, label=parameter_name.full_name + units, max_length=255, required=False, initial=value)
+                elif parameter_name.isDateTime():
+                    fields[key] = forms.DateTimeField(label=parameter_name.full_name + units,
+                                                      required=False,
+                                                      initial=value)
                 else:
                     fields[key] = \
                         forms.CharField(label=parameter_name.full_name + units,

--- a/tardis/tardis_portal/models/parameters.py
+++ b/tardis/tardis_portal/models/parameters.py
@@ -18,6 +18,7 @@ from .instrument import Instrument
 import logging
 import operator
 import pytz
+import dateutil.parser
 
 LOCAL_TZ = pytz.timezone(settings.TIME_ZONE)
 logger = logging.getLogger(__name__)
@@ -380,11 +381,16 @@ class Parameter(models.Model):
         if self.name.isNumeric():
             self.numerical_value = float(value)
         elif self.name.isDateTime():
-            if settings.USE_TZ and is_naive(value):
-                value = make_aware(value, LOCAL_TZ)
-            elif not settings.USE_TZ and is_aware(value):
-                value = make_naive(value, LOCAL_TZ)
-            self.datetime_value = value
+            # We convert the value string into datetime object.
+            # dateutil.parser detects and converts many date formats and is quite
+            # permissive in what it accepts (form validation and API input
+            # validation happens elsewhere and may be less permissive)
+            datevalue = dateutil.parser.parse(value)
+            if settings.USE_TZ and is_naive(datevalue):
+                datevalue = make_aware(value, LOCAL_TZ)
+            elif not settings.USE_TZ and is_aware(datevalue):
+                datevalue = make_naive(datevalue, LOCAL_TZ)
+            self.datetime_value = datevalue
         else:
             self.string_value = unicode(value)
 

--- a/tardis/tardis_portal/models/parameters.py
+++ b/tardis/tardis_portal/models/parameters.py
@@ -378,6 +378,14 @@ class Parameter(models.Model):
             return 'Unitialised %sParameter' % self.parameter_type
 
     def set_value(self, value):
+        """
+        Sets the parameter value, converting into the appropriate data type.
+        Deals with date/time strings that are timezone naive or aware, based
+        on the USE_TZ setting.
+
+        :param value: a string (or string-like) representing the value
+        :return:
+        """
         if self.name.isNumeric():
             self.numerical_value = float(value)
         elif self.name.isDateTime():

--- a/tardis/tardis_portal/tests/test_parametersetmanager.py
+++ b/tardis/tardis_portal/tests/test_parametersetmanager.py
@@ -40,7 +40,6 @@ http://docs.djangoproject.com/en/dev/topics/testing/
 from compare import expect
 from datetime import datetime
 from django.test import TestCase
-import iso8601
 import pytz
 from tardis.tardis_portal.models import Experiment, Dataset, DataFile, \
     DataFileObject, Schema, ParameterName, DatafileParameterSet, \
@@ -182,7 +181,7 @@ class ParameterSetManagerTestCase(TestCase):
         '''
         psm = ParameterSetManager(parameterset=self.datafileparameterset)
 
-        psm.new_param("parameter3", datetime(1970, 01, 01, 10, 0, 0))
+        psm.new_param("parameter3", str(datetime(1970, 01, 01, 10, 0, 0)))
 
         expect(psm.get_param("parameter3", True))\
             .to_equal(datetime(1970, 01, 01, 0, 0, 0, tzinfo=pytz.utc))
@@ -194,7 +193,7 @@ class ParameterSetManagerTestCase(TestCase):
         psm = ParameterSetManager(parameterset=self.datafileparameterset)
 
         psm.new_param("parameter3",
-                      iso8601.parse_date('1970-01-01T08:00:00+08:00'))
+                      '1970-01-01T08:00:00+08:00')
 
         expect(psm.get_param("parameter3", True))\
             .to_equal(datetime(1970, 01, 01, 0, 0, 0, tzinfo=pytz.utc))


### PR DESCRIPTION
_ParameterName.set_value_ takes a string, and is called by both the API and form data entry.
When attempting to make a new _ParameterName_ of type DATETIME, the checks relating to timezones expected a Python _datetime_ and failed if a string was provided.

This patch ensures that the string is properly converted to a Python _datetime_ for timezone checks and subsequent population of _datetime_value_ in the model. The date/time format detection and parsing by _dateutil.parser.parse_ is quite permissive - forms and the API do their own validation (and should be stricter, in the case of the API). I've added a docstring to better describe how the _set_value_ method is intended to be used. I've also added _DateTimeField_ in forms for this datatype.

I've modified two timezone-related tests which were passing a _datetime_ rather than a string (and hence didn't reveal the issue with _set_value_).