### PR TITLE
remove 'add' buttons from publication view

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_datasets.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_datasets.html
@@ -22,7 +22,7 @@
 </h3>
 {% if has_download_permissions or has_write_permissions %}
 
-  {% if has_write_permissions %}
+  {% if has_write_permissions and not experiment.is_publication %}
   <a class="add-dataset btn btn-mini pull-right"
      href="{% url 'tardis.tardis_portal.views.add_dataset' experiment.id %}">
     <i class="icon-plus"></i>

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_metadata.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_metadata.html
@@ -2,7 +2,7 @@
 
 
 <div class="pull-right">
-    {% if has_write_permissions and not experiment.locked %}
+    {% if has_write_permissions and not experiment.locked and not experiment.is_publication %}
         <a title="Add" class="add-metadata btn btn-mini"
            href="{% url 'tardis.tardis_portal.views.add_experiment_par' experiment.id %}">
           <i class="icon-plus"></i>


### PR DESCRIPTION
This PR removed some "Add New..." buttons for publications to encourage changes to be made via the publication form. This is a side-effect of using the experiment model to represent publications.