### PR TITLE
Loading of dataset view pages has been slow for users with access

### DIFF
--- a/tardis/tardis_portal/auth/decorators.py
+++ b/tardis/tardis_portal/auth/decorators.py
@@ -46,17 +46,7 @@ def get_accessible_experiments(request):
 
 def get_accessible_experiments_for_dataset(request, dataset_id):
     experiments = Experiment.safe.all(request.user)
-
-    # probably a much cleverer way of writing this with safe
-    experiment_dataset_access = []
-    for experiment in experiments:
-        experiment_dataset = Experiment.objects.filter(
-            id=experiment.id,
-            datasets__in=[dataset_id])
-        if experiment_dataset.count():
-            experiment_dataset_access.append(experiment_dataset[0])
-
-    return experiment_dataset_access
+    return experiments.filter(datasets__id=dataset_id)
 
 
 def get_shared_experiments(request):


### PR DESCRIPTION
to a large number of experiments because
get_accessible_experiments_for_dataset is slow because it uses a
for loop instead of a QuerySet filter.  This commit modifies the
get_accessible_experiment_for_dataset method to use a faster method
to get all of the experiments accessible to the current user
containing the given dataset ID.