### PR TITLE
Including 'location' (i.e. storage box name) in Replica JSON.

### DIFF
--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -1072,6 +1072,11 @@ class ReplicaResource(MyTardisModelResource):
             del(bundle.data['file_object'])
         return bundle
 
+    def dehydrate(self, bundle):
+        dfo = bundle.obj
+        bundle.data['location'] = dfo.storage_box.name
+        return bundle
+
 
 class ObjectACLResource(MyTardisModelResource):
     content_object = GenericForeignKeyField({


### PR DESCRIPTION
Useful if you are uploading to a receiving storage box, and then
you want to check whether the data has been ingested into the
master storage box yet.