### PR TITLE
Fixing autocache's task name. The convention is that tasks which

### DIFF
--- a/tardis/tardis_portal/tasks.py
+++ b/tardis/tardis_portal/tasks.py
@@ -60,7 +60,7 @@ def ingest_received_files():
         sbox_move_to_master.delay(box.id)
 
 
-@task(name="tardis_portal.storage_box.autocache", ignore_result=True)
+@task(name="tardis_portal.autocache", ignore_result=True)
 def autocache():
     init_filters()
     from tardis.tardis_portal.models import StorageBox


### PR DESCRIPTION
can be run without arguments like ingest_received_files just have
the "tardis_portal." namespace.  The "tardis_portal.storage_box."
namespace is used for tasks which require a storage box ID as their
first argument.