### PR TITLE
Search index improvements: Experiment level metadata included in search

### DIFF
--- a/tardis/search/search_indexes.py
+++ b/tardis/search/search_indexes.py
@@ -42,7 +42,8 @@ import os
 import datetime
 from haystack import indexes
 
-from tardis.tardis_portal.models import DataFile, Dataset, Experiment
+from tardis.tardis_portal.models import DataFile, Dataset, Experiment, \
+    ExperimentParameter
 
 logger = logging.getLogger(__name__)
 
@@ -104,3 +105,18 @@ class DataFileIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return DataFile
+
+
+class ExperimentParameterIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True)
+    experiment_id_stored = indexes.IntegerField()
+    parameter_name = indexes.CharField()
+
+    def prepare_text(self, obj):
+        return obj.get()
+
+    def prepare_experiment_id_stored(self, obj):
+        return obj.parameterset.experiment.id
+
+    def get_model(self):
+        return ExperimentParameter

--- a/tardis/search/search_indexes.py
+++ b/tardis/search/search_indexes.py
@@ -62,7 +62,10 @@ class ExperimentIndex(indexes.SearchIndex, indexes.Indexable):
     experiment_author = indexes.MultiValueField()
 
     def prepare_text(self, obj):
-        return '{} {}'.format(obj.title.encode('utf-8'), obj.description.encode('utf-8'))
+        return '{} {} {}'.format(obj.title.encode('utf-8'),
+                                 ', '.join(self.prepare_experimentauthor(
+                                     obj)).encode('utf-8'),
+                                 obj.description.encode('utf-8'))
 
     def prepare_experimentauthor(self, obj):
         return [author.author for author in obj.experimentauthor_set.all()]

--- a/tardis/search/search_indexes.py
+++ b/tardis/search/search_indexes.py
@@ -62,10 +62,11 @@ class ExperimentIndex(indexes.SearchIndex, indexes.Indexable):
     experiment_author = indexes.MultiValueField()
 
     def prepare_text(self, obj):
-        return '{} {} {}'.format(obj.title.encode('utf-8'),
-                                 ', '.join(self.prepare_experimentauthor(
-                                     obj)).encode('utf-8'),
-                                 obj.description.encode('utf-8'))
+        return '{}<br/>{}<br/>{}'.format(obj.title.encode('utf-8'),
+                                         ', '.join(
+                                             self.prepare_experimentauthor(obj)
+                                         ).encode('utf-8'),
+                                         obj.description.encode('utf-8'))
 
     def prepare_experimentauthor(self, obj):
         return [author.author for author in obj.experimentauthor_set.all()]
@@ -120,6 +121,9 @@ class ExperimentParameterIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_experiment_id_stored(self, obj):
         return obj.parameterset.experiment.id
+
+    def prepare_parameter_name(self, obj):
+        return obj.name.name
 
     def get_model(self):
         return ExperimentParameter

--- a/tardis/search/search_indexes.py
+++ b/tardis/search/search_indexes.py
@@ -62,11 +62,12 @@ class ExperimentIndex(indexes.SearchIndex, indexes.Indexable):
     experiment_author = indexes.MultiValueField()
 
     def prepare_text(self, obj):
-        return '{}<br/>{}<br/>{}'.format(obj.title.encode('utf-8'),
-                                         ', '.join(
-                                             self.prepare_experimentauthor(obj)
-                                         ).encode('utf-8'),
-                                         obj.description.encode('utf-8'))
+        return '{}<br/>{}<br/>{}<br/>{}'.format(obj.title.encode('utf-8'),
+                                                ', '.join(
+                                                    self.prepare_experimentauthor(obj)
+                                                ).encode('utf-8'),
+                                                obj.institution_name,
+                                                obj.description.encode('utf-8'))
 
     def prepare_experimentauthor(self, obj):
         return [author.author for author in obj.experimentauthor_set.all()]

--- a/tardis/search/templates/search/search.html
+++ b/tardis/search/templates/search/search.html
@@ -14,7 +14,8 @@
         {% for result in object_list %}
             {% if result.content_type == 'tardis_portal.experiment' %}
                 <div class="search_result">
-                    <div>Experiment <a href="{{ result.object.get_absolute_url }}">{{ result.highlighted.0|bleach|default:result.experiment_title }}</a>
+                    <div>Experiment <a href="{{ result.object.get_absolute_url }}">{{ result.object }}</a><br/>
+                        <div>{{ result.highlighted.0|bleach|default:result.text }}</div>
                     </div>
                 </div>
             {% elif result.content_type == 'tardis_portal.dataset' %}
@@ -34,6 +35,15 @@
                         {% endfor %}
                         <div>Dataset <a href="{{ result.object.dataset.get_absolute_url }}">{{ result.object.dataset.description }}</a>
                         <div>File <a href="{{ result.object.get_absolute_url }}">{{ result.highlighted.0|bleach|default:result.text }}</a></div></div>
+                    </div>
+                </div>
+            {% elif result.content_type == 'tardis_portal.experimentparameter' %}
+                <div class="search_result">
+                    <div>Experiments with matching metadata:<br/>
+                        {% for experiment in result.experiments %}
+                            <a href="{{ experiment.get_absolute_url }}">{{ experiment }}</a><br/>
+                        {% endfor %}
+                        <div>{{ result.parameter_name }}: {{ result.highlighted.0|bleach|default:result.text }}</div>
                     </div>
                 </div>
             {% endif %}


### PR DESCRIPTION
Experiment level metadata indices are added, allowing high level attributes to be searched (e.g. proposal numbers, DOIs, for example).
Institution and author names are added to the indexed experiment text.
