### PR TITLE
Another round of publication form updates

### DIFF
--- a/tardis/apps/publication_forms/default_settings.py
+++ b/tardis/apps/publication_forms/default_settings.py
@@ -75,57 +75,57 @@ PUBLICATION_EMAIL_MESSAGES = {
     'requires_authorisation': ('[TARDIS] Publication requires authorisation',
                                '''\
 Hello!
-A publication has been submitted by ${user_name} and requires approval by a publication \
+A publication has been submitted by {user_name} and requires approval by a publication \
 administrator.
-You may view the publication here: ${pub_url}
+You may view the publication here: {pub_url}
 
 This publication will not be publicly accessible until all embargo conditions \
 are met following approval.
 To approve this publication, please access the publication approvals \
-interface here: ${approvals_url}
+interface here: {approvals_url}
 '''),
     'awaiting_approval': ('[TARDIS] Publication submitted',
                           '''\
 Hello!
-Your publication, ${pub_title}, has been submitted and is awaiting approval by an \
+Your publication, {pub_title}, has been submitted and is awaiting approval by an \
 administrator.
 You will receive a notification once his has occurred.
 '''),
     'approved': ('[TARDIS] Publication approved',
                  '''\
 Hello!
-Your publication, ${pub_title}, has been approved for release and will appear online \
-following any embargo conditions. You may view your publication here: ${pub_url}
+Your publication, {pub_title}, has been approved for release and will appear online \
+following any embargo conditions. You may view your publication here: {pub_url}
 '''),
     'approved_with_doi': ('[TARDIS] Publication approved',
                           '''\
 Hello!
-Your publication, ${pub_title}, has been approved for release and will appear online \
-following any embargo conditions. You may view your publication here: ${pub_url}
-A DOI has been assigned to this publication (${doi}) \
+Your publication, {pub_title}, has been approved for release and will appear online \
+following any embargo conditions. You may view your publication here: {pub_url}
+A DOI has been assigned to this publication ({doi}) \
 and will become active once your publication is released.
 You may use cite using this DOI immediately.
 '''),
     'rejected': ('[TARDIS] Publication rejected',
                  '''\
 Hello!
-Your publication, ${pub_title}, is unable to be released. Please contact your system \
+Your publication, {pub_title}, is unable to be released. Please contact your system \
 administrator for further information.
 '''),
     'reverted_to_draft': ('[TARDIS] Publication reverted to draft',
                           '''\
 Hello!
-Your publication, ${pub_title}, has been reverted to draft and may now be amended.
+Your publication, {pub_title}, has been reverted to draft and may now be amended.
 '''),
     'released': ('[TARDIS] Publication released',
                  '''\
 Hello,
-Your publication, ${pub_title}, is now public!
+Your publication, {pub_title}, is now public!
 '''),
     'released_with_doi': ('[TARDIS] Publication released',
                           '''\
 Hello,
-Your publication, ${pub_title}, is now public!
-You may view your publication here: http://dx.doi.org/${doi}
+Your publication, {pub_title}, is now public!
+You may view your publication here: http://dx.doi.org/{doi}
 ''')
 }

--- a/tardis/apps/publication_forms/default_settings.py
+++ b/tardis/apps/publication_forms/default_settings.py
@@ -22,10 +22,10 @@ PUBLICATION_DRAFT_SCHEMA = PUBLICATION_SCHEMA_ROOT + 'draft/'
 # publication_schema: the namspace of the schema that should be added to the
 # publication
 # form_template: a URL to the form template (usually static HTML)
-PUBLICATION_FORM_MAPPINGS = [
-    {'dataset_schema': 'http://example.com/a_dataset_schema',
-     'publication_schema': 'http://example.com/a_publication_schema',
-     'form_template': '/static/publication-form/form-template.html'}]
+# PUBLICATION_FORM_MAPPINGS = [
+#    {'dataset_schema': 'http://example.com/a_dataset_schema',
+#     'publication_schema': 'http://example.com/a_publication_schema',
+#     'form_template': '/static/publication-form/form-template.html'}]
 # Note: dataset_schema is treated as a regular expression
 
 # The PDB publication schema is used for any experiments that reference a
@@ -68,3 +68,64 @@ MODC_DOI_MINT_URL_ROOT = 'http://mytardisserver/'
 # Change this to the user name of the data administrator if it should be someone other than the
 # publication creator
 PUBLICATION_DATA_ADMIN = None
