### PR TITLE
Adding support for listing groups (as well as users) in Facility Overview

### DIFF
--- a/tardis/tardis_portal/models/access_control.py
+++ b/tardis/tardis_portal/models/access_control.py
@@ -184,6 +184,8 @@ class ObjectACL(models.Model):
         """
         if self.pluginId == 'django_user':
             return User.objects.get(pk=self.entityId)
+        elif self.pluginId == 'django_group':
+            return Group.objects.get(pk=self.entityId)
         return None
 
     def get_related_object_group(self):

--- a/tardis/tardis_portal/models/experiment.py
+++ b/tardis/tardis_portal/models/experiment.py
@@ -198,6 +198,13 @@ class Experiment(models.Model):
                                         isOwner=True)
         return [acl.get_related_object() for acl in acls]
 
+    def get_groups(self):
+        acls = ObjectACL.objects.filter(pluginId='django_group',
+                                        content_type=self.get_ct(),
+                                        object_id=self.id,
+                                        canRead=True)
+        return [acl.get_related_object() for acl in acls]
+
     def _has_view_perm(self, user_obj):
         if not hasattr(self, 'id'):
             return False

--- a/tardis/tardis_portal/static/js/facility_view.js
+++ b/tardis/tardis_portal/static/js/facility_view.js
@@ -155,8 +155,8 @@
     function groupByUser(data) {
       // Sort by username, group name
 	data.sort(function(a,b) {
-            aOwnerGroup = a.owner + ', ' + a.group
-            bOwnerGroup = b.owner + ', ' + b.group
+            var aOwnerGroup = a.owner + ', ' + a.group
+            var bOwnerGroup = b.owner + ', ' + b.group
 	    if (aOwnerGroup < bOwnerGroup) {
 		return -1;
 	    } else if (aOwnerGroup > bOwnerGroup) {

--- a/tardis/tardis_portal/static/js/facility_view.js
+++ b/tardis/tardis_portal/static/js/facility_view.js
@@ -153,11 +153,13 @@
 
     // Group facilities data by user
     function groupByUser(data) {
-      // Sort by user ID
+      // Sort by username, group name
 	data.sort(function(a,b) {
-	    if (a.owner < b.owner) {
+            aOwnerGroup = a.owner + ', ' + a.group
+            bOwnerGroup = b.owner + ', ' + b.group
+	    if (aOwnerGroup < bOwnerGroup) {
 		return -1;
-	    } else if (a.owner > b.owner) {
+	    } else if (aOwnerGroup > bOwnerGroup) {
 		return 1;
 	    } else {
 		return 0;
@@ -165,17 +167,30 @@
 	});
       
       var result = [];
-      var tmp = {"owner":data[0].owner};
+      if (data[0].group) {
+        data[0].ownerGroup = data[0].owner+', '+data[0].group;
+      }
+      else {
+        data[0].ownerGroup = data[0].owner
+      }
+      var tmp = {"ownerGroup":data[0].ownerGroup};
       tmp['datasets']=[];
       for (var i = 0; i < data.length; i++) {
-        if (tmp.owner !== data[i].owner) {
+        data[i].ownerGroup = data[i].owner+', '+data[i].group;
+        if (data[i].group) {
+          data[i].ownerGroup = data[i].owner+', '+data[i].group;
+        }
+        else {
+          data[i].ownerGroup = data[i].owner
+        }
+        if (tmp.ownerGroup !== data[i].ownerGroup) {
           result.push(tmp);
-          tmp = {"owner":data[i].owner};
+          tmp = {"ownerGroup":data[i].ownerGroup};
           tmp['datasets'] = [];
         }
         var dataset = {};
         for (var key in data[i]) {
-           if (key !== "owner") {
+           if (key !== "ownerGroup") {
              dataset[key] = data[i][key];
            }
         }

--- a/tardis/tardis_portal/templates/tardis_portal/facility_overview.html
+++ b/tardis/tardis_portal/templates/tardis_portal/facility_overview.html
@@ -102,6 +102,7 @@
             <table class="table table-striped table-bordered table-condensed">
                 <tr>
                     <th>Owner</th>
+                    <th>Group</th>
                     <th>Experiment</th>
                     <th>Dataset description</th>
                     <th>Instrument</th>
@@ -110,6 +111,7 @@
                 </tr>
                 <tr ng-repeat-start="dataset in datasets | filter:search_owner:strict | filter:search_experiment:strict | filter:search_instrument:strict">
                     <td>{{dataset.owner}}</td>
+                    <td>{{dataset.group}}</td>
                     <td><a href="/experiment/view/{{dataset.parent_experiment.id}}/" target="_blank">{{dataset.parent_experiment.title}}</a></td>
                     <td>{{dataset.description}}</td>
                     <td>{{dataset.instrument.name}}</td>
@@ -159,6 +161,7 @@
             <table class="table table-striped table-bordered table-condensed">
                 <tr>
                     <th>Owner</th>
+                    <th>Group</th>
                     <th>Experiment</th>
                     <th>Dataset description</th>
                     <th>Created</th>
@@ -170,6 +173,7 @@
                 </tr>
                 <tr ng-repeat-start="dataset in datasetByInstrument.datasets | filter:search_owner:strict | filter:search_experiment:strict">
                     <td>{{dataset.owner}}</td>
+                    <td>{{dataset.group}}</td>
                     <td><a href="/experiment/view/{{dataset.parent_experiment.id}}/" target="_blank">{{dataset.parent_experiment.title}}</a></td>
                     <td>{{dataset.description}}</td>
                     <td>{{dataset.parent_experiment.created_time | date:'yyyy-MM-dd h:mma'}}</td>

--- a/tardis/tardis_portal/templates/tardis_portal/facility_overview.html
+++ b/tardis/tardis_portal/templates/tardis_portal/facility_overview.html
@@ -229,7 +229,7 @@
                 </tr>
                 <tbody ng-repeat="datasetByUser in dataByUser | filter:search_owner:strict">
                 <tr>
-                    <th style="text-align:center" colspan="5">{{datasetByUser.owner}}</th>
+                    <th style="text-align:center" colspan="5">{{datasetByUser.ownerGroup}}</th>
                 </tr>
                 <tr ng-repeat-start="dataset in datasetByUser.datasets | filter:search_experiment:strict | filter:search_instrument:strict">
                     <td><a href="/experiment/view/{{dataset.parent_experiment.id}}/" target="_blank">{{dataset.parent_experiment.title}}</a></td>

--- a/tardis/tardis_portal/views.py
+++ b/tardis/tardis_portal/views.py
@@ -420,9 +420,14 @@ def fetch_facility_data(request, facility_id, start_index, end_index):
     for dataset in dataset_objects:
         instrument = dataset.instrument
         facility = instrument.facility
-        parent_experiment = dataset.experiments.all()[:1].get()
+        try:
+            parent_experiment = dataset.experiments.all()[:1].get()
+        except ObjectDoesNotExist:
+            logger.warning("Not listing dataset id %d in Facility Overview" % dataset.id)
+            continue
         datafile_objects = DataFile.objects.filter(dataset=dataset)
         owners = parent_experiment.get_owners()
+        groups = parent_experiment.get_groups()
         datafiles = []
         dataset_size = 0
         verified_datafiles_count = 0
@@ -468,6 +473,7 @@ def fetch_facility_data(request, facility_id, start_index, end_index):
             "verified_datafiles_count": verified_datafiles_count,
             "verified_datafiles_size": verified_datafiles_size,
             "owner": ', '.join([o.username for o in owners]),
+            "group": ', '.join([g.name for g in groups]),
             "instrument": {
                 "id": instrument.id,
                 "name": instrument.name,


### PR DESCRIPTION
It looks like this cherry-picked commit also includes a workaround for an issue where attempting to display Facility Overview failed if you had orphaned datasets (not linked to any experiments), as a result of manually deleting experiments in the Django Admin interface.  (See "parent_experiment" below.)

Here's what it looks like in context:
http://mydata.readthedocs.org/en/latest/user-groups.html#data-uploads-from-instrument-pcs
http://mydata.readthedocs.org/en/latest/_images/FacilityOverviewUserGroups.PNG
