### PR TITLE
Better formatting of LINK parameters and numbers in parameter table.

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/ajax/parameter_table.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/parameter_table.html
@@ -43,8 +43,16 @@
                 <td class="parameter_value">
                     {% if parameter.name.isLongString %}
                         {{ parameter.get|linebreaks }}
+                    {% elif parameter.name.isNumeric %}
+                        {{ parameter.get|floatformat:"-3" }}
                     {% elif parameter.name.isLink %}
-                        <a href="{{ parameter.link_url }}">{{ parameter.link_gfk }}</a>
+                        <a href="{{ parameter.link_url }}">
+                            {% if parameter.link_gfk %}
+                                {{ parameter.link_gfk }}
+                            {% else %}
+                                {{ parameter.link_url }}
+                            {% endif %}
+                        </a>
                     {% else %}
                         {{ parameter.get }}
                     {% endif %}

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/parameter_table.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/parameter_table.html
@@ -45,11 +45,11 @@
                         {{ parameter.get|linebreaks }}
                     {% elif parameter.name.isNumeric %}
                         {{ parameter.get|floatformat:"-3" }}
-                    {% elif parameter.name.isLink %}
+                    {% elif parameter.name.isLink and parameter.link_url %}
                         <a href="{{ parameter.link_url }}">
                             {% if parameter.link_gfk %}
                                 {{ parameter.link_gfk }}
-                            {% elif parameter.link_url %}
+                            {% else parameter.link_url %}
                                 {{ parameter.link_url }}
                             {% endif %}
                         </a>

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/parameter_table.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/parameter_table.html
@@ -49,7 +49,7 @@
                         <a href="{{ parameter.link_url }}">
                             {% if parameter.link_gfk %}
                                 {{ parameter.link_gfk }}
-                            {% else %}
+                            {% elif parameter.link_url %}
                                 {{ parameter.link_url }}
                             {% endif %}
                         </a>


### PR DESCRIPTION
Better fallback formatting of LINK parameters when gfk isn't assigned.

Show floats to 3 decimal places, integers without decimal places. This is primarily to get integers to render without a single decimal place (eg 42 instead of 42.0), but may cause issues for some apps that relied on a default where many decimal places were shown. This could be solved by adding a "precision" attribute to the ParameterName model that specifies the number of decimal places that is sensible for a measurement.