### PR TITLE
Allowing storage box options and attributes to queried via the API.

### DIFF
--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -39,6 +39,8 @@ from tardis.tardis_portal.models.parameters import ExperimentParameterSet
 from tardis.tardis_portal.models.parameters import ParameterName
 from tardis.tardis_portal.models.parameters import Schema
 from tardis.tardis_portal.models.storage import StorageBox
+from tardis.tardis_portal.models.storage import StorageBoxOption
+from tardis.tardis_portal.models.storage import StorageBoxAttribute
 from tardis.tardis_portal.models.facility import Facility
 from tardis.tardis_portal.models.facility import facilities_managed_by
 from tardis.tardis_portal.models.instrument import Instrument
@@ -206,6 +208,12 @@ class ACLAuthorization(Authorization):
             instruments = Instrument.objects.filter(facility__in=facilities)
             return [instrument for instrument in object_list
                     if instrument in instruments]
+        elif isinstance(bundle.obj, StorageBox):
+            return object_list
+        elif isinstance(bundle.obj, StorageBoxOption):
+            return object_list
+        elif isinstance(bundle.obj, StorageBoxAttribute):
+            return object_list
         else:
             return []
 
@@ -248,6 +256,10 @@ class ACLAuthorization(Authorization):
         elif isinstance(bundle.obj, ParameterName):
             return True
         elif isinstance(bundle.obj, StorageBox):
+            return bundle.request.user.is_authenticated()
+        elif isinstance(bundle.obj, StorageBoxOption):
+            return bundle.request.user.is_authenticated()
+        elif isinstance(bundle.obj, StorageBoxAttribute):
             return bundle.request.user.is_authenticated()
         elif isinstance(bundle.obj, Group):
             return bundle.obj in bundle.request.user.groups.all()
@@ -726,7 +738,40 @@ class DatasetParameterResource(ParameterResource):
         queryset = DatasetParameter.objects.all()
 
 
+class StorageBoxOptionResource(MyTardisModelResource):
+    storage_box = fields.ForeignKey(
+        'tardis.tardis_portal.api.StorageBoxResource',
+        'storage_box',
+        related_name='options',
+        full=False)
+
+    class Meta(MyTardisModelResource.Meta):
+        queryset = StorageBoxOption.objects.all()
+
+
+class StorageBoxAttributeResource(MyTardisModelResource):
+    storage_box = fields.ForeignKey(
+        'tardis.tardis_portal.api.StorageBoxResource',
+        'storage_box',
+        related_name='attributes',
+        full=False)
+
+    class Meta(MyTardisModelResource.Meta):
+        queryset = StorageBoxAttribute.objects.all()
+
+
 class StorageBoxResource(MyTardisModelResource):
+    options = fields.ToManyField(
+        'tardis.tardis_portal.api.StorageBoxOptionResource',
+        'options',
+        related_name='storage_box',
+        full=True, null=True)
+    attributes = fields.ToManyField(
+        'tardis.tardis_portal.api.StorageBoxAttributeResource',
+        'attributes',
+        related_name='storage_box',
+        full=True, null=True)
+
     class Meta(MyTardisModelResource.Meta):
         queryset = StorageBox.objects.all()
 

--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -743,12 +743,11 @@ class DatasetParameterResource(ParameterResource):
 
 
 class StorageBoxResource(MyTardisModelResource):
-    accessible_keys = ['location']
     options = fields.ToManyField(
         'tardis.tardis_portal.api.StorageBoxOptionResource',
         attribute=lambda bundle: StorageBoxOption.objects\
             .filter(storage_box=bundle.obj,
-                    key__in=StorageBoxResource.accessible_keys),
+                    key__in=StorageBoxOptionResource.accessible_keys),
         related_name='storage_box',
         full=True, null=True)
     attributes = fields.ToManyField(
@@ -762,6 +761,7 @@ class StorageBoxResource(MyTardisModelResource):
 
 
 class StorageBoxOptionResource(MyTardisModelResource):
+    accessible_keys = ['location']
     storage_box = fields.ForeignKey(
         'tardis.tardis_portal.api.StorageBoxResource',
         'storage_box',

--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -746,9 +746,9 @@ class DatasetParameterResource(ParameterResource):
 class StorageBoxResource(MyTardisModelResource):
     options = fields.ToManyField(
         'tardis.tardis_portal.api.StorageBoxOptionResource',
-        attribute=lambda bundle: StorageBoxOption.objects\
-            .filter(storage_box=bundle.obj,
-                    key__in=StorageBoxOptionResource.accessible_keys),
+        attribute=lambda bundle: StorageBoxOption.objects
+        .filter(storage_box=bundle.obj,
+                key__in=StorageBoxOptionResource.accessible_keys),
         related_name='storage_box',
         full=True, null=True)
     attributes = fields.ToManyField(

--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -262,7 +262,8 @@ class ACLAuthorization(Authorization):
         elif isinstance(bundle.obj, StorageBox):
             return bundle.request.user.is_authenticated()
         elif isinstance(bundle.obj, StorageBoxOption):
-            return bundle.obj.key in StorageBoxOptionResource.accessible_keys
+            return bundle.request.user.is_authenticated() and \
+                bundle.obj.key in StorageBoxOptionResource.accessible_keys
         elif isinstance(bundle.obj, StorageBoxAttribute):
             return bundle.request.user.is_authenticated()
         elif isinstance(bundle.obj, Group):

--- a/tardis/urls.py
+++ b/tardis/urls.py
@@ -272,6 +272,8 @@ from tardis.tardis_portal.api import ParameterNameResource
 from tardis.tardis_portal.api import ReplicaResource
 from tardis.tardis_portal.api import SchemaResource
 from tardis.tardis_portal.api import StorageBoxResource
+from tardis.tardis_portal.api import StorageBoxOptionResource
+from tardis.tardis_portal.api import StorageBoxAttributeResource
 from tardis.tardis_portal.api import UserResource
 from tardis.tardis_portal.api import GroupResource
 from tardis.tardis_portal.api import ObjectACLResource
@@ -292,6 +294,8 @@ v1_api.register(ParameterNameResource())
 v1_api.register(ReplicaResource())
 v1_api.register(SchemaResource())
 v1_api.register(StorageBoxResource())
+v1_api.register(StorageBoxOptionResource())
+v1_api.register(StorageBoxAttributeResource())
 v1_api.register(UserResource())
 v1_api.register(GroupResource())
 v1_api.register(ObjectACLResource())


### PR DESCRIPTION
The JSON returned when querying a storage box now includes the
JSON for the associated options and attributes, by using full=True
in the ToManyField.