### PR TITLE
Highlight unverified datafiles

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/ajax/datafile_list.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/datafile_list.html
@@ -75,7 +75,7 @@ Select: <a class="dataset_selector_all btn btn-mini">All</a> / <a class="dataset
     {% endif %}
   </td>
   <td>
-    {% if has_download_permissions and datafile.get_view_url %}
+    {% if has_download_permissions and datafile.get_view_url and datafile.verified %}
       <a  class="filelink datafile_name"
           href="{{ datafile.get_view_url }}"
           title="View"

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/datafile_list.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/datafile_list.html
@@ -81,9 +81,17 @@ Select: <a class="dataset_selector_all btn btn-mini">All</a> / <a class="dataset
           title="View"
           target="_blank">{{ datafile.filename }}</a>
     {% else %}
-    <span class="datafile_name">{{ datafile.filename }}</span>
+      {% if datafile.verified %}
+        <span class="datafile_name">{{ datafile.filename }}</span>
+      {% else %}
+        <span class="datafile_name" style="color:red;">{{ datafile.filename }}</span>
+      {% endif %}
     {% endif %}
-    {% if datafile.size %}<span style="margin-right: 5px">({{ datafile.size|filesizeformat }})</span>{% endif %}
+    {% if datafile.verified %}
+      {% if datafile.size %}<span style="margin-right: 5px">({{ datafile.size|filesizeformat }})</span>{% endif %}
+    {% else %}
+      <span style="margin-right: 5px; color:red;">(unverified)</span>
+    {% endif %}
     {% if has_download_permissions and datafile.get_view_url %}
       {% url 'tardis.tardis_portal.iiif.download_image' datafile_id=datafile.id region='full' size=',28' rotation=0 quality='native' format='jpg' as thumbnail %}
       {% url 'tardis.tardis_portal.iiif.download_image' datafile_id=datafile.id region='full' size='full' rotation=0 quality='native' format='png' as image %}


### PR DESCRIPTION
Not sure if it's appropriate to merge this (or a variation of it) into the main MyTardis branch(es), or whether it is too site-specific.  Basically our (facility manager) users said they didn't want their users to be given the false impression that their datafiles had finished uploading to MyTardis by seeing them listed in MyTardis's "My Data" view, when in fact they were still only partially uploaded.  Having the datafiles appear in "My Data" before completing their uploads can result from using the MyTardis's API's staging upload method where the datafile record is created before the actual datafile is uploaded. 

At first our (facility manager) MyTardis users requested that unverified datafiles not appear at all in their users' "My Data" view in MyTardis, but then they changed their mind and requested that the unverified datafiles be listed in "My Data", but that they be clearly annotated as being unverified.  (Hence the red coloring below.)

Also, I found that clicking on the view_url hyperlinks for unverified files could lead to unhandled exceptions, so I disabled the view_url hyperlinks for unverified datafiles.
