### PR TITLE
CSS tweak to allow long datafile names to linebreak at underscores.

### DIFF
--- a/tardis/tardis_portal/static/css/default.css
+++ b/tardis/tardis_portal/static/css/default.css
@@ -95,6 +95,11 @@ div.copylink {
 .datafile_name {
     font-size: 110%;
     font-weight: bold;
+    word-break: break-all;
+}
+
+.datafiles.table {
+    width: auto !important;
 }
 
 .info-box {

--- a/tardis/tardis_portal/static/css/default.css
+++ b/tardis/tardis_portal/static/css/default.css
@@ -98,10 +98,6 @@ div.copylink {
     word-break: break-all;
 }
 
-.datafiles.table {
-    width: auto !important;
-}
-
 .info-box {
     border: 1px solid #DDDDDD;
     padding: 5px 10px 5px 10px;


### PR DESCRIPTION
~~Also, set cell width for datafile list table to 'auto' - this prevents layout issues when using Bootstrap Table in the template.~~