### PR TITLE
Tardis app urls

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,8 @@ in development
 
 * DataFile size is now a BigInteger field
 * new settings for customisations
+* A new AbstractTardisAppConfig class that all new tardis apps should subclass
+* Third-party tardis app dependency checking
 
 
 3.6 - 16 March 2015

--- a/docs/contextual_views.rst
+++ b/docs/contextual_views.rst
@@ -20,7 +20,11 @@ User Guide
 A default installation has no contextual views. To enable them a few
 steps are needed:
 
-* an app needs to be installed in ``tardis/apps/``
+* an app needs to be installed either in ``tardis/apps/``, or the app's
+  configuration must subclass ``AbstractTardisAppConfig`` thereby enabling
+  autodetection. ``AbstractTardisAppConfig`` replaces ``AppConfig`` as
+  described in these
+  `django docs <https://docs.djangoproject.com/en/1.8/ref/applications/>`_.
 
 * ``DataFile`` s need to be manually or automatically tagged with a
   schema that identifies them as viewable with a particular

--- a/tardis/app_config.py
+++ b/tardis/app_config.py
@@ -25,17 +25,18 @@ def is_tardis_app(app_config):
     return isinstance(app_config, AbstractTardisAppConfig)
 
 
+def format_app_name_for_url(name):
+    return re.sub(r'[^a-z]+', '-', name.lower())
+
+
 def get_tardis_apps():
     """
     Gets a list of tuples where the first element is the app name, and the
     second is the module path
     :return:
     """
-    def format_app_name(name):
-        return re.sub(r'[^a-z]+', '-', name.lower())
-
     tardis_apps = []
     for app_name, app_config in apps.app_configs.items():
         if is_tardis_app(app_config):
-            tardis_apps.append((format_app_name(app_name), app_config.name))
+            tardis_apps.append((app_name, app_config.name))
     return tardis_apps

--- a/tardis/app_config.py
+++ b/tardis/app_config.py
@@ -26,7 +26,7 @@ def is_tardis_app(app_config):
 
 
 def format_app_name_for_url(name):
-    return re.sub(r'[^a-z]+', '-', name.lower())
+    return re.sub(r'[^a-z0-9]+', '-', name.lower())
 
 
 def get_tardis_apps():

--- a/tardis/app_config.py
+++ b/tardis/app_config.py
@@ -54,22 +54,19 @@ def check_app_dependencies(app_configs, **kwargs):
     :return: a list of unsatisfied dependencies
     """
 
-    def app_configs_to_dict(configs):
-        return dict([(app_config[1].name, app_config[1]) for app_config in
-                     configs.iteritems()])
-
-    installed_apps = app_configs_to_dict(apps.app_configs)
+    installed_apps = dict([(app_config.name, app_config) for app_config in
+                     apps.app_configs.itervalues()])
 
     # According to https://docs.djangoproject.com/en/1.8/topics/checks/#writing-your-own-checks
     # app_configs may contain a list of apps to check, but if it's None, all
     # apps should be inspected.
     if app_configs:
-        apps_to_check = app_configs_to_dict(app_configs)
+        apps_to_check = app_configs.itervalues()
     else:
-        apps_to_check = installed_apps
+        apps_to_check = installed_apps.itervalues()
 
     errors = []
-    for app in apps_to_check.itervalues():
+    for app in apps_to_check:
         deps = getattr(app, 'app_dependencies', [])
         for dependency in deps:
             if not installed_apps.has_key(dependency):

--- a/tardis/app_config.py
+++ b/tardis/app_config.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class AbstractTardisAppConfig(AppConfig):
+    """
+    All MyTardis app configuration classes should extend this abstract class
+    to have their APIs and URLs automatically added to URL routing.
+    """
+    pass

--- a/tardis/app_config.py
+++ b/tardis/app_config.py
@@ -1,4 +1,10 @@
+from importlib import import_module
+
+import re
 from django.apps import AppConfig
+from django.conf import settings
+
+DEFAULT_APP_CONFIG = 'default_app_config'
 
 
 class AbstractTardisAppConfig(AppConfig):
@@ -7,3 +13,58 @@ class AbstractTardisAppConfig(AppConfig):
     to have their APIs and URLs automatically added to URL routing.
     """
     pass
