### PR TITLE
Fix for a bug introduced when pagination was added to "My Data" page,

### DIFF
--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -364,30 +364,9 @@ def my_data(request):
     shared_experiments = \
         Experiment.safe.shared(request.user).order_by('-update_time')
 
-    try:
-        page_number = int(request.GET.get('page', '1'))
-    except ValueError:
-        page_number = 1
-
-    owned_paginator = \
-        Paginator(owned_experiments, settings.OWNED_EXPS_PER_PAGE)
-    try:
-        owned_exps_page = owned_paginator.page(page_number)
-    except (EmptyPage, InvalidPage):
-        owned_exps_page = owned_paginator.page(owned_paginator.num_pages)
-
-    shared_paginator = \
-        Paginator(shared_experiments, settings.SHARED_EXPS_PER_PAGE)
-    try:
-        shared_exps_page = shared_paginator.page(page_number)
-    except (EmptyPage, InvalidPage):
-        shared_exps_page = shared_paginator.page(owned_paginator.num_pages)
-
     c = {
-        'owned_experiments': owned_exps_page,
-        'owned_paginator': owned_paginator,
-        'shared_experiments': shared_exps_page,
-        'shared_paginator': shared_paginator
+        'owned_experiments': owned_experiments,
+        'shared_experiments': shared_experiments
     }
     return HttpResponse(render_response_index(
         request, 'tardis_portal/my_data.html', c))


### PR DESCRIPTION
where the headings e.g. "25 Experiments You Own" were replaced by
"Experiment You Own" because the context data was not being correctly
supplied to the template.  The pagination objects are not needed
in the "My Data" template itself, only in the ajax-loaded templates
called by the Javascript in the "My Data" template.