### PR TITLE
Proposal: More flexible special character handling in TARs and SFTP

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -311,21 +311,21 @@ Archive Organizations
    "download selected" buttons.  (The list allows for using different
    archive formats depending on the user's platform.)
 
-.. attribute:: tardis.default_settings.DEFAULT_ARCHIVE_ORGANIZATION.
+.. attribute:: tardis.default_settings.DEFAULT_PATH_MAPPER.
 
    This gives the default archive "organization" to be used.
    Organizations are defined via the next attribute.
 
-.. attribute:: tardis.default_settings.ARCHIVE_FILE_MAPPERS.
+.. attribute:: tardis.default_settings.DOWNLOAD_PATH_MAPPERS.
 
    This is a hash that maps archive organization names to Datafile filename
    mapper functions.  These functions are reponsible for generating the
    archive pathnames used for files written to "tar" and "zip" archives
    by the downloads module.
 
-   The **ARCHIVE_FILE_MAPPERS** variable is specified like::
+   The **DOWNLOAD_PATH_MAPPERS** variable is specified like::
 
-       ARCHIVE_FILE_MAPPERS = {
+       DOWNLOAD_PATH_MAPPERS = {
            'test': ('tardis.apps.example.ExampleMapper',),
            'test2': ('tardis.apps.example.ExampleMapper', {'foo': 1})
        }

--- a/tardis/apps/deep_storage_download_mapper/mapper.py
+++ b/tardis/apps/deep_storage_download_mapper/mapper.py
@@ -5,12 +5,52 @@ It recreates the structure as stored in the datafile directory
 import os
 from urllib import quote
 
+from django.conf import settings
 
-def deep_storage_mapper(datafile, rootdir):
+from tardis.tardis_portal.models.datafile import DataFile
+from tardis.tardis_portal.models.dataset import Dataset
+from tardis.tardis_portal.models.experiment import Experiment
+
+
+def deep_storage_mapper(obj, rootdir=None):
+    """
+    :param obj: The model instance (DataFile, Dataset or Experiment)
+                to generate a path for.
+    :param rootdir: The top-level directory name, or None
+    :return: Filesystem-safe path for the object in the archive or SFTP view.
+
+    If rootdir is None, just return a filesystem-safe representation of the
+    object, e.g. "DatasetDescription_123" or "strange %2F filename.txt"
+
+    For now, only DataFiles are supported when rootdir is not None.
+    """
+    safe = settings.SAFE_FILESYSTEM_CHARACTERS
+    if not rootdir:
+        if isinstance(obj, DataFile):
+            return quote(obj.filename, safe=safe)
+        elif isinstance(obj, Dataset):
+            if settings.DATASET_SPACES_TO_UNDERSCORES:
+                desc = obj.description.replace(' ', '_')
+            else:
+                desc = obj.description
+            return quote("%s_%d" % (desc, obj.id), safe=safe)
+        elif isinstance(obj, Experiment):
+            if settings.EXP_SPACES_TO_UNDERSCORES:
+                title = obj.title.replace(' ', '_')
+            else:
+                title = obj.title
+            return quote("%s_%d" % (title, obj.id), safe=safe)
+        else:
+            raise NotImplementedError(type(obj))
+
+    if not isinstance(obj, DataFile):
+        raise NotImplementedError(type(obj))
+
+    datafile = obj
     dataset = datafile.dataset
     exp = dataset.get_first_experiment()
     filepath = os.path.join(dataset.directory or '',
-                            quote(dataset.description, safe=''),
+                            quote(dataset.description, safe=safe),
                             datafile.directory or '', datafile.filename)
     if rootdir != 'datasets':
         return os.path.join(rootdir, filepath)

--- a/tardis/default_settings/downloads.py
+++ b/tardis/default_settings/downloads.py
@@ -1,11 +1,42 @@
-ARCHIVE_FILE_MAPPERS = {
+DOWNLOAD_PATH_MAPPERS = {
     'deep-storage': (
         'tardis.apps.deep_storage_download_mapper.mapper.deep_storage_mapper',
     ),
 }
 
 # Site's default archive organization (i.e. path structure)
-DEFAULT_ARCHIVE_ORGANIZATION = 'deep-storage'
+DEFAULT_PATH_MAPPER = 'deep-storage'
+
+# Don't percent-encode characters in the SAFE_FILESYSTEM_CHARACTERS
+# string when creating TARs and SFTP views.
+#
+# There is a difference between filesystem-safe and shell-safe.
+# For example, in bash, we can create a file:
+#
+# touch ' !#$&'\''()+;,:=@[]'
+#
+# and then create a TAR containing that file:
+#
+# tar cf test.tar ' !#$&'\''()+;,:=@[]'
+#
+# and then remove the file and recreate it by extracting it from the TAR:
+#
+# rm ' !#$&'\''()+;,:=@[]'
+# tar xvf test.tar
+#
+# Extracting the file from the TAR archive alone is not dangerous, but the
+# filename could be considered dangerous for novice shell users or for
+# developers prone to introducing shell-injection vulnerabilities:
+# https://en.wikipedia.org/wiki/Code_injection#Shell_injection
+#
+# SAFE_FILESYSTEM_CHARACTERS = " !#$&'()+,:;=@[]"
+SAFE_FILESYSTEM_CHARACTERS = ""
+
+# Convert experiment title spaces to underscores in TARs and SFTP:
+EXP_SPACES_TO_UNDERSCORES = True
+
+# Convert dataset description spaces to underscores in TARs and SFTP:
+DATASET_SPACES_TO_UNDERSCORES = True
 
 DEFAULT_ARCHIVE_FORMATS = ['tar']
 '''

--- a/tardis/tardis_portal/tests/test_tar_download.py
+++ b/tardis/tardis_portal/tests/test_tar_download.py
@@ -5,6 +5,7 @@ from tarfile import TarFile
 from tempfile import NamedTemporaryFile
 from urllib import quote
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
@@ -70,10 +71,17 @@ class TarDownloadTestCase(TestCase):
             self.assertEqual(int(response['Content-Length']),
                              os.stat(tarfile.name).st_size)
             tf = TarFile(tarfile.name)
+            if settings.EXP_SPACES_TO_UNDERSCORES:
+                exp_title = self.exp.title.replace(' ', '_')
+            else:
+                exp_title = self.exp.title
+            exp_title = quote(exp_title,
+                              safe=settings.SAFE_FILESYSTEM_CHARACTERS)
             for df in self.dfs:
                 full_path = os.path.join(
-                    self.exp.title.replace(' ', '_'),
-                    quote(self.ds.description, safe=''),
+                    exp_title,
+                    quote(self.ds.description,
+                          safe=settings.SAFE_FILESYSTEM_CHARACTERS),
                     df.directory, df.filename)
                 # docker has a file path limit of ~240 characters
                 if os.environ.get('DOCKER_BUILD', 'false') != 'true':

--- a/tardis/tardis_portal/util.py
+++ b/tardis/tardis_portal/util.py
@@ -132,14 +132,15 @@ def render_public_access_badge(experiment):
             'private': True,
         })
     elif experiment.public_access == experiment.PUBLIC_ACCESS_NONE and\
-       experiment.is_publication() and not experiment.is_publication_draft():
+            experiment.is_publication() and\
+            not experiment.is_publication_draft():
         return render_mustache('tardis_portal/badges/public_access', {
             'title': 'No public access, awaiting approval',
             'label': '[PUBLICATION] Awaiting approval',
             'private': True,
         })
     elif experiment.public_access == experiment.PUBLIC_ACCESS_NONE and\
-       experiment.is_publication_draft():
+            experiment.is_publication_draft():
         return render_mustache('tardis_portal/badges/public_access', {
             'title': 'No public access',
             'label': '[PUBLICATION] Draft',
@@ -162,14 +163,6 @@ def render_public_access_badge(experiment):
             'label': 'Public',
             'public': True,
         })
-
-
-def sanitise_name(name):
-    return quote(name.replace(' ', '_').replace('/', ':'), safe='')
-
-
-def dirname_with_id(obj_name, obj_id):
-    return "%s_%d" % (sanitise_name(obj_name), obj_id)
 
 
 def split_path(p):

--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -32,11 +32,11 @@ from tardis.tardis_portal.auth.decorators import (
     has_experiment_download_access, has_experiment_write, has_dataset_write)
 from tardis.tardis_portal.auth.localdb_auth import django_user
 from tardis.tardis_portal.forms import ExperimentForm, DatasetForm
-from tardis.tardis_portal.models import Experiment, Dataset, DataFile, ObjectACL
+from tardis.tardis_portal.models import Experiment, Dataset, DataFile, \
+    ObjectACL
 from tardis.tardis_portal.shortcuts import render_response_index, \
     return_response_error, return_response_not_found, get_experiment_referer, \
     render_response_search
-from tardis.tardis_portal.util import dirname_with_id
 from tardis.tardis_portal.views.utils import (
     _redirect_303, _add_protocols_and_organizations, HttpResponseSeeAlso)
 
@@ -52,8 +52,8 @@ def site_routed_view(request, _default_view, _site_mappings, *args, **kwargs):
     default.
 
     The intention is to define {site: view} mappings in settings.py, and use
-    this wrapper view in urls.py to allow a single URL to be routed to different
-    views depending on the Site in the request.
+    this wrapper view in urls.py to allow a single URL to be routed to
+    different views depending on the Site in the request.
 
     :param request: a HTTP request object
     :type request: :class:`django.http.HttpRequest`
@@ -162,8 +162,8 @@ class IndexView(TemplateView):
         The index view, intended to render the front page of the MyTardis site
         listing recent experiments.
 
-        This default view can be overriden by defining a dictionary INDEX_VIEWS in
-        settings which maps SITE_ID's or domain names to an alternative view
+        This default view can be overriden by defining a dictionary INDEX_VIEWS
+        in settings which maps SITE_ID's or domain names to an alternative view
         function (similar to the DATASET_VIEWS or EXPERIMENT_VIEWS overrides).
 
         :param request: a HTTP request object
@@ -298,8 +298,8 @@ class DatasetView(TemplateView):
         The index view, intended to render the front page of the MyTardis site
         listing recent experiments.
 
-        This default view can be overriden by defining a dictionary INDEX_VIEWS in
-        settings which maps SITE_ID's or domain names to an alternative view
+        This default view can be overriden by defining a dictionary INDEX_VIEWS
+        in settings which maps SITE_ID's or domain names to an alternative view
         function (similar to the DATASET_VIEWS or EXPERIMENT_VIEWS overrides).
 
         :param request: a HTTP request object
@@ -443,9 +443,10 @@ class ExperimentView(TemplateView):
         c['has_download_permissions'] = \
             authz.has_experiment_download_access(request, experiment.id)
         if request.user.is_authenticated():
-            c['is_owner'] = authz.has_experiment_ownership(request, experiment.id)
-            c['has_read_or_owner_ACL'] = authz.has_read_or_owner_ACL(request,
-                                                                     experiment.id)
+            c['is_owner'] = \
+                authz.has_experiment_ownership(request, experiment.id)
+            c['has_read_or_owner_ACL'] = \
+                authz.has_read_or_owner_ACL(request, experiment.id)
 
         # Enables UI elements for the publication form
         c['pub_form_enabled'] = 'tardis.apps.publication_forms' in \
@@ -482,10 +483,12 @@ class ExperimentView(TemplateView):
             {'name': 'Description',
              'viewfn': 'tardis.tardis_portal.views.experiment_description'},
             {'name': 'Metadata',
-             'viewfn': 'tardis.tardis_portal.views.retrieve_experiment_metadata'},
+             'viewfn':
+             'tardis.tardis_portal.views.retrieve_experiment_metadata'},
             {'name': 'Sharing', 'viewfn': 'tardis.tardis_portal.views.share'},
             {'name': 'Transfer Datasets',
-             'viewfn': 'tardis.tardis_portal.views.experiment_dataset_transfer'},
+             'viewfn':
+             'tardis.tardis_portal.views.experiment_dataset_transfer'},
         ]
         appnames = []
         appurls = []
@@ -494,7 +497,8 @@ class ExperimentView(TemplateView):
             try:
                 appnames.append(app['name'])
                 if 'viewfn' in app:
-                    appurls.append(reverse(app['viewfn'], args=[experiment.id]))
+                    appurls.append(reverse(app['viewfn'],
+                                   args=[experiment.id]))
                 elif 'url' in app:
                     appurls.append(app['url'])
             except:
@@ -592,6 +596,7 @@ def sftp_access(request):
     :param request: HttpRequest
     :return: HttpResponse
     """
+    from tardis.tardis_portal.download import make_mapper
     object_type = request.GET.get('object_type')
     object_id = request.GET.get('object_id')
     sftp_start_dir = ''
@@ -616,12 +621,13 @@ def sftp_access(request):
             if has_experiment_download_access(request, exp.id):
                 allowed_exps.append(exp)
         if len(allowed_exps) > 0:
+            path_mapper = make_mapper(settings.DEFAULT_PATH_MAPPER,
+                                      rootdir=None)
             exp = allowed_exps[0]
             path_parts = ['/home', request.user.username, 'experiments',
-                          dirname_with_id(exp.title, exp.id)]
+                          path_mapper(exp)]
             if dataset is not None:
-                path_parts.append(
-                    dirname_with_id(dataset.description, dataset.id))
+                path_parts.append(path_mapper(dataset))
             if datafile is not None:
                 path_parts.append(datafile.directory)
             sftp_start_dir = path.join(*path_parts)

--- a/tardis/tardis_portal/views/utils.py
+++ b/tardis/tardis_portal/views/utils.py
@@ -60,7 +60,7 @@ def _add_protocols_and_organizations(request, collection_object, c):
     from tardis.tardis_portal.download import get_download_organizations
     c['organization'] = get_download_organizations()
     c['default_organization'] = getattr(
-        settings, 'DEFAULT_ARCHIVE_ORGANIZATION', 'classic')
+        settings, 'DEFAULT_PATH_MAPPER', 'classic')
 
 
 def __getFilteredDatafiles(request, searchQueryType, searchFilterData):


### PR DESCRIPTION
There are various places where urllib.quote is used with safe='', implying that no characters are safe to leave unencoded, but as mentioned in https://github.com/mytardis/mytardis/issues/819, some characters like spaces are actually safe for file paths within TARs and SFTP views.

The aim of the pull request is to:

1. Add flexibility to tardis/default_settings/downloads.py, so that MyTardis admins can specify which characters they consider to be safe for file paths in TARs and SFTP views.

2. Encourage more use of the "ARCHIVE_FILE_MAPPERS" (which I propose renaming to "DOWNLOAD_PATH_MAPPERS") in both the TAR downloads and the SFTP view.  Using the default ("deep-storage") mapper is nice because it can be configured in settings.py, unlike the hard-coded sanitise_name and dirname_with_id methods in tardis/tardis_portal/util.py

3. Make tardis/tardis_portal/download.py's make_mapper method (formerly _make_mapper) accessible from outside the download.py module, i.e. in the sftp.py module.

While checking that I didn't break any PEP8 stuff in the files I modified, I found some existing PEP8 issues (e.g. lines longer than 80 characters) which I fixed.

REFERENCES

https://kb.acronis.com/content/39790
https://support.apple.com/en-au/HT202808
http://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names
http://stackoverflow.com/questions/2021624/string-sanitizer-for-filename
https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters