### PR TITLE
Allow unverified file download

### DIFF
--- a/tardis/tardis_portal/download.py
+++ b/tardis/tardis_portal/download.py
@@ -80,7 +80,13 @@ def _create_download_response(request, datafile_id, disposition='attachment'):  
         file_obj = datafile.get_file(verified_only=verified_only)
         if not file_obj:
             # If file path doesn't resolve, return not found
-            return return_response_not_found(request)
+            if verified_only:
+                return render_error_message(request,
+                                            "File is unverified, "
+                                            "please try again later.",
+                                            status=503)
+            else:
+                return return_response_not_found(request)
         wrapper = FileWrapper(file_obj, blksize=65535)
         response = StreamingHttpResponse(wrapper,
                                          content_type=datafile.get_mimetype())

--- a/tardis/tardis_portal/download.py
+++ b/tardis/tardis_portal/download.py
@@ -68,8 +68,10 @@ def _create_download_response(request, datafile_id, disposition='attachment'):  
         return download_image(*args, format='png')
     # Send local file
     try:
+        # Query parameter to allow download of unverified files
+        verified_only = not request.GET.get('ignore_verification_status', False)
         # Get file object for datafile
-        file_obj = datafile.get_file()
+        file_obj = datafile.get_file(verified_only=verified_only)
         if not file_obj:
             # If file path doesn't resolve, return not found
             return return_response_not_found(request)

--- a/tardis/tardis_portal/download.py
+++ b/tardis/tardis_portal/download.py
@@ -68,8 +68,14 @@ def _create_download_response(request, datafile_id, disposition='attachment'):  
         return download_image(*args, format='png')
     # Send local file
     try:
+        verified_only = True
         # Query parameter to allow download of unverified files
-        verified_only = not request.GET.get('ignore_verification_status', False)
+        ignore_verif = request.GET.get('ignore_verification_status', '0')
+        # Ensure ignore_verification_status=0 etc works as expected
+        # a bare ?ignore_verification_status is True
+        if ignore_verif.lower() in [u'', u'1', u'true']:
+            verified_only = False
+
         # Get file object for datafile
         file_obj = datafile.get_file(verified_only=verified_only)
         if not file_obj:

--- a/tardis/tardis_portal/shortcuts.py
+++ b/tardis/tardis_portal/shortcuts.py
@@ -39,10 +39,13 @@ def render_response_search(request, url, c):
 
 
 def render_error_message(request, message, status=400):
-    """Render a simple text error message in a generic error page.  Any newlines are turned into <br>."""
+    """
+    Render a simple text error message in a generic error page.
+    Any newlines are turned into <br>.
+    """
     formatted = cgi.escape(message).replace('\n', '<br/>')
     return render(request, 'tardis_portal/user_error.html',
-                  {'error_message' : formatted}, status=status)
+                  {'error_message': formatted}, status=status)
 
 
 def return_response_not_found(request):

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/datafile_list.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/datafile_list.html
@@ -70,7 +70,7 @@ Select: <a class="dataset_selector_all btn btn-mini">All</a> / <a class="dataset
 {% for datafile in datafiles.object_list %}
 <tr class="datafile search_match_file">
   <td>
-    {% if has_download_permissions %}
+    {% if has_download_permissions and datafile.verified %}
     <input type="checkbox" style="" class="datafile_checkbox" name="datafile" value="{{datafile.id}}" />
     {% endif %}
   </td>
@@ -125,7 +125,7 @@ Select: <a class="dataset_selector_all btn btn-mini">All</a> / <a class="dataset
   </td>
   <td style="width: 110px">
     <div class="btn-group pull-right">
-      {% if has_download_permissions %}
+      {% if has_download_permissions and datafile.verified %}
       <a  class="btn"
           href="{{ datafile.get_download_url }}"
           title="Download">


### PR DESCRIPTION
This patch allows unverified files to be downloaded when the query parameter ?ignore_verification_status is supplied. Some logic was moved from DataFile.file_object to DataFile.get_file (since it's better not to add named parameters to a Python @property). 

The method DataFile.get_file_getter was removed since it is unused in code MyTardis and default apps.