### PR TITLE
Allow 'owner groups' to add remove owners

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,8 @@ in development
   now unique together
 * Changed method tasks to task functions, pre-empting the removal of method
   tasks in new celery versions
+* RESTful API now supports ordering, e.g. &order_by=-title, for Experiments,
+  Datasets and DataFiles.
 * Allowed groups to be 'owners' of an Experiment. Enforce rule in views
   for web UI requiring every Experiment to have at least one user owner.
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,8 +13,10 @@ in development
   than 256 characters.
 * Changed constraints on the instrument model; facility and instrument name are
   now unique together
-* changed method tasks to task functions, pre-empting the removal of methods
+* Changed method tasks to task functions, pre-empting the removal of method
   tasks in new celery versions
+* Allowed groups to be 'owners' of an Experiment. Enforce rule in views
+  for web UI requiring every Experiment to have at least one user owner.
 
 
 3.6 - 16 March 2015

--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -158,8 +158,9 @@ class ACLAuthorization(Authorization):
                 id__in=obj_ids
             )
         elif isinstance(bundle.obj, Dataset):
-            return [ds for ds in object_list
-                    if has_dataset_access(bundle.request, ds.id)]
+            dataset_ids = [ds.id for ds in object_list
+                           if has_dataset_access(bundle.request, ds.id)]
+            return Dataset.objects.filter(id__in=dataset_ids)
         elif isinstance(bundle.obj, DatasetParameterSet):
             return [dps for dps in object_list
                     if has_dataset_access(bundle.request, dps.dataset.id)]
@@ -658,6 +659,11 @@ class ExperimentResource(MyTardisModelResource):
             'id': ('exact', ),
             'title': ('exact',),
         }
+        ordering = [
+            'title',
+            'created_time',
+            'update_time'
+        ]
         always_return_data = True
 
     def dehydrate(self, bundle):
@@ -843,6 +849,9 @@ class DatasetResource(MyTardisModelResource):
             'description': ('exact', ),
             'directory': ('exact', ),
         }
+        ordering = [
+            'description'
+        ]
         always_return_data = True
 
     def prepend_urls(self):
@@ -893,6 +902,10 @@ class DataFileResource(MyTardisModelResource):
             'dataset': ALL_WITH_RELATIONS,
             'filename': ('exact', ),
         }
+        ordering = [
+            'filename',
+            'modification_time'
+        ]
         resource_name = 'dataset_file'
 
     def download_file(self, request, **kwargs):

--- a/tardis/tardis_portal/auth/decorators.py
+++ b/tardis/tardis_portal/auth/decorators.py
@@ -231,11 +231,25 @@ def is_group_admin(request, group_id):
 
 
 def group_ownership_required(f):
+    """
+    A decorator for Django views that validates if a user is a group admin,
+    'staff' or 'superuser' prior to further processing the request.
+    Unauthenticated requests are redirected to the login page. If the
+    user making the request satisfies none of these criteria, an error response
+    is returned.
 
+    :param f: A Django view function
+    :type f: types.FunctionType
+    :return: A Django view function
+    :rtype: types.FunctionType
+    """
     def wrap(request, *args, **kwargs):
+        user = request.user
         if not request.user.is_authenticated():
             return HttpResponseRedirect('/login?next=%s' % request.path)
-        if not is_group_admin(request, kwargs['group_id']):
+        if not (is_group_admin(request, kwargs['group_id']) or
+                user.is_staff or
+                user.is_superuser):
             return return_response_error(request)
         return f(request, *args, **kwargs)
 
@@ -245,11 +259,25 @@ def group_ownership_required(f):
 
 
 def experiment_ownership_required(f):
+    """
+    A decorator for Django views that validates if a user is an owner of an
+    experiment, 'staff' or 'superuser' prior to further processing the request.
+    Unauthenticated requests are redirected to the login page. If the
+    user making the request satisfies none of these criteria, an error response
+    is returned.
 
+    :param f: A Django view function
+    :type f: types.FunctionType
+    :return: A Django view function
+    :rtype: types.FunctionType
+    """
     def wrap(request, *args, **kwargs):
-        if not request.user.is_authenticated():
+        user = request.user
+        if not user.is_authenticated():
             return HttpResponseRedirect('/login?next=%s' % request.path)