+
+
+def get_app_and_config_class(app):
+    """
+    Gets the app module and configuration class if available
+    :param app: a string reference to the app module
+    :return: a tuple containing the app module and configuration class,
+    respectively.
+    """
+    app_module = import_module(app)
+    config_class = None
+    if hasattr(app_module, DEFAULT_APP_CONFIG):
+        module_name, class_name = getattr(app_module,
+                                          DEFAULT_APP_CONFIG).rsplit('.',
+                                                                     1)
+        config_class = getattr(import_module(module_name), class_name)
+    return app_module, config_class
+
+
+def get_app_name(app):
+    """
+    Gets the app's name
+    :param app: a string reference to the app module
+    :return: the app's name
+    """
+    app_module, config_class = get_app_and_config_class(app)
+
+    if config_class is not None:
+        name = config_class.verbose_name
+    elif app.startswith(settings.TARDIS_APP_ROOT):
+        name = app.split('.').pop()
+    else:
+        name = app
+
+    # Replaces any non A-Z characters with a dash (-)
+    return re.sub(r'[^a-z]+', '-', name.lower())
+
+
+def is_tardis_app(app):
+    """
+    Determines whether the installed app is a MyTardis app
+    :param app: a string reference to the app module
+    :return: True if the app is a MyTardis app, False otherwise
+    """
+    if app.startswith(settings.TARDIS_APP_ROOT):
+        return True
+    app_module, config_class = get_app_and_config_class(app)
+    if config_class is not None:
+        return issubclass(config_class, AbstractTardisAppConfig)
+    return False
+
+
+def get_tardis_apps():
+    return [(get_app_name(app), app) for app in settings.INSTALLED_APPS if
+            is_tardis_app(app)]

--- a/tardis/app_config.py
+++ b/tardis/app_config.py
@@ -10,7 +10,9 @@ class AbstractTardisAppConfig(AppConfig):
     All MyTardis app configuration classes should extend this abstract class
     to have their APIs and URLs automatically added to URL routing.
     """
-    pass
+
+    # Override this in subclasses to define any apps that this app depends on
+    app_dependencies = []
 
 
 def is_tardis_app(app_config):
@@ -45,7 +47,8 @@ def get_tardis_apps():
 def check_app_dependencies(app_configs, **kwargs):
     """
     Checks currently installed apps for dependencies required by installed apps
-    as defined by the app_dependencies attribute of the AppConfig object.
+    as defined by the app_dependencies attribute of the AppConfig object, if
+    present.
     :param app_configs: a list of app_configs to check, or None for all apps to
      be checked
     :return: a list of unsatisfied dependencies
@@ -56,7 +59,14 @@ def check_app_dependencies(app_configs, **kwargs):
                      configs.iteritems()])
 
     installed_apps = app_configs_to_dict(apps.app_configs)
-    apps_to_check = installed_apps or app_configs_to_dict(app_configs)
+
+    # According to https://docs.djangoproject.com/en/1.8/topics/checks/#writing-your-own-checks
+    # app_configs may contain a list of apps to check, but if it's None, all
+    # apps should be inspected.
+    if app_configs:
+        apps_to_check = app_configs_to_dict(app_configs)
+    else:
+        apps_to_check = installed_apps
 
     errors = []
     for app in apps_to_check.itervalues():

--- a/tardis/apps/push_to/apps.py
+++ b/tardis/apps/push_to/apps.py
@@ -1,6 +1,6 @@
-from django.apps import AppConfig
+from tardis.app_config import AbstractTardisAppConfig
 
 
-class PushToConfig(AppConfig):
+class PushToConfig(AbstractTardisAppConfig):
     name = 'tardis.apps.push_to'
     verbose_name = 'Push To'

--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -488,16 +488,14 @@ class ExperimentView(TemplateView):
             except:
                 logger.debug('error when loading default exp apps')
 
-        from tardis.urls import getTardisApps
+        from tardis.urls import get_tardis_apps
 
-        for app in getTardisApps():
+        for app_name, app in get_tardis_apps():
             try:
                 appnames.append(
-                    sys.modules['%s.%s.settings'
-                                % (settings.TARDIS_APP_ROOT, app)].NAME)
+                    sys.modules['%s.settings' % app].NAME)
                 appurls.append(
-                    reverse('%s.%s.views.index' % (settings.TARDIS_APP_ROOT,
-                                                   app), args=[experiment.id]))
+                    reverse('%s.views.index' % app, args=[experiment.id]))
             except:
                 logger.debug("No tab for %s" % app)
 

--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -488,7 +488,7 @@ class ExperimentView(TemplateView):
             except:
                 logger.debug('error when loading default exp apps')
 
