### PR TITLE
Raise an exception in DEBUG mode if importing a custom Dataset or Experiment view fails.

### DIFF
--- a/tardis/tardis_portal/views.py
+++ b/tardis/tardis_portal/views.py
@@ -608,7 +608,10 @@ def view_experiment(request, experiment_id,
                 except (ImportError, AttributeError) as e:
                     logger.error('custom view import failed. view name: %s, '
                                  'error-msg: %s' % (repr(view_fn), e))
-                    continue
+                    if getattr(settings, 'DEBUG', True):
+                        raise e
+                    else:
+                        continue
 
     c['experiment'] = experiment
     c['has_write_permissions'] = \
@@ -820,7 +823,10 @@ def view_dataset(request, dataset_id):
                 except (ImportError, AttributeError) as e:
                     logger.error('custom view import failed. view name: %s, '
                                  'error-msg: %s' % (repr(view_fn), e))
-                    continue
+                    if getattr(settings, 'DEBUG', True):
+                        raise e
+                    else:
+                        continue
 
     def get_datafiles_page():
         # pagination was removed by someone in the interface but not here.


### PR DESCRIPTION
This is helpful when developing new custom views within an app, but will fall back to showing the default tardis_portal views if a custom view fails in production.