+
+# A dictionary of length=2 tuples, where the first entry is the email
+# subject line, and the second is the message text
+PUBLICATION_EMAIL_MESSAGES = {
+    'requires_authorisation': ('[TARDIS] Publication requires authorisation',
+                               '''\
+Hello!
+A publication has been submitted by ${user_name} and requires approval by a publication \
+administrator.
+You may view the publication here: ${pub_url}
+
+This publication will not be publicly accessible until all embargo conditions \
+are met following approval.
+To approve this publication, please access the publication approvals \
+interface here: ${approvals_url}
+'''),
+    'awaiting_approval': ('[TARDIS] Publication submitted',
+                          '''\
+Hello!
+Your publication, ${pub_title}, has been submitted and is awaiting approval by an \
+administrator.
+You will receive a notification once his has occurred.
+'''),
+    'approved': ('[TARDIS] Publication approved',
+                 '''\
+Hello!
+Your publication, ${pub_title}, has been approved for release and will appear online \
+following any embargo conditions. You may view your publication here: ${pub_url}
+'''),
+    'approved_with_doi': ('[TARDIS] Publication approved',
+                          '''\
+Hello!
+Your publication, ${pub_title}, has been approved for release and will appear online \
+following any embargo conditions. You may view your publication here: ${pub_url}
+A DOI has been assigned to this publication (${doi}) \
+and will become active once your publication is released.
+You may use cite using this DOI immediately.
+'''),
+    'rejected': ('[TARDIS] Publication rejected',
+                 '''\
+Hello!
+Your publication, ${pub_title}, is unable to be released. Please contact your system \
+administrator for further information.
+'''),
+    'reverted_to_draft': ('[TARDIS] Publication reverted to draft',
+                          '''\
+Hello!
+Your publication, ${pub_title}, has been reverted to draft and may now be amended.
+'''),
+    'released': ('[TARDIS] Publication released',
+                 '''\
+Hello,
+Your publication, ${pub_title}, is now public!
+'''),
+    'released_with_doi': ('[TARDIS] Publication released',
+                          '''\
+Hello,
+Your publication, ${pub_title}, is now public!
+You may view your publication here: http://dx.doi.org/${doi}
+''')
+}

--- a/tardis/apps/publication_forms/email_text.py
+++ b/tardis/apps/publication_forms/email_text.py
@@ -1,5 +1,3 @@
-import string
-
 from django.conf import settings
 
 from . import default_settings
@@ -10,7 +8,7 @@ def interpolate_template(template_name, **kwargs):
         settings, 'PUBLICATION_EMAIL_MESSAGES',
                                          default_settings.PUBLICATION_EMAIL_MESSAGES)
     subject, template = publication_email_messages[template_name]
-    return subject, string.Template(template).substitute(**kwargs)
+    return subject, template.format(**kwargs)
 
 
 def email_pub_requires_authorisation(user_name, pub_url, approvals_url):

--- a/tardis/apps/publication_forms/email_text.py
+++ b/tardis/apps/publication_forms/email_text.py
@@ -6,15 +6,14 @@ from . import default_settings
 def interpolate_template(template_name, **kwargs):
     publication_email_messages = getattr(
         settings, 'PUBLICATION_EMAIL_MESSAGES',
-                                         default_settings.PUBLICATION_EMAIL_MESSAGES)
+        default_settings.PUBLICATION_EMAIL_MESSAGES)
     subject, template = publication_email_messages[template_name]
     return subject, template.format(**kwargs)
 
 
 def email_pub_requires_authorisation(user_name, pub_url, approvals_url):
-    return interpolate_template(
-        'requires_authorisation', user_name=user_name, pub_url=pub_url,
-                                approvals_url=approvals_url)
+    return interpolate_template('requires_authorisation', user_name=user_name,
+                                pub_url=pub_url, approvals_url=approvals_url)
 
 
 def email_pub_awaiting_approval(pub_title):
@@ -25,7 +24,7 @@ def email_pub_approved(pub_title, pub_url, doi=None, message=None):
     if doi:
         subject, email_message = interpolate_template(
             'approved_with_doi', pub_title=pub_title, pub_url=pub_url,
-                                                      doi=doi)
+            doi=doi)
     else:
         subject, email_message = interpolate_template(
             'approved', pub_title=pub_title, pub_url=pub_url)

