### PR TITLE
Pub form updates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ exit
 # sudo apt-get install python-virtualenv virtualenvwrapper python-psycopg2 python-yaml ipython
 # sudo apt-get install python-anyjson python-bs4 python-billiard python-feedparser python-html5lib
 # sudo apt-get install python-httplib2 python-pystache python-crypto python-flexmock python-dateutil
+# sudo apt-get install memcached python-memcache
 
 # for OS X we need these dependencies installed via brew
 # brew install imagemagick --with-libtiff

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,7 @@ exit
 # sudo apt-get install python-httplib2 python-pystache python-crypto python-flexmock python-dateutil
 # sudo apt-get install memcached python-memcache
 
+
 # for OS X we need these dependencies installed via brew
 # brew install imagemagick --with-libtiff
 # brew install libmagic freetype
@@ -40,6 +41,7 @@ python mytardis.py collectstatic
 # for empty databases, sync all and fake migrate, otherwise run a real migration
 python mytardis.py syncdb --all
 python mytardis.py migrate --fake
+python mytardis.py createcachetable celery_lock_cache
 
 python mytardis.py runserver
 # os x:

--- a/tardis/apps/publication_forms/pub_form_config.py
+++ b/tardis/apps/publication_forms/pub_form_config.py
@@ -17,215 +17,194 @@ logger = logging.getLogger(__name__)
 
 
 class PubFormConfig():
-    def _schema_exists(self, namespace):
-        try:
-            return Schema.objects.filter(namespace=namespace).exists()
-        except DatabaseError as e:
-            logger.error('Database error encountered while checking if '
-                         'schema '+namespace+' exists')
-            raise
 
     def _setup_PUBLICATION_SCHEMA_ROOT(self, namespace):
-        schema = Schema(namespace=namespace, name='Publication', hidden=True,
-                        immutable=True)
-        schema.save()
-        ParameterName(schema=schema,
-                      name='embargo',
-                      full_name='embargo',
-                      data_type=ParameterName.DATETIME,
-                      immutable=True,
-                      order=1).save()
-        ParameterName(schema=schema,
-                      name='pdb-embargo',
-                      full_name='pdb-embargo',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=2).save()
-        ParameterName(schema=schema,
-                      name='pdb-last-sync',
-                      full_name='pdb-last-sync',
-                      data_type=ParameterName.DATETIME,
-                      immutable=True,
-                      order=3).save()
-        ParameterName(schema=schema,
-                      name='form_state',
-                      full_name='form_state',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=4).save()
+        schema, _ = Schema.objects.get_or_create(namespace=namespace,
+                                                 name='Publication',
+                                                 hidden=True,
+                                                 immutable=True)
+
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='embargo',
+                                            full_name='embargo',
+                                            data_type=ParameterName.DATETIME,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='pdb-embargo',
+                                            full_name='pdb-embargo',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='pdb-last-sync',
+                                            full_name='pdb-last-sync',
+                                            data_type=ParameterName.DATETIME,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='form_state',
+                                            full_name='form_state',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
 
     def _setup_PUBLICATION_DRAFT_SCHEMA(self, namespace):
-        schema = Schema(namespace=namespace, name='Draft Publication',
-                        hidden=True, immutable=True)
-        schema.save()
+        schema, _ = Schema.objects.get_or_create(namespace=namespace,
+                                                 name='Draft Publication',
+                                                 hidden=True,
+                                                 immutable=True)
 
     def _setup_PDB_PUBLICATION_SCHEMA_ROOT(self, namespace):
