### PR TITLE
Make Parameter.set_value handle LINK data_types

### DIFF
--- a/tardis/urls.py
+++ b/tardis/urls.py
@@ -60,9 +60,12 @@ experiment_lists = patterns(
         name="tardis_portal.experiment_list_shared"),
     )
 
+experiment_view_url = url(r'^experiment/view/(?P<experiment_id>\d+)/?$',
+                          'tardis.tardis_portal.views.view_experiment')
+
 experiment_urls = patterns(
     'tardis.tardis_portal.views',
-    (r'^view/(?P<experiment_id>\d+)/$', 'view_experiment'),
+    # (r'^view/(?P<experiment_id>\d+)/$', 'view_experiment'),
     (r'^edit/(?P<experiment_id>\d+)/$', 'edit_experiment'),
     (r'^list', include(experiment_lists)),
     (r'^view/$', 'experiment_index'),  # Legacy URL
@@ -121,10 +124,13 @@ accounts_urls = patterns(
     (r'', include('registration.backends.default.urls')),
     )
 
+dataset_view_url = url(r'^dataset/(?P<dataset_id>\d+)/?$',
+                       'tardis.tardis_portal.views.view_dataset')
+
 dataset_urls = patterns(
     'tardis.tardis_portal.views',
     (r'^(?P<dataset_id>\d+)/stage-files$', 'stage_files_to_dataset'),
-    (r'^(?P<dataset_id>\d+)$', 'view_dataset'),
+    # (r'^(?P<dataset_id>\d+)$', 'view_dataset'),
     (r'^(?P<dataset_id>\d+)/edit$', 'edit_dataset'),
     (r'^(?P<dataset_id>\d+)/thumbnail$', 'dataset_thumbnail'),
 )
@@ -346,9 +352,11 @@ urlpatterns = patterns(
 
     # Experiment Views
     (r'^experiment/', include(experiment_urls)),
+    experiment_view_url,
 
     # Dataset Views
     (r'^dataset/', include(dataset_urls)),
+    dataset_view_url,
 
     # Datafile Views
     (r'^datafile/', include(datafile_urls)),


### PR DESCRIPTION
Currently Parameter.set_value doesn't explicitly handle LINK data_types, which means the REST API can't be used to properly fill all required fields for this Parameter type.

This patch makes Parameter.set_value for LINKs correctly assign the link_ct / link_id (from which link.gfk GenericForeignKey is derived) for standard experiment and dataset link urls (like those returned by Experiment.get_absolute_url() and Dataset.get_absolute_url() ). The string_value is used as a fallback.

I'm not entirely satisfied with the method of matching urls in the Parameter value, but I haven't found a good way to map get_absolute_url()'s back to their associated model, and the current method will cover the two most likely use cases (which I'm currently using in a MyTardis app).

I've also made Parameter.link_url aware of DATAFILE_VIEWS, DATASET_VIEWS and EXPERIMENT_VIEWS view override methods defined in settings.