### PR TITLE
Rerun the ldap search after binding with the DN (distinguished name).

### DIFF
--- a/tardis/tardis_portal/auth/ldap_auth.py
+++ b/tardis/tardis_portal/auth/ldap_auth.py
@@ -140,6 +140,8 @@ class LDAPBackend(AuthProvider, UserProvider, GroupProvider):
 
             bind_dn = ldap_result[0][0]
             l.simple_bind_s(bind_dn, password)
+            ldap_result = l.search_s(self._user_base, ldap.SCOPE_SUBTREE,
+                                      userRDN, retrieveAttributes)
 
             if ldap_result[0][1]['uid'][0] == username:
                 # check if the given username in combination with the LDAP


### PR DESCRIPTION
The first ldap_search retrieves the DN (from the uid), and the
second search retrieves the attributes needed (mail, givenName).
The givenName attribute sometimes isn't accessible until after
binding with the DN.

See also: Store.Star.Help tickets 6526 and 6528.

and: Django admin email alerts with subject: "[Django] ERROR (EXTERNAL IP): Internal Server Error: /accounts/login/".
