### PR TITLE
enabling customisations for different deployments, fixing some details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,16 @@ tardis/settings.py
 tardis/tardis_portal/tests/rifcs/MyTARDIS-1.xml
 var/
 versions.cfg
+tardis/apps/*
+!tardis/apps/__init__.py
+!tardis/apps/anzsrc_codes
+!tardis/apps/deep_storage_download_mapper
+!tardis/apps/dl_mapper_df_dir_only
+!tardis/apps/equipment
+!tardis/apps/filepicker
+!tardis/apps/mx_views
+!tardis/apps/oaipmh
+!tardis/apps/publication_forms
+!tardis/apps/related_info
+!tardis/apps/slideshow_view
+!tardis/apps/synch_linking

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+in development
+--------------
+
+* new settings for customisations
+
+
 3.6 - 16 March 2015
 -------------------
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -371,6 +371,26 @@ function listed in the ``*_VIEWS`` configuration item and added to the
 
 Refer to the :doc:`views documentation<contextual_views>` for further information.
 
+Site Customisations
+~~~~~~~~~~~~~~~~~~~
+
+Some settings that allow customised messages and styles.
+
+.. code-block:: python
+
+    PUBLICATION_INTRODUCTION = """
+    <p><strong>... introduction and publication agreement ...</strong></p>
+    """
+    SITE_STYLES = ''  # should be CSS
+
+    # if either GA setting is empty, GA is disabled
+    GOOGLE_ANALYTICS_ID = ''  # whatever Google provides
+    GOOGLE_ANALYTICS_HOST = ''  # the host registered with Google
+
+    # these refer to any template finder findable location, e.g. APPDIR/templates/...
+    CUSTOM_ABOUT_SECTION_TEMPLATE = 'tardis_portal/about_include.html'
+    CUSTOM_USER_GUIDE = 'user_guide/index.html'
+
 
 Deployment
 ----------

--- a/tardis/apps/publication_forms/static/publication-form/publication_form.js
+++ b/tardis/apps/publication_forms/static/publication-form/publication_form.js
@@ -271,7 +271,7 @@ app.controller('publicationFormCtrl', function ($scope, $log, $http, ngDialog, $
 
     // A list of available pages of the form, along with a function used to validate the form content
     $scope.form_pages = [{
-        title: 'Ready to publish?',
+        title: '',
         url: 'form_page1.html',
         validationFunction: noValidation
     },

--- a/tardis/apps/publication_forms/templates/form.html
+++ b/tardis/apps/publication_forms/templates/form.html
@@ -34,7 +34,9 @@
 </div>
 
 <script type="text/ng-template" id="form_page1.html">
-  <p><strong>... introductory blurb and publication agreement ...</strong></p>
+    {% endverbatim %}
+    {{ introduction }}
+    {% verbatim %}
 </script>
 <script type="text/ng-template" id="form_page2.html">
   <p><strong>Select your data!</strong> Below is all the data

--- a/tardis/apps/publication_forms/views.py
+++ b/tardis/apps/publication_forms/views.py
@@ -37,7 +37,12 @@ logger = logging.getLogger(__name__)
 @login_required
 def index(request):
     if request.method == 'GET':
-        return HttpResponse(render_response_index(request, 'form.html'))
+        context = {'introduction': getattr(
+            settings, 'PUBLICATION_INTRODUCTION',
+            "<p><strong>... introduction and publication agreement "
+            "...</strong></p>")}
+        return HttpResponse(render_response_index(
+            request, 'form.html', context=context))
     else:
         return process_form(request)
 

--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -612,9 +612,6 @@ class ExperimentParameterSetResource(ParameterSetResource):
         'experimentparameter_set',
         related_name='parameterset', full=True, null=True)
 
-    def save_m2m(self, bundle):
-        super(ExperimentParameterSetResource, self).save_m2m(bundle)
-
     class Meta(ParameterSetResource.Meta):
         queryset = ExperimentParameterSet.objects.all()
 

--- a/tardis/tardis_portal/context_processors.py
+++ b/tardis/tardis_portal/context_processors.py
@@ -58,5 +58,18 @@ def user_details_processor(request):
 def global_contexts(request):
     site_title = getattr(settings, 'SITE_TITLE', None)
     sponsored_by = getattr(settings, 'SPONSORED_TEXT', None)
+    site_styles = getattr(settings, 'SITE_STYLES', '')
     return {'site_title': site_title,
-            'sponsored_by': sponsored_by}
+            'sponsored_by': sponsored_by,
+            'site_styles': site_styles, }
+
+def google_analytics(request):
+    '''
+    adds context for portal_template.html
+    '''
+    ga_id = getattr(settings, 'GOOGLE_ANALYTICS_ID', '')
+    ga_host = getattr(settings, 'GOOGLE_ANALYTICS_HOST', '')
+    ga_enabled = ga_id != '' and ga_host != ''
+    return {'ga_enabled': ga_enabled,
+            'ga_id': ga_id,
+            'ga_host': ga_host}

--- a/tardis/tardis_portal/models/parameters.py
+++ b/tardis/tardis_portal/models/parameters.py
@@ -21,6 +21,7 @@ import logging
 import operator
 import pytz
 import dateutil.parser
+import json
 
 LOCAL_TZ = pytz.timezone(settings.TIME_ZONE)
 logger = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ class Schema(models.Model):
         (DATASET, 'Dataset schema'),
         (DATAFILE, 'Datafile schema'),
         (INSTRUMENT, 'Instrument schema'),
-        (NONE, 'None')
+        (NONE, 'None'),
     )
 
     _SCHEMA_TYPES_SHORT = (
@@ -55,7 +56,7 @@ class Schema(models.Model):
         (DATASET, 'dataset'),
         (DATAFILE, 'datafile'),
         (INSTRUMENT, 'instrument'),
-        (NONE, 'none')
+        (NONE, 'none'),
     )
 
     namespace = models.URLField(unique=True,
@@ -163,8 +164,8 @@ class ParameterName(models.Model):
     LINK = 4
     FILENAME = 5
     DATETIME = 6
-
     LONGSTRING = 7
+    JSON = 8
 
     __TYPE_CHOICES = (
         (NUMERIC, 'NUMERIC'),
@@ -173,7 +174,8 @@ class ParameterName(models.Model):
         (LINK, 'LINK'),
         (FILENAME, 'FILENAME'),
         (DATETIME, 'DATETIME'),
-        (LONGSTRING, 'LONGSTRING')
+        (LONGSTRING, 'LONGSTRING'),
+        (JSON, 'JSON'),
         )
 
     schema = models.ForeignKey(Schema)
@@ -243,6 +245,9 @@ class ParameterName(models.Model):
 
     def getUniqueShortName(self):
         return self.name + '_' + str(self.id)
+
+    def is_json(self):
+        return self.data_type == self.JSON
 
 
 def _getParameter(parameter):
@@ -329,6 +334,9 @@ def _getParameter(parameter):
     elif parameter.name.isDateTime():
         value = str(parameter.datetime_value)
         return value
+
+    elif parameter.name.is_json():
+        return json.loads(parameter.string_value)
 
     else:
         return None

--- a/tardis/tardis_portal/sftp.py
+++ b/tardis/tardis_portal/sftp.py
@@ -344,6 +344,11 @@ class MyTSFTPHandle(SFTPHandle):
 
 class MyTServerInterface(ServerInterface):
 
+    def __init__(self):
+        super(MyTServerInterface, self).__init__()
+        self.username = None
+        self.user = None
+
     def get_allowed_auths(self, username):
         auth_methods = ['password', 'keyboard-interactive']
         # if user_has_key_set_up:
@@ -365,6 +370,9 @@ class MyTServerInterface(ServerInterface):
             request=fake_request,
             authMethod=None)  # checks all available methods
         if user and user.is_authenticated():
+            # the following line is Australian Synchrotron specific and will
+            # disappear when we start using their newer auth system
+            user.epn_list = fake_request.session.get('_epn_list', [])
             self.username = username
             self.user = user
             return AUTH_SUCCESSFUL

--- a/tardis/tardis_portal/static/js/backbone-models.js
+++ b/tardis/tardis_portal/static/js/backbone-models.js
@@ -182,8 +182,7 @@ var MyTardis = (function(){
             }
             this.visibleTiles = _.chain(this.collection.filter(filterFunc))
                 .pluck('id')         // Get IDs
-                .sortBy(_.identity)  // Sort by ID (chronological)
-                .reverse().value();  // Get reversed order
+		.value();
             this.render();
             return this;
 	},

--- a/tardis/tardis_portal/templates/tardis_portal/about.html
+++ b/tardis/tardis_portal/templates/tardis_portal/about.html
@@ -1,85 +1,87 @@
 {% extends "tardis_portal/portal_template.html" %}
-
+{% load static from staticfiles %}
 {% block content %}
-  <div class="page-header">
-		<h1 class="title">Project Development</h1>
-  </div>
 
-  <div class="row-fluid">
-
-    <div class="span2">
-    	<h2><i class="icon-question-sign icon-large"></i> Help</h2>
-    	<ul class="unstyled">
-        <li>
-          <a href="https://github.com/mytardis/mytardis/wiki/UserGuide" target="_blank">User Guide</a>
-        </li>
-        <li>
-    	    <a href="http://mytardis.readthedocs.org/en/latest/index.html" target="_blank">Documentation</a>
-        </li>
-      </ul>
-    </div>
-
-    <div class="span5">
-    	<h2><i class="icon-github-sign icon-large"></i> Code / Documentation</h2>
-    	<p>
-    	The MyTardis project (including the Monash ANDS-funded EIF019 project and the Synchrotron/ANSTO MeCAT project) is being actively developed and documented on
-      <a href="https://github.com/mytardis/mytardis/">GitHub</a>.
-    </div>
-
-    <div class="span5">
-    	<h2><i class="icon-comment icon-large"></i> Discussion Group</h2>
-    	<ul class="unstyled">
-      	<li>
-          MyTardis User Group:
-          <a href="http://groups.google.com/group/tardis-users" target="_blank">
-          tardis-users
-          </a>
-        </li>
-      	<li>
-          MyTardis Developer Group:
-          <a href="http://groups.google.com/group/tardis-devel" target="_blank">
-          tardis-devel
-          </a>
-          <br/>
-          (invite only, contact
-          <a href="mailto: steve.androulakis@monash.edu">Steve Androulakis</a>)
-        </li>
-    	</ul>
-    </div>
-  </div>
-
-  <div class="row-fluid">
-    <div class="span12">
-      <h2><i class="icon-book icon-large"></i> Citation</h2>
-    	<p>
-    	  Please cite the following when referring to MyTardis:
-      </p>
-
-    	<blockquote>
-  	    Androulakis S, Schmidberger J, Bate MA, Degori R,
-  	    Beitz A, Keong C, Cameron B, McGowan S, Porter CJ,
-  	    Harrison A, Hunter J, Martin JL, Kobe B, Dobson RC, Parker
-  	    MW, Whisstock JC, Gray J, Treloar A, Groenewegen D,
-  	    Dickson N, Buckle AM. (2008) Federated repositories of
-  	    X-ray diffraction images. Acta Crystallogr D Biol
-  	    Crystallogr. Jul;64(Pt
-  	    7):810-4.
-  	    <a href="http://www.ncbi.nlm.nih.gov/pubmed/18566516?ordinalpos=1&itool=EntrezSystem2.PEntrez.Pubmed.Pubmed_ResultsPanel.Pubmed_RVDocSum">[PubMed]</a>
-      </blockquote>
-
-    	<p>
-    	  For more information on the MyTardis project please
-    	  contact <a href="mailto:ashley.buckle@med.monash.edu.au">Associate
-    	  Professor Ashley Buckle</a>.
-      </p>
+    <div class="page-header">
+        <h1 class="title">About Store.Synchrotron</h1>
     </div>
     <div class="row-fluid">
-      <div class="pull-right">
-	This server is running <a href="https://github.com/mytardis/mytardis/tree/{{ version.commit_id }}">version {{ version.tag }}</a> of MyTardis,
-	<br/>
-	released {{ version.date }}
-      </div>
+        {% include custom_about_section %}
     </div>
-  </div>
+    <div class="page-header">
+        <h1 class="title">Project Development</h1>
+    </div>
 
+    <div class="row-fluid">
+        <div class="span2">
+            <h2><i class="icon-question-sign icon-large"></i> Help</h2>
+            <ul class="unstyled">
+                <li>
+                    <a href="https://github.com/mytardis/mytardis/wiki/UserGuide"
+                       target="_blank">User Guide</a>
+                </li>
+                <li>
+                    <a href="http://mytardis.readthedocs.org/en/latest/index.html"
+                       target="_blank">Documentation</a>
+                </li>
+            </ul>
+        </div>
+        <div class="span5">
+            <h2><i class="icon-github-sign icon-large"></i>
+                Code / Documentation</h2>
+
+            <p>
+                The MyTardis project (including the Monash ANDS-funded EIF019
+                project and the Synchrotron/ANSTO MeCAT project)
+                is being actively developed and documented on
+                <a href="https://github.com/mytardis/mytardis/">GitHub</a>.
+        </div>
+        <div class="span5">
+            <h2><i class="icon-comment icon-large"></i> Discussion Group</h2>
+            <ul class="unstyled">
+                <li>
+                    MyTardis Developer Group:
+                    <a href="http://groups.google.com/group/tardis-devel"
+                       target="_blank"> tardis-devel
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+    <div class="row-fluid">
+        <div class="span12">
+            <h2><i class="icon-book icon-large"></i> Citation</h2>
+
+            <p>
+                Please cite the following when referring to MyTardis:
+            </p>
+
+            <blockquote>
+                Androulakis S, Schmidberger J, Bate MA, Degori R,
+                Beitz A, Keong C, Cameron B, McGowan S, Porter CJ,
+                Harrison A, Hunter J, Martin JL, Kobe B, Dobson RC, Parker
+                MW, Whisstock JC, Gray J, Treloar A, Groenewegen D,
+                Dickson N, Buckle AM. (2008) Federated repositories of
+                X-ray diffraction images. <em>Acta Crystallogr D Biol
+                Crystallogr.</em> Jul;64(Pt
+                7):810-4.
+                <a href="http://www.ncbi.nlm.nih.gov/pubmed/18566516?ordinalpos=1&itool=EntrezSystem2.PEntrez.Pubmed.Pubmed_ResultsPanel.Pubmed_RVDocSum">[PubMed]</a>
+            </blockquote>
+
+            <p>
+                For more information on the MyTardis project please
+                contact <a href="mailto:steve.androulakis@monash.edu.au">Steve
+                Androulakis</a>.
+            </p>
+        </div>
+        <div class="row-fluid">
+            <div class="pull-right">
+                This server is running <a
+                    href="https://github.com/mytardis/mytardis/tree/{{ version.commit_id }}">version
+                {{ version.tag }}</a> of MyTardis,
+                <br/>
+                released {{ version.date }}
+            </div>
+        </div>
+    </div>
 {% endblock content %}

--- a/tardis/tardis_portal/templates/tardis_portal/about_include.html
+++ b/tardis/tardis_portal/templates/tardis_portal/about_include.html
@@ -1,0 +1,4 @@
+<p>
+    For more information please visit <a
+        href="http://mytardis.org">mytardis.org</a>
+</p>

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/dataset_metadata.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/dataset_metadata.html
@@ -24,39 +24,12 @@
    </div>
    {% endif %}
   {% endcapture %}
-  <div style="margin-top: 10px">
-    {% with parameters=parameterset.datasetparameter_set.all %}
-    <table class="parameter_table table table-bordered {{ parameterset.schema.name|slugify }}">
-      <tr>
-        <th class="schema_name" title="{{ parameterset.schema.namespace }} {{ parameterset.schema.immutable|yesno:'(immutable),' }}" colspan="2">
-        {% if parameterset.schema.name %}
-          {{ parameterset.schema.name }}
-        {% endif %}
-        {% if edit_control %}
-            {{ edit_control }}
-        {% endif %}
-        </th>
-      </tr>
-      {% for parameter in parameters %}
-      <tr>
-          <td class="parameter_name">{{ parameter.name.full_name }}</td>
-          <td class="parameter_value">
-          {% if parameter.name.isLongString %}
-            {{ parameter.get|linebreaks }}
-	  {% elif parameter.name.isLink %}
-	    <a href="{{ parameter.link_url }}">{{parameter.link_gfk}}</a>
-          {% else %}
-            {{ parameter.get }}
-          {% endif %}
-          </td>
-      </tr>
-      {% endfor %}
-    </table>
-    {% endwith %}
-  </div>
+    <div style="margin-top: 10px">
+        {% include "tardis_portal/ajax/parameter_table.html" with parameters=parameterset.datasetparameter_set.all %}
+    </div>
 {% empty %}
-  <div>
-    There is no metadata for this dataset.
-  </div>
+    <div>
+        There is no metadata for this dataset.
+    </div>
 {% endfor %}
 </div>

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_metadata.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_metadata.html
@@ -24,36 +24,11 @@
    </div>
    {% endif %}
   {% endcapture %}
-  <div style="margin-top: 10px">
-    {% with parameters=parameterset.experimentparameter_set.all %}
-    <table class="parameter_table table table-bordered {{ parameterset.schema.name|slugify }}">
-      <tr>
-        <th class="schema_name" title="{{ parameterset.schema.namespace }} {{ parameterset.schema.immutable|yesno:'(immutable),' }}" colspan="2">
-        {% if parameterset.schema.name %}
-          {{ parameterset.schema.name }}
-        {% endif %}
-        {% if edit_control %}
-            {{ edit_control }}
-        {% endif %}
-        </th>
-      </tr>
-      {% for parameter in parameters %}
-      <tr>
-          <td class="parameter_name">{{ parameter.name.full_name }}</td>
-          <td class="parameter_value">
-              {% if parameter.name.isLongString %}
-                  {{ parameter.get|linebreaks }}
-              {% else %}
-                  {{ parameter.get }}
-              {% endif %}
-          </td>
-      </tr>
-      {% endfor %}
-    </table>
-    {% endwith %}
-  </div>
+    <div style="margin-top: 10px">
+        {% include "tardis_portal/ajax/parameter_table.html" with parameters=parameterset.experimentparameter_set.all %}
+    </div>
 {% empty %}
   <div class="alert alert-info">
-    There is no metadata for this dataset.
+    There is no metadata for this experiment.
   </div>
 {% endfor %}

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/parameter_table.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/parameter_table.html
@@ -1,26 +1,55 @@
 <table class="parameter_table table table-striped table-bordered {{ parameterset.schema.name|slugify }}">
-  <tr>
-    <th class="schema_name" title="{{ parameterset.schema.namespace }}{% if parameterset.schema.immutable %} (immutable){% endif %}" colspan="2">
-    {% if parameterset.schema.name %}
-      {{ parameterset.schema.name }}
-    {% endif %}
-    {% if edit_control %}
-        {{ edit_control }}
-    {% endif %}
-    </th>
-  </tr>
-  {% for parameter in parameters %}
-  <tr>
-      <td class="parameter_name">{{ parameter.name.full_name }}</td>
-      <td class="parameter_value">
-          {% if parameter.name.isLongString %}
-            {{ parameter.get|linebreaks }}
-	  {% elif parameter.name.isLink %}
-	    <a href="{{ parameter.link_url }}">{{parameter.link_gfk}}</a>
-          {% else %}
-            {{ parameter.get }}
-          {% endif %}
-      </td>
-  </tr>
-  {% endfor %}
+    <tr>
+        <th class="schema_name"
+            title="{{ parameterset.schema.namespace }}{% if parameterset.schema.immutable %} (immutable){% endif %}"
+            colspan="2">
+            {% if parameterset.schema.name %}
+                {{ parameterset.schema.name }}
+            {% endif %}
+            {% if edit_control %}
+                {{ edit_control }}
+            {% endif %}
+        </th>
+    </tr>
+    {% for parameter in parameters %}
+        {% if parameter.name.is_json %}
+            {% if parameter.name.units == 'fcs-table' %}
+                {% with table=parameter.get %}
+                    <table>
+                        <thead>
+                        <tr>
+                            {% for head in table.thead %}
+                                <th>{{ head.values.0 }}</th>
+                            {% endfor %}
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for row in table.tbody %}
+                            <tr>
+                                {% for col in table.thead %}
+                                    {% with key=col.keys.0 %}
+                                        <td>{{ row.key }}</td>
+                                    {% endwith %}
+                                {% endfor %}
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                {% endwith %}
+            {% endif %}
+        {% else %}
+            <tr>
+                <td class="parameter_name">{{ parameter.name.full_name }}</td>
+                <td class="parameter_value">
+                    {% if parameter.name.isLongString %}
+                        {{ parameter.get|linebreaks }}
+                    {% elif parameter.name.isLink %}
+                        <a href="{{ parameter.link_url }}">{{ parameter.link_gfk }}</a>
+                    {% else %}
+                        {{ parameter.get }}
+                    {% endif %}
+                </td>
+            </tr>
+        {% endif %}
+    {% endfor %}
 </table>

--- a/tardis/tardis_portal/templates/tardis_portal/index.html
+++ b/tardis/tardis_portal/templates/tardis_portal/index.html
@@ -22,7 +22,7 @@
     {% endif %}
   </p>
   <div class="row-fluid">
-    <div class="span6">
+    <div class="span9">
       {% if is_authenticated %}
 	<h3>Your most recent experiments <small><strong>(<a href="{% url 'tardis.tardis_portal.views.my_data' %}">view all</a>)</strong></small></h3>
 	<div id="experiments" class="accordion">

--- a/tardis/tardis_portal/templates/tardis_portal/javascript_libraries.html
+++ b/tardis/tardis_portal/templates/tardis_portal/javascript_libraries.html
@@ -68,4 +68,7 @@ The Font Awesome webfont, CSS, and LESS files are licensed under CC BY 3.0.
 
 {% block site_css %}
 <link type="text/css" href="{% static 'css/default.css' %}" rel="stylesheet" />
+    <style type="text/css">
+        {{ site_styles|safe }}
+    </style>
 {% endblock %}

--- a/tardis/tardis_portal/templates/tardis_portal/my_data.html
+++ b/tardis/tardis_portal/templates/tardis_portal/my_data.html
@@ -8,7 +8,7 @@
 
 <div id="content">
   <div class="row-fluid">
-    <div class="span7">
+    <div class="span9">
       <h2 class="visible-phone">Experiments</h2>
       <div class="pull-right">
         {% if perms.tardis_portal.add_experiment %}
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class="row-fluid">
-    <div class="span7">
+    <div class="span9">
       {% if not shared_experiments and not owned_experiments %}
       <p class="alert alert-info">
 	You do not have access to any private experiments.

--- a/tardis/tardis_portal/templates/tardis_portal/portal_template.html
+++ b/tardis/tardis_portal/templates/tardis_portal/portal_template.html
@@ -241,9 +241,9 @@
 	    }
 	};
       </script>
-      
+
       <div id="message-container"></div>
-      
+
       {% if messages %}
 	  <div id="django-message-container" >
         {% for message in messages %}
@@ -253,8 +253,8 @@
         </p>
         {% endfor %}
       </div>
-      {% endif %}      
-      
+      {% endif %}
+
       <div id="status-alert"
            class="alert alert-block {% if error %}alert-error{% endif %}"
            style="display: none">
@@ -305,7 +305,7 @@
       </div>
 
       {% block footer %}
-      <div class="row-fluid">
+      <div class="row-fluid" id="footer">
 	<div class="span6">
 	  {{sponsored_by|default:""|safe}}
 	</div>
@@ -319,10 +319,24 @@
 
     </div>
     <!-- /container -->
-
-    <!-- javascript
-    ================================================== -->
-    <!-- Placed at the end of the document so the pages load faster -->
-    <script src="{% static 'bootstrap/js/bootstrap.min.js' %}"></script>
+    <script type="text/javascript"
+	    src="{% static 'bootstrap/js/bootstrap.min.js' %}"></script>
+    {% if ga_enabled %}
+    <script type="text/javascript">
+      (function(i,s,o,g,r,a,m) {
+	  i['GoogleAnalyticsObject']=r;
+	  i[r]=i[r]||function(){
+	      (i[r].q=i[r].q||[]).push(arguments)},
+	  i[r].l=1*new Date();
+	  a=s.createElement(o), m=s.getElementsByTagName(o)[0];
+	  a.async=1;
+	  a.src=g;
+	  m.parentNode.insertBefore(a,m)
+      })(window,document,'script',
+	 '//www.google-analytics.com/analytics.js','ga');
+      ga('create', '{{ ga_id }}', '{{ ga_host }}'); {# from context proc #}
+      ga('send', 'pageview');
+    </script>
+    {% endif %}
   </body>
 </html>

--- a/tardis/tardis_portal/templates/tardis_portal/public_data.html
+++ b/tardis/tardis_portal/templates/tardis_portal/public_data.html
@@ -126,6 +126,8 @@
       </div>
       <br/>
     {% endif %}
+    </div>
+  </div>
 
 </div>
 <script type="text/javascript">

--- a/tardis/tardis_portal/templates/tardis_portal/public_data.html
+++ b/tardis/tardis_portal/templates/tardis_portal/public_data.html
@@ -8,7 +8,7 @@
 
 <div id="content">
   <div class="row-fluid">
-    <div class="span7">
+    <div class="span9">
       <h2 class="visible-phone">Experiments</h2>
       <div class="pull-right">
         <a class="btn btn-primary"
@@ -23,7 +23,7 @@
     </div>
   </div>
   <div class="row-fluid">
-    <div class="span7">
+    <div class="span9">
       {% if not public_experiments %}
       <p class="alert alert-info">
 	No experiments have been published yet.

--- a/tardis/tardis_portal/templates/tardis_portal/user_guide.html
+++ b/tardis/tardis_portal/templates/tardis_portal/user_guide.html
@@ -12,6 +12,6 @@ html, body, .container-fluid, .container-fluid .row-fluid,
 {% block content %}
 <div style="margin:-20px;padding:0px;overflow:hidden;height:100%">
 <iframe style="border:none;height:100%;width:100%;margin:0;padding:0"
-	src="{% static 'user_guide/index.html' %}" />
+	src="{% static user_guide_location %}" />
 </div>
 {% endblock content %}

--- a/tardis/tardis_portal/templatetags/dataset_tags.py
+++ b/tardis/tardis_portal/templatetags/dataset_tags.py
@@ -15,7 +15,7 @@ register = template.Library()
 @register.filter
 def dataset_tiles(experiment, include_thumbnails):
     # only show 8 datasets for initial load
-    datasets = experiment.datasets.all()[:8]
+    datasets = experiment.datasets.all().order_by('description')[:8]
 
     # Get data to template (used by JSON service too)
     # ?? doesn't seem to be used by JSON service at all

--- a/tardis/tardis_portal/views.py
+++ b/tardis/tardis_portal/views.py
@@ -352,7 +352,10 @@ def about(request):
          'about_pressed': True,
          'nav': [{'name': 'About', 'link': '/about/'}],
          'version': settings.MYTARDIS_VERSION,
-    }
+         'custom_about_section': getattr(
+             settings, 'CUSTOM_ABOUT_SECTION_TEMPLATE',
+             'tardis_portal/about_include.html'),
+         }
     return HttpResponse(render_response_index(request,
                         'tardis_portal/about.html', c))
 
@@ -957,7 +960,7 @@ def experiment_datasets_json(request, experiment_id):
     objects = [
         get_dataset_info(ds, include_thumbnail=has_download_permissions,
                          exclude=['datafiles'])
-        for ds in experiment.datasets.all()]
+        for ds in experiment.datasets.all().order_by('description')]
 
     return HttpResponse(json.dumps(objects), content_type='application/json')
 
@@ -3329,7 +3332,10 @@ def stage_files_to_dataset(request, dataset_id):
 
 
 def user_guide(request):
-    c = {}
+    c = {
+        'user_guide_location': getattr(
+            settings, 'CUSTOM_USER_GUIDE', 'user_guide/index.html'),
+    }
     return HttpResponse(render_response_index(request,
                         'tardis_portal/user_guide.html', c))
 


### PR DESCRIPTION
These changes enable a few things to be overridden by settings, sometimes in combination with a specific app that provides the relevant static files or templates.
Also, gitignore-ing all but the included apps allows any of your apps to live untouched in their own git repos. Don't worry about submodules, just script your deployment to place additional apps there.
