### PR TITLE
Swagger support for the RESTful API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,9 @@ a RESTful API.
 Not all functionality is being implement at the same time. This documentation
 reflects what is available and tested.
 
+The RESTful API can be explored via the automatically generated Swagger
+documentation at: http://localhost:8000/api/v1/swagger/
+
 Accessible Models
 =================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ django-mustachejs==0.6.0
 django-nose
 django-registration-redux
 -e git+https://github.com/grischa/django-tastypie.git@mytardis-dj1.7#egg=django-tastypie
+django-tastypie-swagger
 django-user-agents==0.2.2
 ecdsa==0.11 #apt: 0.10
 #elementtree

--- a/tardis/settings_changeme.py
+++ b/tardis/settings_changeme.py
@@ -254,6 +254,7 @@ INSTALLED_APPS = (
     'bootstrapform',
     'mustachejs',
     'tastypie',
+    'tastypie_swagger',
     # these optional apps, may require extra settings
     'tardis.apps.publication_forms',
     'tardis.apps.oaipmh',

--- a/tardis/urls.py
+++ b/tardis/urls.py
@@ -332,6 +332,19 @@ api_urls = patterns(
     '',
     (r'^', include(v1_api.urls)),
 )
+
+tastypie_swagger_urls = patterns(
+    '',
+    url(r'v1/swagger/',
+        include('tastypie_swagger.urls',
+                namespace='api_v1_tastypie_swagger'),
+        kwargs={
+          "tastypie_api_module": v1_api,
+          "namespace": "api_v1_tastypie_swagger",
+          "version": "1"}
+        ),
+)
+
 # # END API SECTION
 
 apppatterns = patterns('',)
@@ -346,6 +359,9 @@ urlpatterns = patterns(
     (r'', include(core_urls)),
     # API views
     (r'^api/', include(api_urls)),
+
+    # tastypie_swagger endpoints for API auto-documentation
+    (r'^api/', include(tastypie_swagger_urls)),
 
     # Experiment Views
     (r'^experiment/', include(experiment_urls)),


### PR DESCRIPTION
This patch adds Swagger support via tastypie_swagger for automatic documentation of the RESTful API.

The API can be explored at <mytardis_server>/api/v1/swagger

I've also tested this with the mytardis-app-mydata Django app installed and it correctly detects the additional API endpoints added by the app.

The extra dependency, the Django app at https://github.com/concentricsky/django-tastypie-swagger, is actively maintained.