### PR TITLE
Remove index from string_value, create partial index for short strings on Postgres

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,9 +5,12 @@ in development
 --------------
 
 * DataFile size is now a BigInteger field
-* new settings for customisations
+* New settings for customisations, contextual view overrides (eg INDEX_VIEWS).
 * A new AbstractTardisAppConfig class that all new tardis apps should subclass
 * Third-party tardis app dependency checking
+* Removed database index from Parameter.string_value to allow longer strings in
+  Postgres. Migrations add a Postgres partial index for string_values shorter
+  than 256 characters.
 
 
 3.6 - 16 March 2015

--- a/tardis/tardis_portal/migrations/0007_remove_parameter_string_value_index.py
+++ b/tardis/tardis_portal/migrations/0007_remove_parameter_string_value_index.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tardis_portal', '0006_datafile_remove_size_string_column'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='datafileparameter',
+            name='string_value',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='datasetparameter',
+            name='string_value',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='experimentparameter',
+            name='string_value',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='instrumentparameter',
+            name='string_value',
+            field=models.TextField(null=True, blank=True),
+        ),
+    ]

--- a/tardis/tardis_portal/migrations/0008_string_value_partial_index_postgres.py
+++ b/tardis/tardis_portal/migrations/0008_string_value_partial_index_postgres.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations, connection
+from tardis.tardis_portal.models import ExperimentParameter, DatasetParameter, \
+    DatafileParameter, InstrumentParameter
+from tardis import settings
+
+def _generate_index_migrations():
+    max_length = 256
+
+    # if 'postgres' not in settings.DATABASES['default']['ENGINE'].lower():
+    #     return []
+    if hasattr(connection, 'vendor') and 'postgresql' not in connection.vendor:
+        return []
+
+    string_value_tables = [
+        ExperimentParameter.objects.model._meta.db_table,
+        DatasetParameter.objects.model._meta.db_table,
+        DatafileParameter.objects.model._meta.db_table,
+        InstrumentParameter.objects.model._meta.db_table,
+    ]
+
+    create_template = "CREATE INDEX %s ON %s(string_value) " \
+                      "WHERE char_length(string_value) <= %s;"
+
+    operations = []
+    for table_name in string_value_tables:
+        index_name = table_name + "_string_value"
+        ops = [
+            migrations.RunSQL(
+             "DROP INDEX IF EXISTS %s;" % index_name,
+             reverse_sql=create_template % (index_name, table_name, max_length)
+            ),
+            migrations.RunSQL(
+             create_template % (index_name, table_name, max_length),
+             reverse_sql="DROP INDEX IF EXISTS %s;" % index_name
+            ),
+        ]
+
+        operations.extend(ops)
+
+    return operations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tardis_portal', '0007_remove_parameter_string_value_index'),
+    ]
+
+    operations = _generate_index_migrations()

--- a/tardis/tardis_portal/migrations/0008_string_value_partial_index_postgres.py
+++ b/tardis/tardis_portal/migrations/0008_string_value_partial_index_postgres.py
@@ -6,7 +6,7 @@ from tardis.tardis_portal.models import ExperimentParameter, DatasetParameter, \
     DatafileParameter, InstrumentParameter
 
 def _generate_index_migrations():
-    max_length = 256
+    max_length = 255
 
     if hasattr(connection, 'vendor') and 'postgresql' not in connection.vendor:
         return []

--- a/tardis/tardis_portal/migrations/0008_string_value_partial_index_postgres.py
+++ b/tardis/tardis_portal/migrations/0008_string_value_partial_index_postgres.py
@@ -4,13 +4,10 @@ from __future__ import unicode_literals
 from django.db import models, migrations, connection
 from tardis.tardis_portal.models import ExperimentParameter, DatasetParameter, \
     DatafileParameter, InstrumentParameter
-from tardis import settings
 
 def _generate_index_migrations():
     max_length = 256
 
-    # if 'postgres' not in settings.DATABASES['default']['ENGINE'].lower():
-    #     return []
     if hasattr(connection, 'vendor') and 'postgresql' not in connection.vendor:
         return []
 

--- a/tardis/tardis_portal/models/parameters.py
+++ b/tardis/tardis_portal/models/parameters.py
@@ -430,7 +430,8 @@ class ParameterSet(models.Model, ParameterSetManagerMixin):
 
 class Parameter(models.Model):
     name = models.ForeignKey(ParameterName)
-    string_value = models.TextField(null=True, blank=True, db_index=True)
+    # string_value has a custom index created via migrations (for Postgresql)
+    string_value = models.TextField(null=True, blank=True)
     numerical_value = models.FloatField(null=True, blank=True, db_index=True)
     datetime_value = models.DateTimeField(null=True, blank=True, db_index=True)
     link_id = models.PositiveIntegerField(null=True, blank=True)


### PR DESCRIPTION
This patch removes the database index from Parameter.string_value. This allows the field to accept strings longer than ~2000 characters on Postgres. This is required due to a limitation of the default Postgres B-tree index type. A Postgres partial index is added for short strings to ensure typical queries remain efficient.

There are associated two migrations.

1. Update the string_value on all tables derived from the Parameter model to remove the index.
2. Add a new partial index on *parameter tables that have a string_value column such that only strings <= 256 characters are indexed.

