### PR TITLE
There are other Wand exceptions which can be raised for unrecognized

### DIFF
--- a/tardis/tardis_portal/iiif.py
+++ b/tardis/tardis_portal/iiif.py
@@ -2,8 +2,7 @@ import json
 import mimetypes
 from StringIO import StringIO
 
-from wand.exceptions import MissingDelegateError
-from wand.exceptions import CoderError
+from wand.exceptions import WandException
 from wand.image import Image
 
 from lxml import etree
@@ -175,11 +174,7 @@ def download_image(request, datafile_id, region, size, rotation,
                 else:
                     patch_cache_control(response, private=True, max_age=MAX_AGE)
                 return response
-    except MissingDelegateError:
-        if format:
-            return _invalid_media_response()
-        return HttpResponseNotFound()
-    except CoderError:
+    except WandException:
         return HttpResponseNotFound()
     except ValueError:
         return HttpResponseNotFound()


### PR DESCRIPTION
TIFF formats besides MissingDelegateError and CoderError, e.g.
DelegateError - for a comprehensive list, see
https://github.com/dahlia/wand/blob/master/wand/exceptions.py#L53

So it makes more sense to catch WandException rather than specific
exception classes derived from WandException.

This follows on from https://github.com/mytardis/mytardis/pull/953