### PR TITLE
Optional publication data admin can be set

### DIFF
--- a/tardis/apps/publication_forms/default_settings.py
+++ b/tardis/apps/publication_forms/default_settings.py
@@ -66,4 +66,4 @@ MODC_DOI_MINT_URL_ROOT = 'http://mytardisserver/'
 
 # Change this to the user name of the data administrator if it should be someone other than the
 # publication creator
-PUBLICATION_DATA_ADMIN = 'jrigby'
+PUBLICATION_DATA_ADMIN = None

--- a/tardis/apps/publication_forms/default_settings.py
+++ b/tardis/apps/publication_forms/default_settings.py
@@ -63,3 +63,7 @@ MODC_DOI_DEACTIVATE_DEFINITION = 'https://doiserver/modc/ws/' \
     'DeactivateDoiService.wsdl'
 MODC_DOI_ENDPOINT = 'https://doiserver/modc/ws/'
 MODC_DOI_MINT_URL_ROOT = 'http://mytardisserver/'
+
+# Change this to the user name of the data administrator if it should be someone other than the
+# publication creator
+PUBLICATION_DATA_ADMIN = 'jrigby'


### PR DESCRIPTION
This PR adds the ability to change the publication owner upon approval to a designated data administrator account. The practical outcome of this is that the "managedBy" related object in rif-cs resolves to an appropriate person.
Code formatting has also been cleaned up by PyCharm - new code is ~ L659 - L683

To set a designated data administrator, add the PUBLICATION_DATA_ADMIN to settings.py and set to the username of the appropriate user. If not set, or set to None, no changes of ownership occur. If set to an invalid user, no changes occur but an error is logged.