### PR TITLE
use iterator for big migration; provide feedback on progress

### DIFF
--- a/tardis/tardis_portal/migrations/0005_datafile_add_size_int_column.py
+++ b/tardis/tardis_portal/migrations/0005_datafile_add_size_int_column.py
@@ -6,9 +6,17 @@ from django.db import migrations, models
 
 def cast_string_to_integer(apps, schema_editor):
     DataFile = apps.get_model("tardis_portal", "DataFile")
-    for df in DataFile.objects.all():
+    total_objects = DataFile.objects.all().count()
+
+    print
+    current_object = 0
+    for df in DataFile.objects.all().iterator():
         df._size = long(df.size)
         df.save()
+        current_object += 1
+        if current_object % 10000 == 0:
+            print "{0} of {1} datafile objects converted".format(
+                    current_object, total_objects)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
This migration can be very long on large databases, and consumes a lot of memory if the iterator isn't used. This PR provides feedback on progress, and reduces memory consumption.