### PR TITLE
Update docs and docstrings for contextual view overrides

### DIFF
--- a/docs/contextual_views.rst
+++ b/docs/contextual_views.rst
@@ -2,6 +2,13 @@
 Contextual Views
 ================
 
+Introduction
+============
+In order to better represent specific data types and facilities, MyTardis
+allows apps to override the default views for Experiments, Datasets,
+DataFile metadata, and the main index page. The following sections detail
+settings and requirements of apps to make this happen.
+
 Datafile Views
 ==============
 
@@ -41,12 +48,12 @@ steps are needed:
 
 ::
 
-    DATAFILE_VIEWS = [("http://example.org/views/awesome_view",
-                       "/apps/awesome-view/view"),]
+    DATAFILE_VIEWS = [("http://example.org/schemas/datafile/my_awesome_schema",
+                       "/apps/my-awesome-app/view"),]
 
 Currently, the default view is always ``DataFile`` metadata. This
 can be changed, for example, by developing a custom ``Dataset`` view,
-which is explained in the following chapter.
+which is explained in the following section.
 
 Dataset and Experiment Views
 ============================
@@ -55,52 +62,86 @@ Rationale
 ---------
 
 For some specific uses the data available can be presented and/or
-processed in useful ways. The example that this feature was built for
-are single-image and many-image datasets from the Australian
-Synchrotron. Single images can be displayed large and for a many-image
-dataset it is more useful to show a couple of example images taken at
-regular intervals not from the beginning of the set of files.  These
-different datasets can be tagged differently and subsequently
-displayed differently.
+processed in useful ways. MyTardis allows views for Experiments and Datasets to
+be overriden by apps on a per-schema basis, allowing custom views for specifc
+data types. The example that this feature was built for are single-image and
+many-image datasets from the Australian Synchrotron. Single images can be
+displayed large and for a many-image dataset it is more useful to show a couple
+of example images taken at regular intervals not from the beginning of the set
+of files. These different datasets can be detected via their schema namespace
+and displayed differently.
 
 User Guide
 ----------
 
-Similarly to contextual ``DataFile`` views, ``Dataset`` and ``Experiment``
-views rely on specific schemas attached to them.
+Akin to ``DataFile`` contextual views, ``Dataset`` and ``Experiment``
+contextual views rely on matching a specific schema namespace in an attached
+ParameterSet.
 
-The schema for each view either needs to be created and attached to a
-Dataset, or the view can be set up for Dataset schemas that are
-already in use.
+Existing schemas can be used, or a special schema intended only for tagging an
+Experiment or Dataset for contextual view override can be attached (via an
+otherwise empty ParameterSet).
 
-There are two main differences:
-
-* instead of an AJAX-loaded URL the settings associate a view function
-  with a schema.
+``Dataset`` and ``Experiment`` contextual views are configured in settings by
+ associating a schema namespace with a class-based view (or view function).
+Unlike ``DataFile`` contextual views which inject content into the DOM via an
+AJAX call, these contextual views override the entire page.
 
   Example:
 
 ::
 
     DATASET_VIEWS = [
-        ("http://example.org/awesome_data/1",
-         "tardis.apps.mx_views.views.view_full_dataset"),
+        ('http://example.org/schemas/dataset/my_awesome_schema',
+         'tardis.apps.my_awesome_app.views.CustomDatasetViewSubclass'),
     ]
+
     EXPERIMENT_VIEWS = [
-        ("http://example.org/awesome_experiments/1",
-         "tardis.apps.mx_views.views.view_fancy_experiment"),
+        ('http://example.org/schemas/expt/my_awesome_schema',
+         'tardis.apps.my_awesome_app.views.CustomExptViewSubclass'),
     ]
 
+Custom Index View
+=================
 
-* there is currently no UI choice of the ``Dataset`` and ``Experiment`` views.
+Rationale
+---------
+Specific sites or facilities often want to display a custom index page that
+presents recently ingested experiments in a way which is more meaningful for
+their particular domain or application. MyTardis support overriding the
+index page (/) on a per-domain or per-``Site`` basis.
 
-Good practice
--------------
+User Guide
+----------
 
-The default and well-tested ``Dataset`` and ``Experiment`` views can be
-changed minimally for specific purposes by extending the default template
-and overriding a template block.
+Example:
+::
 
-New versions may change the default view functions. If you copy and paste them
-for your application, please check with each upgrade that you are still using
-up to date code.
+    INDEX_VIEWS = {
+        1: 'tardis.apps.my_custom_app.views.MyCustomIndexSubclass',
+        'facility.example.org': 'tardis.apps.myapp.AnotherCustomIndexSubclass'
+    }
+
+A custom view override is defined in settings as dictionary mapping a
+class-based view (or view function) to a Django
+`Site <https://docs.djangoproject.com/en/1.8/ref/contrib/sites/>`_. A ``Site`` is
+specified by SITE_ID (an integer) or the domain name of the incoming request.
+
+Developers creating custom contextual index views are encouraged to subclass
+``tardis.tardis_portal.views.pages.IndexView``.
+
+Good practice for app developers
+================================
+
+In order to benefit from future bug and security fixes in core MyTardis, app
+developers are strongly encouraged to override ``IndexView``, ``DatasetView``
+and ``ExperimentView`` (from ``tardis.tardis_portal.pages``) when creating
+custom contextual views.
+
+The default and well-tested ``index.html``, ``view_dataset.html`` and
+``view_experiment.html`` templates can used as a basis for these custom
+contextual views.
+
+New versions may change the default templates and view functions. If you copy
+and paste parts for your application, please check with each upgrade that you
+are still using up to date code.

