### PR TITLE
Add static files reference to experiment lists.

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/experiment/list_base.html
+++ b/tardis/tardis_portal/templates/tardis_portal/experiment/list_base.html
@@ -1,4 +1,5 @@
 {% extends "tardis_portal/portal_template.html" %}
+{% load static from staticfiles %}
 {% load experiment_tags %}
 {% load experimentstats %}
 {% load humanize %}


### PR DESCRIPTION
The html/css formatting is not correct on the experiment list pages, because the static files are not loaded in  the experiment/list_base.html.

Added the load static from the static files.
