### PR TITLE
Sftpd logging

### DIFF
--- a/tardis/tardis_portal/sftp.py
+++ b/tardis/tardis_portal/sftp.py
@@ -448,7 +448,7 @@ class MyTSFTPRequestHandler(SocketServer.BaseRequestHandler):
         # We may never begin a session if the client rejects the server's
         # RSA host key, or if the client is only attempting to monitor
         # whether the server is actively listening on the appropriate port.
-        logger.info(self.client_address[0])
+        logger.info('Connection requested from %s' % self.client_address[0])
 
         self.transport = Transport(self.request)
         self.transport.load_server_moduli()


### PR DESCRIPTION
I'm interesting in knowing what IP addresses are probing port 2200 on my MyTardis server, so I've added some more logging to sftp.py.

Here's an example (where I've replaced my IP address with 1.2.3.4, and I've replaced Nagios's IP address with 5.6.7.8):

```
2015-08-21 10:22:31,480 - INFO - Connection requested from 1.2.3.4
2015-08-21 10:22:31,528 - INFO - Connected (version 2.0, client OpenSSH_6.2)
2015-08-21 10:22:31,972 - INFO - Auth rejected (none).
2015-08-21 10:22:51,373 - WARNING - Failed authentication for wettenhj from 1.2.3.4
2015-08-21 10:22:51,374 - INFO - Auth rejected (keyboard-interactive).
2015-08-21 10:22:57,466 - INFO - Successful authentication for wettenhj from 1.2.3.4
2015-08-21 10:22:57,466 - INFO - Auth granted (keyboard-interactive).
2015-08-21 10:25:25,209 - INFO - Connection requested from 5.6.7.8
2015-08-21 10:25:25,270 - INFO - Connected (version 2.0, client check_ssh_1.5)
```