--- a/tardis/default_settings.py
+++ b/tardis/default_settings.py
@@ -264,6 +264,7 @@ INSTALLED_APPS = (
     # 'tardis.apps.push_to',
 )
 
+INDEX_VIEWS = {}
 '''
 A custom index page override is defined in as dictionary mapping a class-based
 view (or view function) to a Django ``Site``, specified by SITE_ID (an integer)
@@ -277,8 +278,8 @@ eg:
             'store.example.com': 'tardis.apps.myapp.AnotherCustomIndexSubclass'
         }
 '''
-INDEX_VIEWS = {}
 
+DATASET_VIEWS = []
 '''
 Dataset view overrides ('contextual views') are specified as tuples mapping
 a Schema namespace to a class-based view (or view function).
@@ -291,8 +292,8 @@ eg:
              'tardis.apps.my_awesome_app.views.CustomDatasetViewSubclass'),
         ]
 '''
-DATASET_VIEWS = []
 
+EXPERIMENT_VIEWS = []
 '''
 Experiment view overrides ('contextual views') are specified as tuples mapping
 a Schema namespace to a class-based view (or view function).
@@ -305,7 +306,6 @@ eg:
              'tardis.apps.my_awesome_app.views.CustomExptViewSubclass'),
         ]
 '''
-EXPERIMENT_VIEWS = []
 
 JASMINE_TEST_DIRECTORY = path.abspath(path.join(path.dirname(__file__),
                                                 'tardis_portal',

--- a/tardis/default_settings.py
+++ b/tardis/default_settings.py
@@ -264,36 +264,48 @@ INSTALLED_APPS = (
     # 'tardis.apps.push_to',
 )
 
-# Here you can define any custom view overrides provided by apps.
-# Index page overrides are associated with a Django 'Site', specified
-# by SITE_ID (an integer) or the domain name of the incoming request.
-# Overriding index views are encouraged to subclass
-# tardis.tardis_portal.views.pages.IndexView. However, in order to reference
-# this class-based view from settings you need to create a wrapper function
-# which returns MySubclassedView.as_view() (since class-based views cannot
-# be referenced by module path strings like traditional view functions).
-# eg
-# def my_custom_index_wrapper(request, *args, **kwargs):
-#     from tardis.tardis_portal.views.pages import class_to_view
-#     return class_to_view(MySubclassedView, request, *args, **kwargs):
-#
-# Dataset and Experiment view overrides are mapped via a Schema
-# namespace.
-#
-# INDEX_VIEWS = {
-#     1: 'tardis.apps.my_custom_app.views.my_custom_index_wrapper',
-#     'store.example.com': 'tardis.apps.myapp.my_custom_index_wrapper'
-# }
-#
-# DATASET_VIEWS = [
-#     ('http://www.tardis.edu.au/schemas/dataset/my_example_schema',
-#      'tardis.apps.my_custom_app.views.dataset_view_wrapper_fn'),
-# ]
-#
-# EXPERIMENT_VIEWS = [
-#     ('http://www.tardis.edu.au/schemas/expt/my_example_schema',
-#      'tardis.apps.my_custom_app.views.expt_view_wrapper_fn'),
-# ]
+'''
+A custom index page override is defined in as dictionary mapping a class-based
+view (or view function) to a Django ``Site``, specified by SITE_ID (an integer)
+or the domain name of the incoming request.
+See: https://mytardis.readthedocs.org/en/develop/contextual_views.html#custom-index-view
+
+eg:
+::
+        INDEX_VIEWS = {
+            1: 'tardis.apps.my_custom_app.views.MyCustomIndexSubclass',
+            'store.example.com': 'tardis.apps.myapp.AnotherCustomIndexSubclass'
+        }
+'''
+INDEX_VIEWS = {}
+
+'''
+Dataset view overrides ('contextual views') are specified as tuples mapping
+a Schema namespace to a class-based view (or view function).
+See: https://mytardis.readthedocs.org/en/develop/contextual_views.html#dataset-and-experiment-views
+
+eg:
+::
+        DATASET_VIEWS = [
+            ('http://example.org/schemas/dataset/my_awesome_schema',
+             'tardis.apps.my_awesome_app.views.CustomDatasetViewSubclass'),
+        ]
+'''
+DATASET_VIEWS = []
+
+'''
+Experiment view overrides ('contextual views') are specified as tuples mapping
+a Schema namespace to a class-based view (or view function).
+See: https://mytardis.readthedocs.org/en/develop/contextual_views.html#dataset-and-experiment-views
+
+eg:
+::
+        EXPERIMENT_VIEWS = [
+            ('http://example.org/schemas/expt/my_awesome_schema',
+             'tardis.apps.my_awesome_app.views.CustomExptViewSubclass'),
+        ]
+'''
+EXPERIMENT_VIEWS = []
 
 JASMINE_TEST_DIRECTORY = path.abspath(path.join(path.dirname(__file__),
                                                 'tardis_portal',


### PR DESCRIPTION
I've updated the docs relating to contextual view overrides and turned the associated comments in default_settings.py into docstrings. I've only provided examples of settings for class-based views to encourage their use in preference to view functions.