### PR TITLE
oaipmh URLs are now https, not http.

### DIFF
--- a/tardis/apps/oaipmh/provider/experiment.py
+++ b/tardis/apps/oaipmh/provider/experiment.py
@@ -317,9 +317,9 @@ class RifCsExperimentProvider(AbstractExperimentProvider):
                 return getattr(settings, 'RIFCS_GROUP', '')
             def _get_originating_source(metadata):
                 # TODO: Handle repository data from federated MyTardis instances
-                return "http://%s/" % site.domain
+                return "https://%s/" % site.domain
             def _get_location(metadata):
-                return "http://%s%s" % \
+                return "https://%s%s" % \
                     ( site.domain,
                       reverse('tardis.tardis_portal.views.view_experiment',
                               args=[metadata.getMap().get('id')]) )
@@ -457,7 +457,7 @@ class RifCsExperimentProvider(AbstractExperimentProvider):
                                                           'RIFCS_GROUP', ''))
         def _get_originating_source(metadata):
             # TODO: Handle repository data from federated MyTardis instances
-            return "http://%s/" % site.domain
+            return "https://%s/" % site.domain
         # registryObjects
         wrapper = SubElement(element, _nsrif('registryObjects'), \
                        nsmap={None: RIFCS_NS, 'xsi': NS_XSI} )

--- a/tardis/apps/oaipmh/server.py
+++ b/tardis/apps/oaipmh/server.py
@@ -112,7 +112,7 @@ class ProxyingServer(IOAI):
         current_site = Site.objects.get_current().domain
         return Identify(
             "%s (MyTardis)" % (settings.DEFAULT_INSTITUTION,),
-            'http://%s%s' % (current_site, reverse('oaipmh-endpoint')),
+            'https://%s%s' % (current_site, reverse('oaipmh-endpoint')),
             '2.0',
             self._get_admin_emails(current_site),
             datetime.fromtimestamp(0),

--- a/tardis/apps/oaipmh/tests/test_oai.py
+++ b/tardis/apps/oaipmh/tests/test_oai.py
@@ -104,7 +104,7 @@ class EndpointTestCase(TestCase):
         # <originatingSource>http://keydomain.test.example/</originatingSource>
         expect(registryObject.xpath('r:originatingSource/text()',
                                     namespaces=ns)[0]) \
-                                    .to_equal('http://example.com/')
+                                    .to_equal('https://example.com/')
         # <collection type="dataset">
         expect(registryObject.xpath('r:collection/@type',
                                     namespaces=ns)[0]).to_equal('dataset')
@@ -128,7 +128,7 @@ class EndpointTestCase(TestCase):
         loc_xpath = 'r:location/r:address/r:electronic[@type="url"]'\
                     +'/r:value/text()'
         expect(collection.xpath(loc_xpath, namespaces=ns)[0]) \
-                .to_equal('http://example.com/experiment/view/%d/' %
+                .to_equal('https://example.com/experiment/view/%d/' %
                           experiment.id)
         # <rights>
         #     <accessRights>
@@ -168,7 +168,7 @@ class EndpointTestCase(TestCase):
         # <originatingSource>http://keydomain.test.example/</originatingSource>
         expect(registryObject.xpath('r:originatingSource/text()',
                                     namespaces=ns)[0]) \
-                                    .to_equal('http://example.com/')
+                                    .to_equal('https://example.com/')
         # <collection type="dataset">
         expect(registryObject.xpath('r:party/@type',
                                     namespaces=ns)[0]).to_equal('person')


### PR DESCRIPTION
I believe this should do the trick for the store.synch rif-cs feed URLs redirecting back to the main page.