### PR TITLE
Fixes to Cyberduck screenshot

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ exit
 # sudo apt-get install python-virtualenv virtualenvwrapper python-psycopg2 python-yaml ipython
 # sudo apt-get install python-anyjson python-bs4 python-billiard python-feedparser python-html5lib
 # sudo apt-get install python-httplib2 python-pystache python-crypto python-flexmock python-dateutil
-# sudo apt-get install libldap2-dev libsasl2-dev libssl-dev
+# sudo apt-get install libldap2-dev libsasl2-dev libssl-dev libfreetype6-dev
 # # optionally:
 # # sudo apt-get install memcached python-memcache
 

--- a/tardis/default_settings.py
+++ b/tardis/default_settings.py
@@ -343,6 +343,12 @@ AUTH_PROVIDERS = (
      'tardis.tardis_portal.auth.localdb_auth.DjangoAuthBackend'),
 )
 
+SFTP_USERNAME_ATTRIBUTE = 'email'
+'''
+The attribute from the User model ('email' or 'username') used to generate
+the SFTP login example on the sftp_access help page.
+'''
+
 # default authentication module for experiment ownership user during
 # ingestion? Must be one of the above authentication provider names
 DEFAULT_AUTH = 'localdb'

--- a/tardis/tardis_portal/views/images.py
+++ b/tardis/tardis_portal/views/images.py
@@ -28,10 +28,13 @@ def cybderduck_connection_window(request):
     base = Image.open(base_image)
     font = ImageFont.truetype(font_file, 13)
     draw = ImageDraw.Draw(base)
+
     if request.user.userprofile.isDjangoAccount:
         sftp_username = request.user.username
     else:
-        sftp_username = request.user.email
+        login_attr = getattr(settings, 'SFTP_USERNAME_ATTRIBUTE', 'email')
+        sftp_username = getattr(request.user, login_attr)
+
     sftp_host = request.get_host().split(':')[0]
     sftp_port = str(getattr(settings, 'SFTP_PORT', 2200))
     info = [


### PR DESCRIPTION
This pull request fixes some issues with screenshot on the SFTP help page.

libfreetype6-dev is required on Ubuntu for Pillow to render fonts, otherwise screenshot generation fails.

The screenshot now honours SFTP_USERNAME_ATTRIBUTE so that it is consistent with the text instructions on the page.