### PR TITLE
Legacy UserProvider auth code populates 'display' key in user dictionary, which

### DIFF
--- a/docs/ref/auth_ldap.rst
+++ b/docs/ref/auth_ldap.rst
@@ -41,8 +41,9 @@ initialising the LDAP backend.
 .. attribute:: tardis.settings_changeme.LDAP_USER_ATTR_MAP
 
     The LDAP user attribute map is used to map internal identifiers
-    like *display* and *email* to their LDAP equivalents e.g.
-    *{"givenName": "display", "mail": "email"}*
+    like *first_name*, *last_name* and *email* to their LDAP equivalents e.g.
+    *{"givenName": "first_name", "sn": "last_name", "mail": "email"}*
+
 
 .. attribute:: tardis.settings_changeme.LDAP_GROUP_ID_ATTR
 

--- a/tardis/tardis_portal/auth/authservice.py
+++ b/tardis/tardis_portal/auth/authservice.py
@@ -165,7 +165,7 @@ class AuthService():
             authMethods = [authMethod]
         for authMethod in authMethods:
             # authenticate() returns either a User or a dictionary describing a
-            # user (id, display, email, first_name, last_name).
+            # user (id, email, first_name, last_name).
             authenticate_retval = self._authentication_backends[
                 authMethod].authenticate(**credentials)
             user = self.get_or_create_user(authenticate_retval,
@@ -189,7 +189,7 @@ class AuthService():
         if authMethod in self._authentication_backends:
             try:
                 # get_user returns either a User or a dictionary describing a
-                # user (id, display, email, first_name, last_name).
+                # user (id, email, first_name, last_name).
                 user = self._authentication_backends[authMethod].get_user(user_id)
             except (NotImplementedError, AttributeError):
                 # For backwards compatibility

--- a/tardis/tardis_portal/auth/interfaces.py
+++ b/tardis/tardis_portal/auth/interfaces.py
@@ -63,7 +63,8 @@ class UserProvider:
         return the user dictionary in the format of::
 
             {"id": 123,
-            "display": "John Smith",
+            "first_name": "John",
+            "last_name": "Smith",
             "email": "john@example.com"}
 
         """
@@ -76,7 +77,8 @@ class UserProvider:
         each user is in the format of::
 
             {"id": 123,
-            "display": "John Smith",
+            "first_name": "John",
+            "last_name": "Smith",
             "email": "john@example.com"}
 
         """

--- a/tardis/tardis_portal/auth/ldap_auth.py
+++ b/tardis/tardis_portal/auth/ldap_auth.py
@@ -147,7 +147,8 @@ class LDAPBackend(AuthProvider, UserProvider, GroupProvider):
                 # check if the given username in combination with the LDAP
                 # auth method is already in the UserAuthentication table
                 user = ldap_result[0][1]
-                return {'display': user['givenName'][0],
+                return {'first_name': user['givenName'][0],
+                        'last_name': user['sn'][0],
                         "id": user['uid'][0],
                         "email": user['mail'][0]}
             return None
@@ -173,7 +174,8 @@ class LDAPBackend(AuthProvider, UserProvider, GroupProvider):
         return the user dictionary in the format of::
 
             {"id": 123,
-            "display": "John Smith",
+            "first_name": "John",
+            "last_name": "Smith",
             "email": "john@example.com"}
 
         """

--- a/tardis/tardis_portal/auth/localdb_auth.py
+++ b/tardis/tardis_portal/auth/localdb_auth.py
@@ -90,15 +90,17 @@ class DjangoUserProvider(UserProvider):
         return the user dictionary in the format of::
 
             {"id": 123,
-            "display": "John Smith",
+            "first_name": "John",
+            "last_name": "Smith",
             "email": "john@example.com"}
 
         """
         try:
             userObj = User.objects.get(username=id)
-            return {'id': id, 'display': userObj.first_name + ' ' +
-                    userObj.last_name, 'first_name': userObj.first_name,
-                    'last_name': userObj.last_name, 'email': userObj.email}
+            return {'id': id,
+                    'first_name': userObj.first_name,
+                    'last_name': userObj.last_name,
+                    'email': userObj.email}
         except User.DoesNotExist:
             return None
 

--- a/tardis/tardis_portal/tests/test_ldap.py
+++ b/tardis/tardis_portal/tests/test_ldap.py
@@ -34,7 +34,8 @@ class LDAPTest(TestCase):
         import tardis.tardis_portal.tests.slapd as slapd
         global server
         if not slapd.Slapd.check_paths():
-            raise SkipTest()
+            raise SkipTest('slapd.Slapd.check_paths() failed, '
+                           'so skipping LDAPTest')
 
         server = slapd.Slapd()
         server.set_port(38911)
@@ -54,14 +55,14 @@ class LDAPTest(TestCase):
         from tardis.tardis_portal.auth.ldap_auth import ldap_auth
 
         l = ldap_auth()
-        res = l._query(settings.LDAP_USER_BASE, '(objectClass=*)', ['cn'])
+        res = l._query(settings.LDAP_USER_BASE, '(objectClass=*)', ['givenName', 'sn'])
         res1 = [('ou=People,dc=example,dc=com', {}),
                 ('uid=testuser1,ou=People,dc=example,dc=com',
-                 {'cn': ['Test User']}),
+                 {'givenName': 'Test', 'sn': 'User'}),
                 ('uid=testuser2,ou=People,dc=example,dc=com',
-                 {'cn': ['Test User2']}),
+                 {'givenName': 'Test', 'sn': 'User2'}),
                 ('uid=testuser3,ou=People,dc=example,dc=com',
-                 {'cn': ['Test User3']})]
+                 {'givenName': 'Test', 'sn': 'User3'})]
         self.assertEqual(res, res1)
 
         res = l._query(settings.LDAP_GROUP_BASE, '(objectClass=*)', ['cn'])
