### PR TITLE
When a new dataset is created by POSTing to MyTardis's API,

### DIFF
--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -774,6 +774,7 @@ class DatasetResource(MyTardisModelResource):
             'description': ('exact', ),
             'directory': ('exact', ),
         }
+        always_return_data = True
 
     def prepend_urls(self):
         return [


### PR DESCRIPTION
MyData assumes that the new record's JSON will be returned
in the HTTP response, e.g. here:
https://github.com/monash-merc/mydata/blob/develop/mydata/DatasetModel.py#L79

Having "always_return_data = True" in the MyTardis API's
DatasetResource class's Meta will achieve this.

Alternatively, MyData could be rewritten to do a separate API lookup
after creating the record, or it could assume that the new record
created has the same content as the JSON POSTed to the API, together
with a new primary key as included in the 'location' header of the
HTTP response.