### PR TITLE
Authorisation checkbox on final page, publication approval optional

### DIFF
--- a/docs/apps/publication_forms.rst
+++ b/docs/apps/publication_forms.rst
@@ -49,6 +49,10 @@ defined:
    should be added to :py:const:`CELERYBEAT_SCHEDULE` and set to a
    reasonable interval for embargo processing
 
+To disable the approval workflow and have publications automatically
+released, :py:const:`PUBLICATIONS_REQUIRE_APPROVAL` can be set to False
+(defaults to True).
+
 DOI support
 -----------
 These additional settings are required for DOI minting support:

--- a/tardis/apps/publication_forms/default_settings.py
+++ b/tardis/apps/publication_forms/default_settings.py
@@ -46,6 +46,8 @@ GENERIC_PUBLICATION_DATASET_SCHEMA = PUBLICATION_SCHEMA_ROOT + 'generic/'
 
 PDB_REFRESH_INTERVAL = timedelta(days=7)
 
+PUBLICATIONS_REQUIRE_APPROVAL = True
+
 PUBLICATION_FORM_MAPPINGS = [
     {'dataset_schema': r'^http://synchrotron.org.au/mx/',
      'publication_schema': PDB_PUBLICATION_SCHEMA_ROOT,

--- a/tardis/apps/publication_forms/templates/form.html
+++ b/tardis/apps/publication_forms/templates/form.html
@@ -190,6 +190,12 @@
     <input type="date" ng-model="formData.embargo"><a class="btn btn-primary btn-mini"
                                                       ng-click="setEmbargoToToday()">today</a>
   </div>
+  <div class="well">
+       <input type="checkbox" ng-model="formData.acknowledge" value="true">
+      I am authorised to publish the selected datasets with the license and
+      embargo period selected and have received the appropriate consent from
+      co-authors and other relevant parties.
+  </div>
 </script>
 <script type="text/ng-template" id="form_page5.html">
   <p><strong>Done!</strong> Your publication has been submitted and will be accessible

--- a/tardis/apps/publication_forms/views.py
+++ b/tardis/apps/publication_forms/views.py
@@ -50,11 +50,13 @@ def process_form(request):
     # Decode the form data
     form_state = json.loads(request.body)
 
-    def validation_error():
+    def validation_error(error=None):
+        if error is None:
+            error = 'Invalid form data was submitted ' \
+                    '(server-side validation failed)'
         return HttpResponse(
             json.dumps({
-                'error': 'Invalid form data was submitted '
-                         '(server-side validation failed)'}),
+                'error': error}),
             content_type="application/json")
 
     # Check if the form data contains a publication ID
@@ -175,6 +177,10 @@ def process_form(request):
         # and specific error messages can be returned
         # to the browser before the publication's draft
         # status is removed.
+
+        if 'acknowledge' not in form_state or not form_state['acknowledge']:
+            return validation_error('You must confirm that you are '
+                                    'authorised to submit this publication')
 
         set_publication_authors(form_state['authors'], publication)
 

--- a/tardis/apps/publication_forms/views.py
+++ b/tardis/apps/publication_forms/views.py
@@ -262,6 +262,11 @@ def process_form(request):
                        default_settings.PUBLICATIONS_REQUIRE_APPROVAL):
             approve_publication(request, publication, message=None,
                                 send_email=False)
+            # approve_publication will delete the form state, so don't
+            # bother saving is and return.
+            form_state['action'] = ''
+            return HttpResponse(json.dumps(form_state),
+                                content_type="appication/json")
 
         # Trigger publication record update
         tasks.update_publication_records.delay()


### PR DESCRIPTION
* If `PUBLICATIONS_REQUIRE_APPROVAL` is set to False, all publications are automatically approved for release.
* The final page now contains an authorisation checkbox that the user must select for the publication to be accepted.