### PR TITLE
Better use of the RENDER_IMAGE_SIZE_LIMIT setting.  If we have

### DIFF
--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -344,7 +344,9 @@ class DataFile(models.Model):
     def get_image_data(self):
         from .parameters import DatafileParameter
 
-        if self.is_image():
+        render_image_size_limit = getattr(settings, 'RENDER_IMAGE_SIZE_LIMIT',
+                                          0)
+        if self.is_image() and self.size <= render_image_size_limit:
             return self.get_file()
 
         # look for image data in parameters

--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -351,6 +351,7 @@ class DataFile(models.Model):
             return self.get_file()
 
         # look for image data in parameters
+        preview_image_par = None
         pss = self.getParameterSets()
 
         if not pss:

--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -346,7 +346,8 @@ class DataFile(models.Model):
 
         render_image_size_limit = getattr(settings, 'RENDER_IMAGE_SIZE_LIMIT',
                                           0)
-        if self.is_image() and self.size <= render_image_size_limit:
+        if self.is_image() and (self.size <= render_image_size_limit or
+                                render_image_size_limit == 0):
             return self.get_file()
 
         # look for image data in parameters

--- a/tardis/tardis_portal/models/dataset.py
+++ b/tardis/tardis_portal/models/dataset.py
@@ -92,14 +92,7 @@ class Dataset(models.Model):
 
     def get_images(self):
         from .datafile import IMAGE_FILTER
-        images = self.datafile_set.order_by('filename')\
-                                  .filter(IMAGE_FILTER)
-        render_image_size_limit = getattr(settings, 'RENDER_IMAGE_SIZE_LIMIT',
-                                          0)
-        if render_image_size_limit:
-            images = images.filter(size__lte=render_image_size_limit)
-
-        return images
+        return self.datafile_set.order_by('filename').filter(IMAGE_FILTER)
 
     def _get_image(self):
         try:

--- a/tardis/tardis_portal/models/experiment.py
+++ b/tardis/tardis_portal/models/experiment.py
@@ -164,15 +164,9 @@ class Experiment(models.Model):
 
     def get_images(self):
         from .datafile import IMAGE_FILTER
-        images = self.get_datafiles().order_by('-modification_time',
-                                               '-created_time') \
+        return self.get_datafiles().order_by('-modification_time',
+                                             '-created_time') \
             .filter(IMAGE_FILTER)
-        render_image_size_limit = getattr(settings, 'RENDER_IMAGE_SIZE_LIMIT',
-                                          0)
-        if render_image_size_limit:
-            images = images.extra(where=['CAST(size AS BIGINT) <= %d'
-                                         % render_image_size_limit])
-        return images
 
     def get_size(self):
         from .datafile import DataFile


### PR DESCRIPTION
generated a (small) preview image using a filter and saved it
in a DatafileParameter, then there is no need to exclude that
DataFile from the preview images, even if the original DataFile's
file size is large.  Instead of excluding it, we just need to
ensure that DataFile's get_image_data method doesn't return a
file object for a large file.  It should either return a file
object for a small image file, or None.