-        if not has_experiment_ownership(request, kwargs['experiment_id']):
+        if not (has_experiment_ownership(request, kwargs['experiment_id']) or
+                user.is_staff or
+                user.is_superuser):
             return return_response_error(request)
         return f(request, *args, **kwargs)
 

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/access_list_group.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/access_list_group.html
@@ -46,7 +46,9 @@
       <select id="id_permission_group">
       <option value="read">View Only</option>
       <option value="edit">View and Edit</option>
+      <option value="owner">Full Owner</option>
   </select>
+  <p><em>Owner Groups have the ability to change access controls and share experiments with others.</em></p>
   <br/>
   <a class="form_submit btn btn-primary" id="group" href="">
     <i class="icon-plus"></i>

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/share.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/share.html
@@ -556,7 +556,7 @@ $(document).ready(function() {
               </dd>
             </dl>
         </p>
-        {% if is_owner %}
+        {% if is_owner or is_superuser or is_staff %}
         <a data-experiment_id="{{experiment.id}}" class="public_access_link btn btn-mini" title="Change">
           <i class="icon-cog"></i>
           Change Public Access
@@ -569,7 +569,7 @@ $(document).ready(function() {
     <h4>Users</h4>
     <p>Users who have a share in this experiment:</p>
     <div id="experiment_user_list"/>
-    {% if is_owner %}
+    {% if is_owner or is_superuser or is_staff %}
     <a data-experiment_id="{{experiment.id}}" class="share_link btn btn-mini" title="Change">
         <i class="icon-share"></i>
         Change User Sharing
@@ -579,7 +579,7 @@ $(document).ready(function() {
     <h4>Groups</h4>
     <p>Groups who have a share in this experiment:</p>
     <div id="experiment_group_list"/>
-    {% if is_owner %}
+    {% if is_owner or is_superuser or is_staff %}
     <a data-experiment_id="{{experiment.id}}" class="share_link_group btn btn-mini" title="Change">
         <i class="icon-share"></i>
         Change Group Sharing
@@ -605,7 +605,7 @@ $(document).ready(function() {
     <p>Temporary access links provide full access to recipients regardless of an experiment's public status.</p>
     <div id="experiment_token_list"/>
 
-        {% if is_owner %}
+        {% if is_owner or is_superuser or is_staff %}
         <a title="Create New Temporary Link"
             href="{{ experiment.get_create_token_url }}"
             class="create_token_link btn btn-mini">

--- a/tardis/tardis_portal/templates/tardis_portal/form_template.html
+++ b/tardis/tardis_portal/templates/tardis_portal/form_template.html
@@ -14,6 +14,7 @@
   <div class="span12">
   	<form enctype="multipart/form-data" action="" method="post"
           class="form-horizontal">
+      {% csrf_token %}
       {% load bootstrap %}
       <fieldset>
   		  {{ form|bootstrap }}

--- a/tardis/tardis_portal/views/authorisation.py
+++ b/tardis/tardis_portal/views/authorisation.py
@@ -464,7 +464,7 @@ def change_user_permissions(request, experiment_id, username):
 
         if form.is_valid:
             if 'isOwner' in form.changed_data and \
-                            form.cleaned_data['isOwner'] == False and \
+                            form.cleaned_data['isOwner'] is False and \
                             len(owner_acls) == 1:
                 return render_error_message(
                     request,


### PR DESCRIPTION
These changes allow groups to be assigned as an 'owner' (ObjectACL.isOwned) of an experiment. Any member of an owner group has permission to add/remove user and group permissions for that experiment, including removing other owner users or groups. The business logic used by user-facing views (but not REST API) enforces a requirement that an experiment have at least one user owner (previously it enforced that a user owner cannot remove themselves).

The use case for this feature is to allow a facility manager group that has initial ownership of an experiment to share it with end-user clients. This is preferable to the current state where if an experiment can't/won't be automatically assigned to an end-user owner immediately upon ingestion (eg the way MyData typically does), the options for resharing that experiment by facility mangers are limited to: 

a) having facility managers log in using shared 'facility' user account that initially owns the experiment [yeck :stuck_out_tongue_closed_eyes: ] 

b) assigning a list of facility manager owners upon ingestion (high maintenance)

c) giving all facility managers staff/superuser permission and training to use the Django admin interface to assign ACLs [nope :-1:]

d) the option that I've invariably missed but @grischa will point out :)

By allowing 'owner groups', we leverage the group permissions system to avoid those three aforementioned workarounds.

I've also allowed any user flagged as 'staff' (eg have Django admin access) and 'superuser' to add remove user and group ownership of experiments via the MyTardis web UI.