### PR TITLE
Show an 'accept' button on the first page of the publication form

### DIFF
--- a/tardis/apps/publication_forms/templates/form.html
+++ b/tardis/apps/publication_forms/templates/form.html
@@ -25,7 +25,7 @@
     </li>
     <li>{{ currentPageIdx + 1 }} of {{ totalPages - 1 }}</li>
     <li class="next">
-      <a href="#" ng-click="nextPage()"><span ng-hide="isLastPage()">Save and continue</span><span ng-show="isLastPage()">Submit</span></a>
+      <a href="#" ng-click="nextPage()"><span ng-show="currentPageIdx == 0">Accept and continue</span><span ng-hide="currentPageIdx == 0 || isLastPage()">Save and continue</span><span ng-show="isLastPage()">Submit</span></a>
     </li>
     <li class="next" ng-show="isLastPage()">
       <a href="#" ng-click="saveAndClose()">Save and finish later</a>


### PR DESCRIPTION
The intro/conditions page of the publication form used to say "Save and continue" even though there is nothing at this point to actually save. The button now reads "Accept and continue".