### PR TITLE
API's read_list method calls get_accessible_datafiles_for_user (and

### DIFF
--- a/tardis/tardis_portal/auth/decorators.py
+++ b/tardis/tardis_portal/auth/decorators.py
@@ -48,7 +48,7 @@ def get_accessible_experiments_for_dataset(request, dataset_id):
     experiments = Experiment.safe.all(request.user)
 
     # probably a much cleverer way of writing this with safe
-    experiment_dataset_access = []
+    experiment_dataset_access = Experiment.objects.none()
     for experiment in experiments:
         experiment_dataset = Experiment.objects.filter(
             id=experiment.id,
@@ -76,7 +76,7 @@ def get_accessible_datafiles_for_user(request):
 
     experiments = get_accessible_experiments(request)
     if experiments.count() == 0:
-        return []
+        return DataFile.objects.none()
 
     queries = [Q(dataset__experiments__id=e.id) for e in experiments]
 


### PR DESCRIPTION
it may in future call get_accessible_experiments_for_dataset), so
we should ensure that the "get_accessible_..." methods always
return a QuerySet, not an ordinary Python list.  Otherwise, the API
could attempt to call the QuerySet's filter method on an ordinary
Python list.