-        schema = Schema(namespace=namespace, name='Protein Data Bank',
-                        hidden=False, immutable=True)
-        schema.save()
-        ParameterName(schema=schema,
-                      name='pdb-id',
-                      full_name='PDB ID',
-                      data_type=ParameterName.STRING,
-                      is_searchable=True,
-                      immutable=True,
-                      order=1).save()
-        ParameterName(schema=schema,
-                      name='title',
-                      full_name='Title',
-                      data_type=ParameterName.STRING,
-                      is_searchable=True,
-                      immutable=True,
-                      order=2).save()
-        ParameterName(schema=schema,
-                      name='url',
-                      full_name='URL',
-                      data_type=ParameterName.URL,
-                      immutable=True,
-                      order=3).save()
-        ParameterName(schema=schema,
-                      name='resolution',
-                      full_name='Resolution',
-                      units='Å',
-                      data_type=ParameterName.NUMERIC,
-                      is_searchable=True,
-                      immutable=True,
-                      order=4).save()
-        ParameterName(schema=schema,
-                      name='r-value',
-                      full_name='R-Value',
-                      units='(obs.)',
-                      data_type=ParameterName.NUMERIC,
-                      is_searchable=True,
-                      immutable=True,
-                      order=5).save()
-        ParameterName(schema=schema,
-                      name='r-free',
-                      full_name='R-Free',
-                      data_type=ParameterName.NUMERIC,
-                      is_searchable=True,
-                      immutable=True,
-                      order=6).save()
-        ParameterName(schema=schema,
-                      name='space-group',
-                      full_name='Space Group',
-                      data_type=ParameterName.STRING,
-                      is_searchable=True,
-                      immutable=True,
-                      order=7).save()
-        ParameterName(schema=schema,
-                      name='unit-cell',
-                      full_name='Unit Cell (Å,°)',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=8).save()
+        schema, _ = Schema.objects.get_or_create(namespace=namespace,
+                                                 name='Protein Data Bank',
+                                                 hidden=False,
+                                                 immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='pdb-id',
+                                            full_name='PDB ID',
+                                            data_type=ParameterName.STRING,
+                                            is_searchable=True,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='title',
+                                            full_name='Title',
+                                            data_type=ParameterName.STRING,
+                                            is_searchable=True,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='url',
+                                            full_name='URL',
+                                            data_type=ParameterName.URL,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='resolution',
+                                            full_name='Resolution',
+                                            units='Å',
+                                            data_type=ParameterName.NUMERIC,
+                                            is_searchable=True,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='r-value',
+                                            full_name='R-Value',
+                                            units='(obs.)',
+                                            data_type=ParameterName.NUMERIC,
+                                            is_searchable=True,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='r-free',
+                                            full_name='R-Free',
+                                            data_type=ParameterName.NUMERIC,
+                                            is_searchable=True,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='space-group',
+                                            full_name='Space Group',
+                                            data_type=ParameterName.STRING,
+                                            is_searchable=True,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='unit-cell',
+                                            full_name='Unit Cell (Å,°)',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
 
     def _setup_PDB_SEQUENCE_PUBLICATION_SCHEMA(self, namespace):
-        schema = Schema(namespace=namespace, name='Sequence Data',
-                        hidden=False, immutable=True)
-        schema.save()
-        ParameterName(schema=schema,
-                      name='expression-system',
-                      full_name='Expression System',
-                      data_type=ParameterName.STRING,
-                      is_searchable=True,
-                      immutable=True,
-                      order=1).save()
-        ParameterName(schema=schema,
-                      name='organism',
-                      full_name='Organism',
-                      data_type=ParameterName.STRING,
-                      is_searchable=True,
-                      immutable=True,
-                      order=2).save()
-        ParameterName(schema=schema,
-                      name='sequence',
-                      full_name='Sequence',
-                      data_type=ParameterName.STRING,
-                      is_searchable=True,
-                      immutable=True,
-                      order=3).save()
+        schema, _ = Schema.objects.get_or_create(namespace=namespace,
+                                                 name='Sequence Data',
+                                                 hidden=False,
+                                                 immutable=True)
+
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='expression-system',
+                                            full_name='Expression System',
+                                            data_type=ParameterName.STRING,
+                                            is_searchable=True,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='organism',
+                                            full_name='Organism',
+                                            data_type=ParameterName.STRING,
+                                            is_searchable=True,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='sequence',
+                                            full_name='Sequence',
+                                            data_type=ParameterName.STRING,
+                                            is_searchable=True,
+                                            immutable=True)
 
     def _setup_PDB_CITATION_PUBLICATION_SCHEMA(self, namespace):
-        schema = Schema(namespace=namespace, name='Citation', hidden=False,
-                        immutable=True)
-        schema.save()
-        ParameterName(schema=schema,
-                      name='title',
-                      full_name='Title',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=1).save()
-        ParameterName(schema=schema,
-                      name='authors',
-                      full_name='Authors',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=2).save()
-        ParameterName(schema=schema,
-                      name='journal',
-                      full_name='Journal',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=3).save()
-        ParameterName(schema=schema,
-                      name='volume',
-                      full_name='Volume',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=4).save()
-        ParameterName(schema=schema,
-                      name='page-range',
-                      full_name='Pages',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=5).save()
-        ParameterName(schema=schema,
-                      name='doi',
-                      full_name='DOI',
-                      data_type=ParameterName.URL,
-                      immutable=True,
-                      order=6).save()
+        schema, _ = Schema.objects.get_or_create(namespace=namespace,
+                                                 name='Citation',
+                                                 hidden=False,
+                                                 immutable=True)
+
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='title',
+                                            full_name='Title',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='authors',
+                                            full_name='Authors',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='journal',
+                                            full_name='Journal',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='volume',
+                                            full_name='Volume',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='page-range',
+                                            full_name='Pages',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='doi',
+                                            full_name='DOI',
+                                            data_type=ParameterName.URL,
+                                            immutable=True)
 
     def _setup_PUBLICATION_DETAILS_SCHEMA(self, namespace):
