### PR TITLE
Allow empty files

### DIFF
--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -161,8 +161,12 @@ class DataFile(models.Model):
                 not self.md5sum and not self.sha512sum and require_checksums:
             raise Exception('Every Datafile requires a checksum')
         elif settings.REQUIRE_DATAFILE_SIZES and \
-                not self.size:
+             str(self.size).strip() is '':
             raise Exception('Every Datafile requires a file size')
+
+        if str(self.size).strip() is not '' and int(self.size) < 0:
+            raise Exception('Datafile size cannot be less than 0 bytes')
+
         super(DataFile, self).save(*args, **kwargs)
 
     def get_size(self):

--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -158,14 +158,17 @@ class DataFile(models.Model):
     def save(self, *args, **kwargs):
         require_checksums = kwargs.pop('require_checksums', True)
         if settings.REQUIRE_DATAFILE_CHECKSUMS and \
-                not self.md5sum and not self.sha512sum and require_checksums:
+                not self.md5sum and \
+                not self.sha512sum and \
+                require_checksums:
             raise Exception('Every Datafile requires a checksum')
-        elif settings.REQUIRE_DATAFILE_SIZES and \
-             str(self.size).strip() is '':
-            raise Exception('Every Datafile requires a file size')
-
-        if str(self.size).strip() is not '' and int(self.size) < 0:
-            raise Exception('Datafile size cannot be less than 0 bytes')
+        elif settings.REQUIRE_DATAFILE_SIZES:
+            if ((isinstance(self.size, (str, unicode)) and
+                 (self.size.strip() is '' or long(self.size.strip()) < 0)) or
+                (isinstance(self.size, (int, long)) and self.size < 0) or
+                str(self.size).strip() is ''):
+                raise Exception('Invalid Datafile size (must be >= 0): %s' %
+                                repr(self.size))
 
         super(DataFile, self).save(*args, **kwargs)
 

--- a/tardis/tardis_portal/tests/test_models.py
+++ b/tardis/tardis_portal/tests/test_models.py
@@ -116,7 +116,7 @@ class ModelTestCase(TestCase):
     def test_datafile(self):
         from tardis.tardis_portal.models import Experiment, Dataset, DataFile
 
-        def _build(dataset, filename, url, protocol):
+        def _build(dataset, filename, url):
             from tardis.tardis_portal.models import \
                 DataFileObject
             datafile = DataFile(dataset=dataset, filename=filename)
@@ -145,7 +145,7 @@ class ModelTestCase(TestCase):
         try:
             settings.REQUIRE_DATAFILE_SIZES = False
             settings.REQUIRE_DATAFILE_CHECKSUMS = False
-            df_file = _build(dataset, 'file.txt', 'path/file.txt', '')
+            df_file = _build(dataset, 'file.txt', 'path/file.txt')
             self.assertEqual(df_file.filename, 'file.txt')
             self.assertEqual(df_file.file_objects.all()[0].uri,
                              'path/file.txt')
@@ -154,7 +154,7 @@ class ModelTestCase(TestCase):
             self.assertEqual(df_file.get_download_url(),
                              '/api/v1/dataset_file/1/download')
 
-            df_file = _build(dataset, 'file1.txt', 'path/file1.txt', 'vbl')
+            df_file = _build(dataset, 'file1.txt', 'path/file1.txt')
             self.assertEqual(df_file.filename, 'file1.txt')
             self.assertEqual(df_file.file_objects.all()[0].uri,
                              'path/file1.txt')
@@ -162,7 +162,7 @@ class ModelTestCase(TestCase):
             self.assertEqual(df_file.size, '')
             self.assertEqual(df_file.get_download_url(),
                              '/api/v1/dataset_file/2/download')
-            df_file = _build(dataset, 'file1.txt', 'path/file1#txt', 'vbl')
+            df_file = _build(dataset, 'file1.txt', 'path/file1#txt')
             self.assertEqual(df_file.filename, 'file1.txt')
             self.assertEqual(df_file.dataset, dataset)
             self.assertEqual(df_file.size, '')
@@ -170,12 +170,30 @@ class ModelTestCase(TestCase):
                              '/api/v1/dataset_file/3/download')
 
             df_file = _build(dataset, 'f.txt',
-                             'http://localhost:8080/filestore/f.txt', '')
+                             'http://localhost:8080/filestore/f.txt')
             self.assertEqual(df_file.filename, 'f.txt')
             self.assertEqual(df_file.dataset, dataset)
             self.assertEqual(df_file.size, '')
             self.assertEqual(df_file.get_download_url(),
                              '/api/v1/dataset_file/4/download')
+
+            # check that we can create datafiles with byte size of zero
+            df_file = _build(dataset, 'empty.txt',
+                             'http://localhost:8080/5/empty.txt')
+            df_file.size = 0  # actually a CharField, so gets saved as a string
+            df_file.save()
+            df_pk = df_file.pk
+            saved_df = DataFile.objects.get(pk=df_pk)
+            self.assertEqual(saved_df.size, '0')
+
+
+            # check that can't save negative byte sizes
+            df_file = _build(dataset, 'lessthanempty.txt',
+                             'http://localhost:8080/6/lessthanempty.txt')
+            df_file.size = '-1'
+            with self.assertRaises(Exception):
+                df_file.save()
+
             # Now check the 'REQUIRE' config params
             with self.assertRaises(Exception):
                 settings.REQUIRE_DATAFILE_SIZES = True

--- a/tardis/tardis_portal/tests/test_models.py
+++ b/tardis/tardis_portal/tests/test_models.py
@@ -178,21 +178,21 @@ class ModelTestCase(TestCase):
                              '/api/v1/dataset_file/4/download')
 
             # check that we can create datafiles with byte size of zero
-            df_file = _build(dataset, 'empty.txt',
-                             'http://localhost:8080/5/empty.txt')
-            df_file.size = 0  # actually a CharField, so gets saved as a string
+            # size is actually a CharField, so gets saved as a string
+            settings.REQUIRE_DATAFILE_SIZES = True
+            df_file = DataFile(dataset=dataset,
+                               filename='empty.txt',
+                               size=0)
             df_file.save()
             df_pk = df_file.pk
             saved_df = DataFile.objects.get(pk=df_pk)
-            self.assertEqual(saved_df.size, '0')
-
+            self.assertEqual(saved_df.size, u'0')
 
             # check that can't save negative byte sizes
-            df_file = _build(dataset, 'lessthanempty.txt',
-                             'http://localhost:8080/6/lessthanempty.txt')
-            df_file.size = '-1'
             with self.assertRaises(Exception):
-                df_file.save()
+                settings.REQUIRE_DATAFILE_SIZES = True
+                DataFile(dataset=dataset, filename='lessthanempty.txt',
+                         size='-1').save()
 
             # Now check the 'REQUIRE' config params
             with self.assertRaises(Exception):


### PR DESCRIPTION
Allows creation of an empty (zero size) data file via the API if the JSON request provides an int instead of a string (size = 0 instead of size = '0') and REQUIRE_DATAFILE_SIZES is turned on. Removes an unused variable in the unit tests for the DataFile model, and adds a test to check that zero sized files are possible, but negative sized files aren't.