### PR TITLE
Bug fix for handling RAPID_CONNECT_* settings

### DIFF
--- a/tardis/default_settings.py
+++ b/tardis/default_settings.py
@@ -672,7 +672,7 @@ RAPID_CONNECT_ENABLED = False
 RAPID_CONNECT_CONFIG = {}
 
 RAPID_CONNECT_CONFIG['secret'] = 'CHANGE_ME'
-RAPID_CONNECT_CONFIG['authnrequest_url'] = 'CHANGE_ME'
+RAPID_CONNECT_CONFIG['authnrequest_url'] = ''
 '''something like
 'https://rapid.test.aaf.edu.au/jwt/authnrequest/research/XXXXXXXXXXXXXXXX'
 '''

--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ImproperlyConfigured
 from django.core.paginator import Paginator, EmptyPage, InvalidPage
 from django.core.urlresolvers import reverse
 from django.db import connection
@@ -111,9 +111,15 @@ def use_rapid_connect(fn):
                                              'RAPID_CONNECT_ENABLED', False)
 
         if c['RAPID_CONNECT_ENABLED']:
-            c['RAPID_CONNECT_LOGIN_URL'] = getattr(
-                    settings.RAPID_CONNECT_CONFIG,
-                    'authnrequest_url')
+            c['RAPID_CONNECT_LOGIN_URL'] = \
+                getattr(settings, 'RAPID_CONNECT_CONFIG', {}).get(
+                    'authnrequest_url',
+                    None)
+
+            if not c['RAPID_CONNECT_LOGIN_URL']:
+                raise ImproperlyConfigured(
+                    "RAPID_CONNECT_CONFIG['authnrequest_url'] must be "
+                    "configured in settings if RAPID_CONNECT_ENABLED is True.")
         return c
 
     return add_rapid_connect_settings


### PR DESCRIPTION
This fixes some incorrect handling of the RAPID_CONNECT_CONFIG dictionary from settings. Raises an exception if Rapid Connect is turned on and RAPID_CONNECT_CONFIG['authnrequest_url'] is not set.