### PR TITLE
Small fix to user permissions form handling

### DIFF
--- a/tardis/tardis_portal/views/authorisation.py
+++ b/tardis/tardis_portal/views/authorisation.py
@@ -462,7 +462,7 @@ def change_user_permissions(request, experiment_id, username):
     if request.method == 'POST':
         form = ChangeUserPermissionsForm(request.POST, instance=acl)
 
-        if form.is_valid:
+        if form.is_valid():
             if 'isOwner' in form.changed_data and \
                             form.cleaned_data['isOwner'] is False and \
                             len(owner_acls) == 1:


### PR DESCRIPTION
Fix usage of `form.is_valid()` (should be method call). Prior to this fix, `form.is_valid` (pointing to the method, not calling the method) would have always evaluated to `True` even if the form doesn't validate.