### PR TITLE
removed silly experiment apps code

### DIFF
--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -488,19 +488,6 @@ class ExperimentView(TemplateView):
             except:
                 logger.debug('error when loading default exp apps')
 
-        from tardis.urls import getTardisApps
-
-        for app in getTardisApps():
-            try:
-                appnames.append(
-                    sys.modules['%s.%s.settings'
-                                % (settings.TARDIS_APP_ROOT, app)].NAME)
-                appurls.append(
-                    reverse('%s.%s.views.index' % (settings.TARDIS_APP_ROOT,
-                                                   app), args=[experiment.id]))
-            except:
-                logger.debug("No tab for %s" % app)
-
         c['apps'] = zip(appurls, appnames)
 
         return c


### PR DESCRIPTION
This code suggest a world where an app would provide a view `index` in a `views` module, always.
I believe we have more sophisticated ways to specify these things now, and I am not aware of anyone using this, so I am removing it.