-        schema = Schema(namespace=namespace, name='Publication Details',
-                        hidden=False, immutable=True)
-        schema.save()
-        ParameterName(schema=schema,
-                      name='doi',
-                      full_name='DOI',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=1).save()
-        ParameterName(schema=schema,
-                      name='acknowledgements',
-                      full_name='Acknowledgements',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=2).save()
+        schema, _ = Schema.objects.get_or_create(namespace=namespace,
+                                                 name='Publication Details',
+                                                 hidden=False,
+                                                 immutable=True)
+
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='doi',
+                                            full_name='DOI',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='acknowledgements',
+                                            full_name='Acknowledgements',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
 
     def _setup_MX_PUBLICATION_DATASET_SCHEMA(self, namespace):
-        schema = Schema(namespace=namespace, name='MX dataset details',
-                        hidden=False, immutable=True)
-        schema.save()
-        ParameterName(schema=schema,
-                      name='dataset',
-                      full_name='Dataset',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=1).save()
-        ParameterName(schema=schema,
-                      name='description',
-                      full_name='Description',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=2).save()
-        ParameterName(schema=schema,
-                      name='additional-information',
-                      full_name='Additional information',
-                      data_type=ParameterName.STRING,
-                      immutable=True,
-                      order=3).save()
+        schema, _ = Schema.objects.get_or_create(namespace=namespace,
+                                                 name='MX dataset details',
+                                                 hidden=False,
+                                                 immutable=True)
+
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='dataset',
+                                            full_name='Dataset',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='description',
+                                            full_name='Description',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
+        ParameterName.objects.get_or_create(schema=schema,
+                                            name='additional-information',
+                                            full_name='Additional information',
+                                            data_type=ParameterName.STRING,
+                                            immutable=True)
 
     def do_setup(self, force=False):
         logger.info('Checking for required django settings.')
@@ -263,14 +242,10 @@ class PubFormConfig():
                             ' later! (%s)' % description)
 
         for schema, description in required_schemas:
-            if self._schema_exists(getattr(settings, schema,
-                                           getattr(default_settings, schema))):
-                logger.info('Schema ' + schema + ' exists, skipping.')
-            else:
-                logger.info('Setting up schema: ' + schema)
-                getattr(self, '_setup_' + schema)(
-                    getattr(settings, schema,
-                            getattr(default_settings, schema)))
+            logger.info('Setting up schema: ' + schema)
+            getattr(self, '_setup_' + schema)(
+                getattr(settings, schema,
+                        getattr(default_settings, schema)))
 
         pub_group = getattr(settings, 'PUBLICATION_OWNER_GROUP',
                             'publication-admin')

--- a/tardis/apps/publication_forms/tasks.py
+++ b/tardis/apps/publication_forms/tasks.py
@@ -38,14 +38,11 @@ def update_publication_records():
     release_lock = lambda: cache.delete(lock_id)
 
     if (acquire_lock()):
-        print('has lock')
         try:
             populate_pdb_pub_records()
             process_embargos()
         finally:
             release_lock()
-    else:
-        print('no lock')
 
 
 def has_pdb_embargo(publication):

--- a/tardis/settings_changeme.py
+++ b/tardis/settings_changeme.py
@@ -51,6 +51,8 @@ custom buildout.cfg:
 # 'django.middleware.cache.FetchFromCacheMiddleware'
 # to your MIDDLEWARE_CLASSES setting below
 
+# The MemcachedCache backend is required for the publication form app
+
 # CACHES = {
 #    'default': {
 #        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',

--- a/tardis/settings_changeme.py
+++ b/tardis/settings_changeme.py
@@ -51,14 +51,23 @@ custom buildout.cfg:
 # 'django.middleware.cache.FetchFromCacheMiddleware'
 # to your MIDDLEWARE_CLASSES setting below
 
-# The MemcachedCache backend is required for the publication form app
-
 # CACHES = {
 #    'default': {
 #        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
 #        'LOCATION': '127.0.0.1:11211',
 #    }
 # }
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+    },
+    'celery-locks': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'celery_lock_cache',
+    }
+}
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name


### PR DESCRIPTION
* Memcached added to build.sh as a dependency
* Celery task locking fixed by adding a DB cache backend
* Default cache set to memcached
* Publication form setup checks all Schemas and ParameterNames using get_or_create rather than assuming that no setup is required if a schema exists - addresses cases where new parameter names are added to publication schemas.
* Numerical values from the PDBHelper utility are checked for ValueErrors, for cases where the PDB file contains '?' as an entry instead of a value. Invalid entries are logged and omitted from the parameter set.