### PR TITLE
Fixing issue triggered by PR 854 (Font Awesome upgrade).

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/ajax/datafile_list.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/datafile_list.html
@@ -57,7 +57,7 @@
                     Select: <a class="dataset_selector_all btn btn-mini">All</a> / <a class="dataset_selector_none btn btn-mini">None</a>
                     <div class="pull-right">
                         <button type="submit" class="btn btn-mini download-selected">
-                            <i class="fa fa-download-alt"></i>
+                            <i class="fa fa-download"></i>
                             Download Selected Files
                         </button>
                         <input type="hidden" name="comptype" value="{{default_format}}"/>
@@ -128,7 +128,7 @@
                             <a class="btn{% if datafile.is_online %}" title="Download"
                                {% else %} archived-file disabled"{% endif %}
                                href="{{ datafile.get_download_url }}">
-                                <i class="fa fa-download-alt fa-lg"></i>
+                                <i class="fa fa-download fa-lg"></i>
                             </a>
                         {% endif %}
                         {% if has_write_permissions and not immutable %}

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_datasets.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_datasets.html
@@ -8,7 +8,7 @@
   {% if has_download_permissions or has_write_permissions %}
     {% if has_download_permissions %}
       <button type="submit" class="btn btn-mini download-selected">
-        <i class="fa fa-download-alt"></i>
+        <i class="fa fa-download"></i>
         Download Selected
       </button>
       <input type="hidden" name="comptype" value="{{default_format}}"/>

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_description.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_description.html
@@ -108,7 +108,7 @@
         {% for o in organization %}
           <a class="btn btn-primary btn-mini" href="{{p.1}}{{o}}"
              title="Download Entire Experiment as {{p.0|upper}} with {{o}} organization">
-            <i class="fa fa-download-alt"></i>
+            <i class="fa fa-download"></i>
             {% if o == default_organization %}
             {{p.0|upper}}
             {% else %}
@@ -121,7 +121,7 @@
       {% for p in protocol %}
         <a class="btn btn-primary btn-mini" href="{{p.1}}"
            title="Download Entire Experiment as {{p.0|upper}}">
-          <i class="fa fa-download-alt"></i>
+          <i class="fa fa-download"></i>
           {{p.0|upper}}
         </a>
       {% endfor %}

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/owned_exps_list.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/owned_exps_list.html
@@ -80,7 +80,7 @@
                {% if forloop.first %}
                  <a class="dllink" href="{{dlurl}}"
                     title="Download Entire Experiment as {{dltype}}">
-                   <i class="fa fa-download-alt"></i>
+                   <i class="fa fa-download"></i>
                    <em>Download data as .{{dltype}}</em>
                  </a>
                {% endif %}

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/parameters.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/parameters.html
@@ -17,7 +17,7 @@
       <a  class="btn"
           href="{{ datafile.get_download_url }}"
           title="Download">
-          <i class="fa fa-download-alt fa-lg"></i>
+          <i class="fa fa-download fa-lg"></i>
       </a>
       {% endif %}
       {% if has_write_permissions and not immutable %}

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/shared_exps_list.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/shared_exps_list.html
@@ -70,7 +70,7 @@
                {% if forloop.first %}
                  <a class="dllink" href="{{dlurl}}"
                     title="Download Entire Experiment as {{dltype}}">
-                   <i class="fa fa-download-alt"></i>
+                   <i class="fa fa-download"></i>
                    <em>Download data as .{{dltype}}</em>
                  </a>
                {% endif %}

--- a/tardis/tardis_portal/templates/tardis_portal/index.html
+++ b/tardis/tardis_portal/templates/tardis_portal/index.html
@@ -59,7 +59,7 @@
 			{% if forloop.first %}
 			  <a class="dllink" href="{{dlurl}}"
 			     title="Download Entire Experiment as {{dltype}}">
-			    <i class="fa fa-download-alt"></i>
+			    <i class="fa fa-download"></i>
 			    <em>Download data as .{{dltype}}</em>
 			  </a>
 			{% endif %}
@@ -147,7 +147,7 @@
 		    {% if forloop.first %}
 		      <a class="dllink" href="{{dlurl}}"
 			 title="Download Entire Experiment as {{dltype}}">
-			<i class="fa fa-download-alt"></i>
+			<i class="fa fa-download"></i>
 			<em>Download data as .{{dltype}}</em>
 		      </a>
 		    {% endif %}

--- a/tardis/tardis_portal/templates/tardis_portal/public_data.html
+++ b/tardis/tardis_portal/templates/tardis_portal/public_data.html
@@ -69,7 +69,7 @@
 		    {% if forloop.first %}
 		      <a class="dllink" href="{{dlurl}}"
 			 title="Download Entire Experiment as {{dltype}}">
-			<i class="fa fa-download-alt"></i>
+			<i class="fa fa-download"></i>
 			<em>Download data as .{{dltype}}</em>
 		      </a>
 		    {% endif %}

--- a/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
@@ -563,7 +563,7 @@ $('#modal-metadata .submit-button').live('click', function() {
                             {% for o in organization %}
                                 <a class="btn btn-primary btn-mini" href="{{p.1}}{{o}}"
                                    title="Download Entire Experiment as {{p.0|upper}} with {{o}} organization">
-                                    <i class="fa fa-download-alt"></i>
+                                    <i class="fa fa-download"></i>
                                     {% if o == default_organization %}
                                         {{p.0|upper}}
                                     {% else %}
@@ -576,7 +576,7 @@ $('#modal-metadata .submit-button').live('click', function() {
                         {% for p in protocol %}
                             <a class="btn btn-primary btn-mini" href="{{p.1}}"
                                title="Download Entire Dataset as {{p.0|upper}}">
-                                <i class="fa fa-download-alt"></i>
+                                <i class="fa fa-download"></i>
                                 {{p.0|upper}}
                             </a>
                         {% endfor %}


### PR DESCRIPTION
icon-download-alt should have been replaced by fa-download, but in some cases it was
incorrectly replaced by fa-download-alt which doesn't exist in Font Awesome 4.7.0