### PR TITLE
add index to mimetype field

### DIFF
--- a/tardis/tardis_portal/migrations/0010_auto_20160503_1443.py
+++ b/tardis/tardis_portal/migrations/0010_auto_20160503_1443.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tardis_portal', '0009_auto_20160128_1119'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='datafile',
+            name='mimetype',
+            field=models.CharField(db_index=True, max_length=80, blank=True),
+        ),
+    ]

--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -55,7 +55,7 @@ class DataFile(models.Model):
     size = models.BigIntegerField(blank=True, null=True)
     created_time = models.DateTimeField(null=True, blank=True)
     modification_time = models.DateTimeField(null=True, blank=True)
-    mimetype = models.CharField(blank=True, max_length=80)
+    mimetype = models.CharField(db_index=True, blank=True, max_length=80)
     md5sum = models.CharField(blank=True, max_length=32)
     sha512sum = models.CharField(blank=True, max_length=128)
     deleted = models.BooleanField(default=False)


### PR DESCRIPTION
This goes part of the way to solving slow queries associated with Dataset.get_images() by creating a mimetype field index