@@ -80,7 +81,8 @@ class LDAPTest(TestCase):
         user = l.getUserById('testuser1')
         user1 = {'id': 'testuser1',
                  'email': 't.user@example.com',
-                 'display': 'Test'}
+                 'first_name': 'Test',
+                 'last_name': 'User'}
         self.assertEqual(user, user1)
 
         user = l.getUserById('nulluser')
@@ -99,7 +101,9 @@ class LDAPTest(TestCase):
                      'authMethod': 'ldap'}
         u = l.authenticate(req)
         u1 = {'email': 't.user@example.com',
-              'display': 'Test', 'id': 'testuser1'}
+              'first_name': 'Test',
+              'last_name': 'User',
+              'id': 'testuser1'}
         self.failUnlessEqual(u, u1)
 
         # Test authservice API

--- a/tardis/test_settings.py
+++ b/tardis/test_settings.py
@@ -86,7 +86,7 @@ LDAP_USE_TLS = False
 LDAP_URL = "ldap://localhost:38911/"
 
 LDAP_USER_LOGIN_ATTR = "uid"
-LDAP_USER_ATTR_MAP = {"givenName": "display", "mail": "email"}
+LDAP_USER_ATTR_MAP = {"givenName": "first_name", "sn": "last_name", "mail": "email"}
 LDAP_GROUP_ID_ATTR = "cn"
 LDAP_GROUP_ATTR_MAP = {"description": "display"}
 


### PR DESCRIPTION
is the user's full name (e.g. 'cn' in LDAP), but what we really need is 'first_name' and 'last_name' which can be found in LDAP as 'givenName' and 'sn' respectively.

The main driver for this change is that LDAP users are getting imported into MyTardis with a blank first name and a blank last name, and this causes problems with default experiment titles in MyData e.g. instead of a default experiment title of "Microscope1 - John Smith", the experiment title generated by MyData could be given a title of "Microscope1 - ".  The minimum code change to achieve this is the change to ldap_auth.py below, but it also requires changing the LDAP_USER_ATTR_MAP setting in your settings.py, as demonstrated in test_settings.py below.
