### PR TITLE
allow connection sharing with gevent

### DIFF
--- a/tardis/tardis_portal/sftp.py
+++ b/tardis/tardis_portal/sftp.py
@@ -32,7 +32,9 @@ if not paramiko_log.handlers:
 
 if getattr(settings, 'SFTP_GEVENT', False):
     from gevent import monkey
+    from django.db import connection
     monkey.patch_all()
+    connection.allow_thread_sharing = True
 
 # django db related modules must be imported after monkey-patching
 from django.contrib.sites.models import Site


### PR DESCRIPTION
SFTP seems to misbehave with gevent, throwing DatabaseErrors such as
```
DatabaseError: DatabaseWrapper objects created in a thread can only be used in that same thread. The object with alias 'default' was created in thread id 140451766560576 and this is thread id 140451572674800.
```

In cases where gevent is used, setting `allow_thread_sharing` to True seems to do the trick. See [this stack overflow answer](http://stackoverflow.com/questions/13194064/using-celery-on-processes-and-gevent-in-tasks-at-the-same-time/30707837#30707837).