### PR TITLE
Removing dataset.is_online check because it contributes significantly

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
@@ -556,7 +556,7 @@ $('#modal-metadata .submit-button').live('click', function() {
 <div class="row-fluid">
     <div class="span12">
         {% block downloads %}
-            {% if has_download_permissions and dataset.is_online %}
+            {% if has_download_permissions %}
                 <p><b>Download Dataset:</b>
                     {% if organization|length > 1 %}
                         {% for p in protocol %}
@@ -587,16 +587,6 @@ $('#modal-metadata .submit-button').live('click', function() {
                     <a class="btn btn-primary btn-mini"
                        href="{% url 'tardis_portal.dataset_checksums' dataset.id %}"
                        title="Download MD5 checksums for all files in this Dataset">MD5</a>
-                </p>
-            {%  elif has_download_permissions and not dataset.is_online %}
-                <p>Some or all files in this dataset are archived.
-                <a href="{% url "cache_dataset" dataset.id %}"
-                   id="request-fast-access"
-                   class="btn btn-success btn-mini">Retrieve All
-                    Files</a>
-                <a class="btn btn-primary btn-mini"
-                   href="{% url 'tardis_portal.dataset_checksums' dataset.id %}"
-                   title="Download MD5 checksums for all files in this Dataset">MD5</a>
                 </p>
             {% endif %}
         {% endblock downloads %}


### PR DESCRIPTION
to slow page loading for large datasets, as discussed here:
https://github.com/mytardis/mytardis/issues/595

Instead of trying to check the status of every file in the dataset
when the page loads, we can have the ajax check only the current
page of displayed files.

Eventually we want a better user experience for tape recalls, but
the "Some or all files in this dataset are archived" warning resulting
from the dataset.is_online check has not proved useful enough to
justify the slow page loading time.

As noted in the linked GitHub issue, it may be possible to
do the dataset.is_online query more efficiently with aggregate /
group by queries, but personally I don't think it's worth the
trouble.

It would be possible to write an asynchronous task to check datasets
periodically and add some metadata indicating whether their files
are all available on disk, or whether some of all are on tape, but
that is beyond the scope of this pull request.