### PR TITLE
encode utf-8 for haystack indexing

### DIFF
--- a/tardis/search/search_indexes.py
+++ b/tardis/search/search_indexes.py
@@ -61,7 +61,7 @@ class ExperimentIndex(indexes.SearchIndex, indexes.Indexable):
     experiment_author = indexes.MultiValueField()
 
     def prepare_text(self, obj):
-        return '{} {}'.format(obj.title, obj.description)
+        return '{} {}'.format(obj.title.encode('utf-8'), obj.description.encode('utf-8'))
 
     def prepare_experimentauthor(self, obj):
         return [author.author for author in obj.experimentauthor_set.all()]


### PR DESCRIPTION
Avoid errors such as this:
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 716: ordinal not in range(128)

when indexing experiments with haystack for search.