### PR TITLE
Urgent bugfix for celery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ Sphinx
 Wand
 amqp<2
 argparse==1.2.1 #apt: libpython2.7-stdlib
-billiard
 bleach==1.4.1 #apt: 1.2.2
 celery==3.1.17 #apt: 3.1.6
 compare


### PR DESCRIPTION
fixing billiard version conflict, celery reqs the right version automatically