### PR TITLE
Revert use of is_staff to allow modifications to experiment ownership

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Releases
 ========
 
+In development
+--------------
+* Revert behaviour that allowed 'Staff' users to modify experiment ownership and
+  sharing permissions via the web UI.
+
 3.7 - 17 March 2016
 -------------------
 

--- a/tardis/tardis_portal/auth/decorators.py
+++ b/tardis/tardis_portal/auth/decorators.py
@@ -232,8 +232,8 @@ def is_group_admin(request, group_id):
 
 def group_ownership_required(f):
     """
-    A decorator for Django views that validates if a user is a group admin,
-    'staff' or 'superuser' prior to further processing the request.
+    A decorator for Django views that validates if a user is a group admin
+    or 'superuser' prior to further processing the request.
     Unauthenticated requests are redirected to the login page. If the
     user making the request satisfies none of these criteria, an error response
     is returned.
@@ -248,7 +248,6 @@ def group_ownership_required(f):
         if not request.user.is_authenticated():
             return HttpResponseRedirect('/login?next=%s' % request.path)
         if not (is_group_admin(request, kwargs['group_id']) or
-                user.is_staff or
                 user.is_superuser):
             return return_response_error(request)
         return f(request, *args, **kwargs)
@@ -261,7 +260,7 @@ def group_ownership_required(f):
 def experiment_ownership_required(f):
     """
     A decorator for Django views that validates if a user is an owner of an
-    experiment, 'staff' or 'superuser' prior to further processing the request.
+    experiment or 'superuser' prior to further processing the request.
     Unauthenticated requests are redirected to the login page. If the
     user making the request satisfies none of these criteria, an error response
     is returned.
@@ -276,7 +275,6 @@ def experiment_ownership_required(f):
         if not user.is_authenticated():
             return HttpResponseRedirect('/login?next=%s' % request.path)
         if not (has_experiment_ownership(request, kwargs['experiment_id']) or
-                user.is_staff or
                 user.is_superuser):
             return return_response_error(request)
         return f(request, *args, **kwargs)

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/share.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/share.html
@@ -556,7 +556,7 @@ $(document).ready(function() {
               </dd>
             </dl>
         </p>
-        {% if is_owner or is_superuser or is_staff %}
+        {% if is_owner or is_superuser %}
         <a data-experiment_id="{{experiment.id}}" class="public_access_link btn btn-mini" title="Change">
           <i class="icon-cog"></i>
           Change Public Access
@@ -569,7 +569,7 @@ $(document).ready(function() {
     <h4>Users</h4>
     <p>Users who have a share in this experiment:</p>
     <div id="experiment_user_list"/>
-    {% if is_owner or is_superuser or is_staff %}
+    {% if is_owner or is_superuser %}
     <a data-experiment_id="{{experiment.id}}" class="share_link btn btn-mini" title="Change">
         <i class="icon-share"></i>
         Change User Sharing
@@ -579,7 +579,7 @@ $(document).ready(function() {
     <h4>Groups</h4>
     <p>Groups who have a share in this experiment:</p>
     <div id="experiment_group_list"/>
-    {% if is_owner or is_superuser or is_staff %}
+    {% if is_owner or is_superuser %}
     <a data-experiment_id="{{experiment.id}}" class="share_link_group btn btn-mini" title="Change">
         <i class="icon-share"></i>
         Change Group Sharing
@@ -605,7 +605,7 @@ $(document).ready(function() {
     <p>Temporary access links provide full access to recipients regardless of an experiment's public status.</p>
     <div id="experiment_token_list"/>
 
-        {% if is_owner or is_superuser or is_staff %}
+        {% if is_owner or is_superuser %}
         <a title="Create New Temporary Link"
             href="{{ experiment.get_create_token_url }}"
             class="create_token_link btn btn-mini">

--- a/tardis/tardis_portal/views/authorisation.py
+++ b/tardis/tardis_portal/views/authorisation.py
@@ -777,7 +777,6 @@ def share(request, experiment_id):
     if user.is_authenticated():
         c['is_owner'] = authz.has_experiment_ownership(request, experiment_id)
         c['is_superuser'] = user.is_superuser
-        c['is_staff'] = user.is_staff
 
     domain = Site.objects.get_current().domain
     public_link = experiment.public_access >= Experiment.PUBLIC_ACCESS_METADATA


### PR DESCRIPTION
This reverts a previous change that allowed 'Staff' users to modify any experiment sharing and ownership in the MyTardis web UI. This better follows Django convention, in line with typical expectations from a Django app.

Discussed: https://github.com/mytardis/mytardis/issues/789

Partially reverts a 'feature' added in https://github.com/mytardis/mytardis/pull/599 / https://github.com/mytardis/mytardis/pull/601.