### PR TITLE
use alternative paramiko branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ mimeparse==0.1.3 #apt: 0.1.4
 nose
 nosexcover
 # paramiko==1.15.2 #apt: 1.10.1
--e git+https://github.com/jasonrig/paramiko.git@rsacert#egg=paramiko
+-e git+https://github.com/jasonrig/paramiko.git@rsacert_tardis#egg=paramiko
 pillow
 pwgen==0.4
 pylint


### PR DESCRIPTION
I'm rebasing the rsacert branch in my paramiko fork for the certificates PR I have with them. This branch change ensures pushes based on the latest paramiko code will not break tardis deployments in the mean time.