### PR TITLE
Workaround for issue where failing thumbnail generation in the sequence

### DIFF
--- a/tardis/tardis_portal/iiif.py
+++ b/tardis/tardis_portal/iiif.py
@@ -3,6 +3,7 @@ import mimetypes
 from StringIO import StringIO
 
 from wand.exceptions import MissingDelegateError
+from wand.exceptions import CoderError
 from wand.image import Image
 
 from lxml import etree
@@ -177,6 +178,8 @@ def download_image(request, datafile_id, region, size, rotation,
     except MissingDelegateError:
         if format:
             return _invalid_media_response()
+        return HttpResponseNotFound()
+    except CoderError:
         return HttpResponseNotFound()
     except ValueError:
         return HttpResponseNotFound()

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/owned_exps_list.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/owned_exps_list.html
@@ -107,7 +107,7 @@
                    <a class="thumbnail" href="{% url 'tardis.tardis_portal.download.view_datafile' datafile.id %}">{% url 'tardis.tardis_portal.iiif.download_image' datafile_id=datafile.id region='full' size=',50' rotation=0 quality='native' format='jpg' as thumbnail %}
                    <img alt="Thumbnail for Datafile #{{datafile.id}}"
                         src="{{ thumbnail }}"
-                        onerror="$(this).hide()"/></a>
+                        onerror="$(this).parent().parent().hide()"/></a>
                  </li>
                  {% if forloop.last %}
                    </ul>

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/shared_exps_list.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/shared_exps_list.html
@@ -97,7 +97,7 @@
                    <a class="thumbnail" href="{% url 'tardis.tardis_portal.download.view_datafile' datafile.id %}">{% url 'tardis.tardis_portal.iiif.download_image' datafile_id=datafile.id region='full' size=',50' rotation=0 quality='native' format='jpg' as thumbnail %}
                    <img alt="Thumbnail for Datafile #{{datafile.id}}"
                         src="{{ thumbnail }}"
-                        onerror="$(this).hide()"/></a>
+                        onerror="$(this).parent().parent().hide()"/></a>
                  </li>
                  {% if forloop.last %}
                    </ul>

--- a/tardis/tardis_portal/templates/tardis_portal/index.html
+++ b/tardis/tardis_portal/templates/tardis_portal/index.html
@@ -88,7 +88,7 @@
 			    <a class="thumbnail" href="{% url 'tardis.tardis_portal.download.view_datafile' datafile.id %}">{% url 'tardis.tardis_portal.iiif.download_image' datafile_id=datafile.id region='full' size=',50' rotation=0 quality='native' format='jpg' as thumbnail %}
 			    <img alt="Thumbnail for Datafile #{{datafile.id}}"
 				 src="{{ thumbnail }}"
-				 onerror="$(this).hide()"/></a>
+				 onerror="$(this).parent().parent().hide()"/></a>
 			  </li>
 			  {% if forloop.last %}
 			    </ul>


### PR DESCRIPTION
of 5 thumbnails for each dataset leaves a tiny square which when clicked
on shows a 404 or 500 error.

Previously, just the \<img\> tag was hidden, now the \<li\> tag which contains the \<img\> tag is hidden.

The real issue is that libtiff (as used by ImagMagick / Wand) is not equipped to generate thumbnails for some TIFF images, and shouldn't really be attempting this at response time - it should be done asynchronously, e.g. using Bioformats.  But given that Bioformats is not part of the core MyTardis repository yet, the built-in thumbnail generation can remain with workarounds like this until we have time to review it properly.