### PR TITLE
Addressing the part of Issue

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,8 @@ in development
 * Allowed groups to be 'owners' of an Experiment. Enforce rule in views
   for web UI requiring every Experiment to have at least one user owner.
 * Registration support updated for latest django-registration-redux package
+* Speed-ups for dataset view page loading for datasets with large numbers of
+  images.  The carousel is now limited to a maximum of 100 preview images.
 
 
 3.6 - 16 March 2015

--- a/tardis/default_settings.py
+++ b/tardis/default_settings.py
@@ -409,6 +409,9 @@ DOWNLOAD_ARCHIVE_SIZE_LIMIT = 0
 # Render image file size limit: zero means no limit
 RENDER_IMAGE_SIZE_LIMIT = 0
 
+# Max number of images in dataset view's carousel: zero means no limit
+MAX_IMAGES_IN_CAROUSEL = 0
+
 # temporary download file location
 DOWNLOAD_TEMP_DIR = gettempdir()
 

--- a/tardis/tardis_portal/models/dataset.py
+++ b/tardis/tardis_portal/models/dataset.py
@@ -97,8 +97,7 @@ class Dataset(models.Model):
         render_image_size_limit = getattr(settings, 'RENDER_IMAGE_SIZE_LIMIT',
                                           0)
         if render_image_size_limit:
-            images = images.extra(where=['CAST(size AS BIGINT) <= %d'
-                                         % render_image_size_limit])
+            images = images.filter(size__lte=render_image_size_limit)
 
         return images
 

--- a/tardis/tardis_portal/templates/tardis_portal/experiment_tags/experiment_browse_item.html
+++ b/tardis/tardis_portal/templates/tardis_portal/experiment_tags/experiment_browse_item.html
@@ -18,7 +18,7 @@
       <span property="dc:author">{{ author.author }}</span>{% endfor %}
     </small>
   </h4>
-  {% if show_images and experiment.get_images.count > 0 %}
+  {% if show_images and experiment.get_images.exists %}
     <div class="image-preview">
       <span style="height: 28px"></span>
     {% for datafile in experiment.get_images|slice:":10" %}

--- a/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
@@ -461,11 +461,11 @@ $('#modal-metadata .submit-button').live('click', function() {
     <div class="row-fluid" style="margin-bottom: 20px">
     <h3>Preview Images</h3>
     <div class="info-box">
-    {% if dataset.get_images.count > 0 %}
+    {% if dataset.get_images.exists %}
       <div id="preview" class="carousel" style="margin: 20px auto 20px auto">
         <!-- Carousel items -->
         <div class="carousel-inner" style="background-color: white;">
-          {% for datafile in dataset.get_images %}
+          {% for datafile in dataset.get_images|slice:":100" %}
             <div class="{{ forloop.first|yesno:'active ,' }}item" style="height: 100%">
               {% url 'tardis.tardis_portal.iiif.download_image' datafile_id=datafile.id region='full' size='!320,240' rotation=0 quality='native' format='jpg' as thumbnail %}
               {% url 'tardis.tardis_portal.iiif.download_image' datafile_id=datafile.id region='full' size='full' rotation=0 quality='native' format='png' as image %}
@@ -481,7 +481,7 @@ $('#modal-metadata .submit-button').live('click', function() {
             </div>
           {% endfor %}
         </div>
-        {% if dataset.get_images.count > 1 %}
+        {% if dataset.get_images|slice:":2"|length > 1 %}
             <!-- Carousel nav -->
             <a class="carousel-control left" href="#preview" data-slide="prev">&lsaquo;</a>
             <a class="carousel-control right" href="#preview" data-slide="next">&rsaquo;</a>

--- a/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
@@ -465,7 +465,7 @@ $('#modal-metadata .submit-button').live('click', function() {
       <div id="preview" class="carousel" style="margin: 20px auto 20px auto">
         <!-- Carousel items -->
         <div class="carousel-inner" style="background-color: white;">
-          {% for datafile in dataset.get_images|slice:":100" %}
+          {% for datafile in dataset.get_images|slice:carousel_slice %}
             <div class="{{ forloop.first|yesno:'active ,' }}item" style="height: 100%">
               {% url 'tardis.tardis_portal.iiif.download_image' datafile_id=datafile.id region='full' size='!320,240' rotation=0 quality='native' format='jpg' as thumbnail %}
               {% url 'tardis.tardis_portal.iiif.download_image' datafile_id=datafile.id region='full' size='full' rotation=0 quality='native' format='png' as image %}

--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -249,6 +249,11 @@ class DatasetView(TemplateView):
 
         dataset_id = dataset.id
         upload_method = getattr(settings, "UPLOAD_METHOD", False)
+        max_images_in_carousel = getattr(settings, "MAX_IMAGES_IN_CAROUSEL", 0)
+        if max_images_in_carousel:
+            carousel_slice = ":%s" % max_images_in_carousel
+        else:
+            carousel_slice = ":"
 
         c.update(
             {'dataset': dataset,
@@ -265,6 +270,7 @@ class DatasetView(TemplateView):
                  dataset_id),
              'upload_method': upload_method,
              'push_to_enabled': PushToConfig.name in settings.INSTALLED_APPS,
+             'carousel_slice': carousel_slice,
              }
         )
 


### PR DESCRIPTION
https://github.com/mytardis/mytardis/issues/595
which relates to counting and loading of preview images.  (Not
addressing the is_online part of that issue.)  For a dataset
with 125,550 datafiles, running exists() on the QuerySet takes
a fraction of a second, whereas testing if
get_images.count() > 0
takes several minutes.

Carousel loading time has been improved by limiting the number of
images to 100, using a slice filter.  This limit could be a setting
in settings.py, but I don't think it's worth doing that.