-        from tardis.urls import get_tardis_apps
+        from tardis.app_config import get_tardis_apps
 
         for app_name, app in get_tardis_apps():
             try:

--- a/tardis/urls.py
+++ b/tardis/urls.py
@@ -357,7 +357,7 @@ tastypie_swagger_urls = patterns(
 
 apppatterns = patterns('', )
 for app_name, app in get_tardis_apps():
-    apppatterns += patterns('tardis.apps',
+    apppatterns += patterns('',
                             (r'^%s/' % format_app_name_for_url(app_name),
                              include('%s.urls' % app)))
 urlpatterns = patterns(

--- a/tardis/urls.py
+++ b/tardis/urls.py
@@ -1,7 +1,5 @@
 from importlib import import_module
 import logging
-
-import re
 from os import path
 
 from django.contrib import admin
@@ -19,7 +17,7 @@ import django_jasmine.urls
 from tastypie.api import Api
 from tastypie.resources import Resource
 
-from tardis.app_config import AbstractTardisAppConfig
+from tardis.app_config import get_tardis_apps
 from tardis.tardis_portal.api import (
     DatafileParameterResource,
     DatafileParameterSetResource,
@@ -50,60 +48,6 @@ from tardis.tardis_portal.views.pages import site_routed_view
 admin.autodiscover()
 
 logger = logging.getLogger(__name__)
-
-
-def get_tardis_apps():
-    default_app_config = 'default_app_config'
-
-    def get_app_and_config_class(app):
-        """
-        Gets the app module and configuration class if available
-        :param app: a string reference to the app module
-        :return: a tuple containing the app module and configuration class,
-        respectively.
-        """
-        app_module = import_module(app)
-        config_class = None
-        if hasattr(app_module, default_app_config):
-            module_name, class_name = getattr(app_module,
-                                              default_app_config).rsplit('.',
-                                                                         1)
-            config_class = getattr(import_module(module_name), class_name)
-        return app_module, config_class
-
-    def get_app_name(app):
-        """
-        Gets the app's name
-        :param app: a string reference to the app module
-        :return: the app's name
-        """
-        app_module, config_class = get_app_and_config_class(app)
-
-        if config_class is not None:
-            name = config_class.verbose_name
-        elif app.startswith(settings.TARDIS_APP_ROOT):
-            name = app.split('.').pop()
-        else:
-            name = app
-
-        # Replaces any non A-Z characters with a dash (-)
-        return re.sub(r'[^a-z]+', '-', name.lower())
-
-    def is_tardis_app(app):
-        """
-        Determines whether the installed app is a MyTardis app
-        :param app: a string reference to the app module
-        :return: True if the app is a MyTardis app, False otherwise
-        """
-        if app.startswith(settings.TARDIS_APP_ROOT):
-            return True
-        app_module, config_class = get_app_and_config_class(app)
-        if config_class is not None:
-            return issubclass(config_class, AbstractTardisAppConfig)
-        return False
-
-    return [(get_app_name(app), app) for app in settings.INSTALLED_APPS if
-            is_tardis_app(app)]
 
 handler500 = 'tardis.views.error_handler'
 

--- a/tardis/urls.py
+++ b/tardis/urls.py
@@ -17,7 +17,7 @@ import django_jasmine.urls
 from tastypie.api import Api
 from tastypie.resources import Resource
 
-from tardis.app_config import get_tardis_apps
+from tardis.app_config import get_tardis_apps, format_app_name_for_url
 from tardis.tardis_portal.api import (
     DatafileParameterResource,
     DatafileParameterSetResource,
@@ -331,7 +331,7 @@ for app_name, app in get_tardis_apps():
             resource_name = resource._meta.resource_name
             if not resource_name.startswith(app_name):
                 resource._meta.resource_name = '%s_%s' % (
-                    app_name, resource_name)
+                    format_app_name_for_url(app_name), resource_name)
             v1_api.register(resource())
     except ImportError as e:
         logger.debug('App API URLs import error: %s' % str(e))
@@ -358,7 +358,7 @@ tastypie_swagger_urls = patterns(
 apppatterns = patterns('', )
 for app_name, app in get_tardis_apps():
     apppatterns += patterns('tardis.apps',
-                            (r'^%s/' % app_name,
+                            (r'^%s/' % format_app_name_for_url(app_name),
                              include('%s.urls' % app)))
 urlpatterns = patterns(
     '',

--- a/tardis/urls.py
+++ b/tardis/urls.py
@@ -1,5 +1,7 @@
 from importlib import import_module
 import logging
+
+import re
 from os import path
 
 from django.contrib import admin
@@ -17,6 +19,7 @@ import django_jasmine.urls
 from tastypie.api import Api
 from tastypie.resources import Resource
 
+from tardis.app_config import AbstractTardisAppConfig
 from tardis.tardis_portal.api import (
     DatafileParameterResource,
     DatafileParameterSetResource,
@@ -49,10 +52,58 @@ admin.autodiscover()
 logger = logging.getLogger(__name__)
 
 
-def getTardisApps():
-    return map(lambda app: app.split('.').pop(),
-               filter(lambda app: app.startswith(settings.TARDIS_APP_ROOT),
-                      settings.INSTALLED_APPS))
+def get_tardis_apps():
+    default_app_config = 'default_app_config'
+
+    def get_app_and_config_class(app):
+        """
+        Gets the app module and configuration class if available
+        :param app: a string reference to the app module
+        :return: a tuple containing the app module and configuration class,
+        respectively.
+        """
+        app_module = import_module(app)
+        config_class = None
+        if hasattr(app_module, default_app_config):
+            module_name, class_name = getattr(app_module,
+                                              default_app_config).rsplit('.',
+                                                                         1)
+            config_class = getattr(import_module(module_name), class_name)
+        return app_module, config_class
+
+    def get_app_name(app):
+        """
+        Gets the app's name
+        :param app: a string reference to the app module
+        :return: the app's name
+        """
+        app_module, config_class = get_app_and_config_class(app)
+
+        if config_class is not None:
+            name = config_class.verbose_name
+        elif app.startswith(settings.TARDIS_APP_ROOT):
+            name = app.split('.').pop()
+        else:
+            name = app
+
+        # Replaces any non A-Z characters with a dash (-)
+        return re.sub(r'[^a-z]+', '-', name.lower())
+
+    def is_tardis_app(app):
+        """
+        Determines whether the installed app is a MyTardis app
+        :param app: a string reference to the app module
+        :return: True if the app is a MyTardis app, False otherwise
+        """
+        if app.startswith(settings.TARDIS_APP_ROOT):
+            return True
+        app_module, config_class = get_app_and_config_class(app)
+        if config_class is not None:
+            return issubclass(config_class, AbstractTardisAppConfig)
+        return False
+
+    return [(get_app_name(app), app) for app in settings.INSTALLED_APPS if
+            is_tardis_app(app)]
 
 handler500 = 'tardis.views.error_handler'
 
@@ -324,9 +375,9 @@ v1_api.register(FacilityResource())
 v1_api.register(InstrumentResource())
 
 # App API additions
-for app in getTardisApps():
+for app_name, app in get_tardis_apps():
     try:
-        app_api = import_module('tardis.apps.%s.api' % app)
+        app_api = import_module('%s.api' % app)
         for res_name in dir(app_api):
             if not res_name.endswith('AppResource'):
                 continue
@@ -334,9 +385,9 @@ for app in getTardisApps():
             if not issubclass(resource, Resource):
                 continue
             resource_name = resource._meta.resource_name
-            if not resource_name.startswith(app):
+            if not resource_name.startswith(app_name):
                 resource._meta.resource_name = '%s_%s' % (
-                    app, resource_name)
+                    app_name, resource_name)
             v1_api.register(resource())
     except ImportError as e:
         logger.debug('App API URLs import error: %s' % str(e))
@@ -360,12 +411,11 @@ tastypie_swagger_urls = patterns(
 
 # # END API SECTION
 
-apppatterns = patterns('',)
-for app in getTardisApps():
+apppatterns = patterns('', )
+for app_name, app in get_tardis_apps():
     apppatterns += patterns('tardis.apps',
-                            (r'^%s/' % app.replace('_', '-'),
-                             include('%s.%s.urls' %
-                                     (settings.TARDIS_APP_ROOT, app))))
+                            (r'^%s/' % app_name,
+                             include('%s.urls' % app)))
 urlpatterns = patterns(
     '',
     (r'', include(core_urls)),


### PR DESCRIPTION
This PR extends the current functionality of automatically including URL routing (including API urls) form tardis.apps.* to any installed app that is tardis-specific but not under the tardis.apps namespace. Tardis-specific apps are identified as those that reside under tardis.apps or as any that derive their AppConfig class from tardis.app_config.AbstractTardisAppConfig (which is in itself a subclass of django.apps.AppConfig).