### PR TITLE
row.key for a variable key isn't supported in Django:

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/ajax/parameter_table.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/parameter_table.html
@@ -1,3 +1,4 @@
+{% load lookupfilters %}
 <table class="parameter_table table table-striped table-bordered {{ parameterset.schema.name|slugify }}">
     <tr>
         <th class="schema_name"
@@ -13,6 +14,9 @@
     </tr>
     {% for parameter in parameters %}
         {% if parameter.name.is_json %}
+            <tr>
+                <td class="parameter_name">{{ parameter.name.full_name }}</td>
+                <td class="parameter_value">
             {% if parameter.name.units == 'fcs-table' %}
                 {% with table=parameter.get %}
                     <table>
@@ -27,9 +31,7 @@
                         {% for row in table.tbody %}
                             <tr>
                                 {% for col in table.thead %}
-                                    {% with key=col.keys.0 %}
-                                        <td>{{ row.key }}</td>
-                                    {% endwith %}
+                                    <td>{{ row|get_item:col.keys.0 }}</td>
                                 {% endfor %}
                             </tr>
                         {% endfor %}
@@ -37,6 +39,8 @@
                     </table>
                 {% endwith %}
             {% endif %}
+                </td>
+            </tr>
         {% else %}
             <tr>
                 <td class="parameter_name">{{ parameter.name.full_name }}</td>

--- a/tardis/tardis_portal/templatetags/lookupfilters.py
+++ b/tardis/tardis_portal/templatetags/lookupfilters.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from django.template import Library
+from django import template
+
+
+def get_item(dictionary, key):
+    """Returns a value from a dictionary."""
+    return dictionary.get(key)
+
+
+register = template.Library()
+register.filter('get_item', get_item)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/3371

Without this fix, I don't see any data within my table body, i.e. row.key seems to look up a key named "key" instead of the actual column key (e.g. "col1").

Also, I've added the surrounding "tr" and "td" tags, so that the tabular parameter value appears within the overall datafile parameter table (and inherits its CSS), instead of appearing as a separate table. 