### PR TITLE
Create a temporary file copy of a datafile object

### DIFF
--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -306,8 +306,8 @@ class DataFile(models.Model):
         Returns a traditional file-system-based file object
         that is a copy of the original data. The file is deleted
         when the context is destroyed.
-        :param directory:
-        :return:
+        :param directory: the directory in which to create the temp file
+        :return: the temporary file object
         """
         temp_file = NamedTemporaryFile(delete=True, dir=directory)
         try:

--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -313,6 +313,7 @@ class DataFile(models.Model):
         try:
             temp_file.write(self.file_object.read())
             temp_file.flush()
+            temp_file.seek(0, 0)
             yield temp_file
         finally:
             temp_file.close()

--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -2,6 +2,9 @@
 # remove when file sizes are integers
 import hashlib
 import logging
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+
 from os import path
 import mimetypes
 
@@ -296,6 +299,23 @@ class DataFile(models.Model):
             return dfos[0].get_full_path()
         else:
             return None
+
+    @contextmanager
+    def get_as_temporary_file(self, directory=None):
+        """
+        Returns a traditional file-system-based file object
+        that is a copy of the original data. The file is deleted
+        when the context is destroyed.
+        :param directory:
+        :return:
+        """
+        temp_file = NamedTemporaryFile(delete=True, dir=directory)
+        try:
+            temp_file.write(self.file_object.read())
+            temp_file.flush()
+            yield temp_file
+        finally:
+            temp_file.close()
 
     def is_local(self):
         return self.file_objects.all()[0].is_local()


### PR DESCRIPTION
This PR adds a "get_as_temporary_file" method to the DataFile object that creates a standard filesystem temporary file object that can be used with libraries that cannot accept a python File object.

This method was added specifically to address issues with the h5py HDF5 library, which expect a file name to be given. It would, however, allow external filters to process data stored in non-filesystem storage, such as swift/s3.