--- a/tardis/apps/publication_forms/email_text.py
+++ b/tardis/apps/publication_forms/email_text.py
@@ -1,78 +1,73 @@
-def email_pub_requires_authorisation(user_name, pub_url, approvals_url):
-    return '''\
-Hello!
-A publication has been submitted by %s and requires approval by a publication \
-administrator.
-You may view the publication here: %s
+import string
 
-This publication will not be publicly accessible until all embargo conditions \
-are met following approval.
-To approve this publication, please access the publication approvals \
-interface here: %s
-''' % (user_name,
-       pub_url,
-       approvals_url)
+from django.conf import settings
+
+from . import default_settings
+
+
+def interpolate_template(template_name, **kwargs):
+    publication_email_messages = getattr(
+        settings, 'PUBLICATION_EMAIL_MESSAGES',
+                                         default_settings.PUBLICATION_EMAIL_MESSAGES)
+    subject, template = publication_email_messages[template_name]
+    return subject, string.Template(template).substitute(**kwargs)
+
+
+def email_pub_requires_authorisation(user_name, pub_url, approvals_url):
+    return interpolate_template(
+        'requires_authorisation', user_name=user_name, pub_url=pub_url,
+                                approvals_url=approvals_url)
 
 
 def email_pub_awaiting_approval(pub_title):
-    return '''\
-Hello!
-Your publication, %s, has been submitted and is awaiting approval by an \
-administrator.
-You will receive a notification once his has occurred.''' % pub_title
+    return interpolate_template('awaiting_approval', pub_title=pub_title)
 
 
-def email_pub_approved(pub_title, message=None, doi=None, url=None):
-    email_message = '''\
-Hello!
-Your publication, %s, has been approved for release and will appear online \
-following any embargo conditions. You may view your publication here: %s
-''' % (pub_title, url)
-
-    if doi is not None:
-        email_message += '''A DOI has been assigned to this publication (%s) \
-and will become active once your publication is released.
-You may use cite using this DOI immediately.''' % doi
+def email_pub_approved(pub_title, pub_url, doi=None, message=None):
+    if doi:
+        subject, email_message = interpolate_template(
+            'approved_with_doi', pub_title=pub_title, pub_url=pub_url,
+                                                      doi=doi)
+    else:
+        subject, email_message = interpolate_template(
+            'approved', pub_title=pub_title, pub_url=pub_url)
 
     if message:
