### PR TITLE
Re-install missing context processor: manage_account_processor

### DIFF
--- a/tardis/default_settings.py
+++ b/tardis/default_settings.py
@@ -156,6 +156,8 @@ TEMPLATES = [
                 '.registration_processor',
                 'tardis.tardis_portal.context_processors'
                 '.user_details_processor',
+                'tardis.tardis_portal.context_processors'
+                '.manage_account_processor',
             ],
             'loaders': [
                 'django.template.loaders.app_directories.Loader',


### PR DESCRIPTION
Re-install the missing context processor.
Allows the visibility of the 'Manage Account' page to be controlled via the following setting: MANAGE_ACCOUNT_ENABLED. 
This setting is set to True in the default_settings, and will be set to True by the context processor if the setting is not found.