### PR TITLE
When a new experiment is created by POSTing to MyTardis's API,

### DIFF
--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -626,6 +626,7 @@ class ExperimentResource(MyTardisModelResource):
             'id': ('exact', ),
             'title': ('exact',),
         }
+        always_return_data = True
 
     def dehydrate(self, bundle):
         exp = bundle.obj


### PR DESCRIPTION
MyData assumes that the new record's JSON will be returned
in the HTTP response, e.g. here:

https://github.com/monash-merc/mydata/blob/develop/mydata/ExperimentModel.py#L210

Having "always_return_data = True" in the MyTardis API's
ExperimentResource class's Meta will achieve this.