-        email_message += ''' ---
+        email_message += '''
+---
 %s''' % message
 
-    return email_message
+    return subject, email_message
 
 
 def email_pub_rejected(pub_title, message=None):
-    email_message = '''\
-Hello!
-Your publication, %s, is unable to be released. Please contact your system \
-administrator for further information.
-''' % pub_title
+    subject, email_message = interpolate_template(
+        'rejected', pub_title=pub_title)
 
     if message:
         email_message += ''' ---
 %s''' % message
 
-    return email_message
+    return subject, email_message
 
 
 def email_pub_reverted_to_draft(pub_title, message=None):
-    email_message = '''\
-Hello!
-Your publication, %s, has been reverted to draft and may now be amended.
-''' % pub_title
+    subject, email_message = interpolate_template(
+        'reverted_to_draft', pub_title=pub_title)
 
     if message:
         email_message += ''' ---
 %s''' % message
 
-    return email_message
+    return subject, email_message
 
 
 def email_pub_released(pub_title, doi=None):
-    email_message = '''Hello,
-Your publication, %s, is now public!
-''' % pub_title
     if doi:
-        email_message += 'You may view your publication here: ' \
-                         'http://dx.doi.org/%s' % doi
-    return email_message
+        subject, message = interpolate_template(
+            'released_with_doi', pub_title=pub_title, doi=doi)
+    else:
+        subject, message = interpolate_template(
+            'released', pub_title=pub_title)
+
+    return subject, message

--- a/tardis/apps/publication_forms/tasks.py
+++ b/tardis/apps/publication_forms/tasks.py
@@ -118,10 +118,9 @@ def process_embargos():
                 except ExperimentParameter.DoesNotExist:
                     pass
 
-            email_message = email_pub_released(pub.title, doi_value)
+            subject, email_message = email_pub_released(pub.title, doi_value)
 
-            send_mail_to_authors(pub, '[TARDIS] Publication released',
-                                 email_message)
+            send_mail_to_authors(pub, subject, email_message)
             pub.save()
 
 

--- a/tardis/apps/publication_forms/tests/test_email_templates.py
+++ b/tardis/apps/publication_forms/tests/test_email_templates.py
@@ -1,0 +1,78 @@
+from django.test import TestCase
+
+from .. import email_text
+
+
+class EmailTemplates(TestCase):
+
+    def test_pub_approved_template(self):
+        subject, message = email_text.email_pub_approved(
+            '_pub_title_', '_pub_url_', '_doi_', '_message_')
+        self.assertTrue('_pub_title_' in message)
+        self.assertTrue('_pub_url_' in message)
+        self.assertTrue('_doi_' in message)
+        self.assertTrue('_message_' in message)
+
+        subject, message = email_text.email_pub_approved(
+            '_pub_title_', '_pub_url_', None, '_message_')
+        self.assertTrue('_pub_title_' in message)
+        self.assertTrue('_pub_url_' in message)
+        self.assertTrue('_doi_' not in message)
+        self.assertTrue('_message_' in message)
+
+        subject, message = email_text.email_pub_approved(
+            '_pub_title_', '_pub_url_', '_doi_')
+        self.assertTrue('_pub_title_' in message)
+        self.assertTrue('_pub_url_' in message)
+        self.assertTrue('_doi_' in message)
+        self.assertTrue('_message_' not in message)
+
+        subject, message = email_text.email_pub_approved(
+            '_pub_title_', '_pub_url_')
+        self.assertTrue('_pub_title_' in message)
+        self.assertTrue('_pub_url_' in message)
+        self.assertTrue('_doi_' not in message)
+        self.assertTrue('_message_' not in message)
+
+    def test_pub_awaiting_approval_template(self):
+        subject, message = email_text.email_pub_awaiting_approval(
+            '_pub_title_')
+        self.assertTrue('_pub_title_' in message)
+
+    def test_pub_rejected_template(self):
+        subject, message = email_text.email_pub_rejected(
+            '_pub_title_', '_message_')
+        self.assertTrue('_pub_title_' in message)
+        self.assertTrue('_message_' in message)
+
+        subject, message = email_text.email_pub_rejected('_pub_title_')
+        self.assertTrue('_pub_title_' in message)
+        self.assertTrue('_message_' not in message)
+
+    def test_pub_released_template(self):
+        subject, message = email_text.email_pub_released(
+            '_pub_title_', '_doi_')
+        self.assertTrue('_pub_title_' in message)
+        self.assertTrue('_doi_' in message)
+
+        subject, message = email_text.email_pub_released('_pub_title_')
+        self.assertTrue('_pub_title_' in message)
+        self.assertTrue('_doi_' not in message)
+
+    def test_pub_requires_authorisation_template(self):
+        subject, message = email_text.email_pub_requires_authorisation(
+            '_user_name_', '_pub_url_', '_approvals_url_')
+        self.assertTrue('_user_name_' in message)
+        self.assertTrue('_pub_url_' in message)
+        self.assertTrue('_approvals_url_' in message)
+
+    def test_pub_reverted_to_draft_template(self):
+        subject, message = email_text.email_pub_reverted_to_draft(
+            '_pub_title_', '_message_')
+        self.assertTrue('_pub_title_' in message)
+        self.assertTrue('_message_' in message)
+
+        subject, message = email_text.email_pub_reverted_to_draft(
+            '_pub_title_')
+        self.assertTrue('_pub_title_' in message)
+        self.assertTrue('_message_' not in message)

--- a/tardis/tardis_portal/views.py
+++ b/tardis/tardis_portal/views.py
@@ -222,6 +222,7 @@ def index(request):
             limit = 4
     public_experiments = Experiment.objects\
         .exclude(public_access=Experiment.PUBLIC_ACCESS_NONE)\
+        .exclude(public_access=Experiment.PUBLIC_ACCESS_EMBARGO)\
         .order_by('-update_time')[:limit]
     c['public_experiments'] = public_experiments
     c['RAPID_CONNECT_ENABLED'] = settings.RAPID_CONNECT_ENABLED
@@ -3078,8 +3079,9 @@ class ExperimentSearchView(SearchView):
                  authz.get_accessible_experiments(self.request)])
 
         access_list.extend(
-            [e.pk for e in Experiment.objects.exclude(
-                public_access=Experiment.PUBLIC_ACCESS_NONE)])
+            [e.pk for e in Experiment.objects
+                .exclude(public_access=Experiment.PUBLIC_ACCESS_NONE)
+                .exclude(public_access=Experiment.PUBLIC_ACCESS_EMBARGO)])
 
         ids = list(set(experiment_ids) & set(access_list))
         experiments = Experiment.objects.filter(pk__in=ids)\


### PR DESCRIPTION
Email templates are now configurable in settings, with default templates given in tardis/apps/publication_forms/default_settings.py. These can be overridden in the main settings.py file.

There was a bug where embargoed publications were still shown in experiment listings, although their content remained inaccessible. Embargoed publications are now correctly omitted from public data listings.