### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django>=1.8,<1.9
 SPARQLWrapper==1.6.4 #apt: 1.4.1
 Sphinx
 Wand
-amqp
+amqp==1.4.9
 argparse==1.2.1 #apt: libpython2.7-stdlib
 billiard
 bleach==1.4.1 #apt: 1.2.2


### PR DESCRIPTION
I ran through install instructions and got AMQP v2.0.0 installed for some reason. Even though pip shows 1.4.9 as being the latest. Not sure how that works. Anyway 2.0.0. breaks on "from amqp import promise"