### PR TITLE
Readme rewrite

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,9 +78,21 @@ Known deployments
 Related Projects and Repositories
 ---------------------------------
 - MyData: https://github.com/mytardis/mydata
+
+  - A desktop application for managing uploads to MyTardis
 - NIF ImageTrove: https://github.com/NIF-au/imagetrove
+
+  - A tool for ingesting and archiving NIF datasets, including
+    - Web front end: `MyTardis <http://mytardis.org/>`_
+    - A DICOM server: `DICOM <http://dicom.offis.de/dcmtk.php.en>`_
+    - A dataset uploader: `imagetrove-uploader <https://github.com/NIF-au/imagetrove-uploader>`_
+    - Federated authentication with the Australian Access Federation's `Rapid Connect <https://rapid.aaf.edu.au>`_ service
+- NIF ImageTrove Docker deployment: https://github.com/UWA-FoS/docker-mytardis
+
+  - For ease of deployment, all of ImageTrove's components are packaged into a Docker container.
 - NIF Trusted Data Repositories: https://github.com/NIF-au/TDR
-- Docker deployment: https://github.com/UWA-FoS/docker-mytardis
+
+  - Delivering durable, reliable, high-quality image data
 
 Releases
 --------

--- a/README.rst
+++ b/README.rst
@@ -30,13 +30,13 @@ storage, data access, collaboration and data publication.
 
 Key features for users
 ----------------------
-The MyTardis data management platform is a software solution that manages research data and the associated metadata. MyTardis handles the underlying storage to ensure that data is securely archived and provides access to the data through a web portal. You can also access your data using an SFTP client like `Cyberduck <https://cyberduck.io/>`_.
+The MyTardis data management platform is a software solution that manages research data and the associated metadata. MyTardis handles the underlying storage to ensure that data is securely archived and provides access to the data through a web portal. Data hosted in MyTardis can also be accessed via SFTP.
 
 `Read more... <http://www.mytardis.org/introduction/>`_
 
 Key features for instrument facilities
 --------------------------------------
-MyTardis takes care of distributing data to your users. Its instrument integration technology takes care of securely and automatically shifting data from instrument to repository, accessible by the right users, in real-time.
+MyTardis takes care of distributing data to your users. Its instrument integration technology takes care of securely and automatically shifting data from instrument to repository and makes it accessible by the right users.
 
 `Read more... <http://www.mytardis.org/for-facilities/>`_
 

--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ Known deployments
 - Store.Monash: https://store.erc.monash.edu
 - NIF ImageTrove: https://imagetrove.cai.uq.edu.au/
 - MHTP Medical Genomics: https://mhtp-seq.erc.monash.edu/
+- ANSTO: https://tardis.nbi.ansto.gov.au/
 - Monash MyTardis Demo: https://mytardisdemo.erc.monash.edu/
 
 Related Projects and Repositories

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ MyTardis is mostly written in the `Python programming language <https://www.pyth
 
 To set up and manage these services we employ the `SaltStack <https://saltstack.com/>`_ orchestration software and cloud technologies.
 
-_`Read more...`: http://www.mytardis.org/for-developers/
+`Read more... <http://www.mytardis.org/for-developers/>`_
 
 Find out more
 -------------

--- a/README.rst
+++ b/README.rst
@@ -68,29 +68,29 @@ The wiki at https://github.com/mytardis/mytardis/wiki includes
 
 Known deployments
 -----------------
-- Store.Synchrotron: https://store.synchrotron.org.au/
-- Store.Monash: https://store.erc.monash.edu
-- NIF ImageTrove: https://imagetrove.cai.uq.edu.au/
-- MHTP Medical Genomics: https://mhtp-seq.erc.monash.edu/
-- ANSTO: https://tardis.nbi.ansto.gov.au/
-- Monash MyTardis Demo: https://mytardisdemo.erc.monash.edu/
+- **Store.Synchrotron**: https://store.synchrotron.org.au/
+- **Store.Monash**: https://store.erc.monash.edu
+- **NIF ImageTrove**: https://imagetrove.cai.uq.edu.au/
+- **MHTP Medical Genomics**: https://mhtp-seq.erc.monash.edu/
+- **ANSTO**: https://tardis.nbi.ansto.gov.au/
+- **Monash MyTardis Demo**: https://mytardisdemo.erc.monash.edu/
 
 Related projects and repositories
 ---------------------------------
-- MyData: https://github.com/mytardis/mydata
+- **MyData**: https://github.com/mytardis/mydata
 
   - A desktop application for managing uploads to MyTardis
-- NIF ImageTrove: https://github.com/NIF-au/imagetrove
+- **NIF ImageTrove**: https://github.com/NIF-au/imagetrove
 
   - A tool for ingesting and archiving NIF datasets, including
     - Web front end: `MyTardis <http://mytardis.org/>`_
     - A DICOM server: `DICOM <http://dicom.offis.de/dcmtk.php.en>`_
     - A dataset uploader: `imagetrove-uploader <https://github.com/NIF-au/imagetrove-uploader>`_
     - Federated authentication with the Australian Access Federation's `Rapid Connect <https://rapid.aaf.edu.au>`_ service
-- NIF ImageTrove Docker deployment: https://github.com/UWA-FoS/docker-mytardis
+- **NIF ImageTrove Docker deployment**: https://github.com/UWA-FoS/docker-mytardis
 
   - For ease of deployment, all of ImageTrove's components are packaged into a Docker container.
-- NIF Trusted Data Repositories: https://github.com/NIF-au/TDR
+- **NIF Trusted Data Repositories**: https://github.com/NIF-au/TDR
 
   - Delivering durable, reliable, high-quality image data
 

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Known deployments
 - ANSTO: https://tardis.nbi.ansto.gov.au/
 - Monash MyTardis Demo: https://mytardisdemo.erc.monash.edu/
 
-Related Projects and Repositories
+Related projects and repositories
 ---------------------------------
 - MyData: https://github.com/mytardis/mydata
 

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Related projects and repositories
   - A tool for ingesting and archiving NIF datasets, including
   
     - Web front end: `MyTardis <http://mytardis.org/>`_
-    - A DICOM server: `DICOM <http://dicom.offis.de/dcmtk.php.en>`_
+    - A DICOM server: `DICOM ToolKit <http://dicom.offis.de/dcmtk.php.en>`_
     - A dataset uploader: `imagetrove-uploader <https://github.com/NIF-au/imagetrove-uploader>`_
     - Federated authentication with the Australian Access Federation's `Rapid Connect <https://rapid.aaf.edu.au>`_ service
 - **NIF ImageTrove Docker deployment**: https://github.com/UWA-FoS/docker-mytardis

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,7 @@ Related projects and repositories
 - **NIF ImageTrove**: https://github.com/NIF-au/imagetrove
 
   - A tool for ingesting and archiving NIF datasets, including
+  
     - Web front end: `MyTardis <http://mytardis.org/>`_
     - A DICOM server: `DICOM <http://dicom.offis.de/dcmtk.php.en>`_
     - A dataset uploader: `imagetrove-uploader <https://github.com/NIF-au/imagetrove-uploader>`_

--- a/README.rst
+++ b/README.rst
@@ -18,24 +18,33 @@ MyTardis
   :target: https://coveralls.io/r/mytardis/mytardis?branch=develop
   :alt: Coveralls Badge
 
-MyTardis is a multi-institutional collaborative venture that facilitates the
-archiving and sharing of data and metadata collected at major facilities such
-as the Australian Synchrotron and ANSTO and within Institutions.
+MyTardis began at Monash University to solve the problem of users needing to
+store large datasets and share them with collaborators online. Its particular
+focus is on integration with scientific instruments, instrument facilities and
+research storage and computing infrastructure; to address the challenges of data
+storage, data access, collaboration and data publication.
 
-An example of the benefit of a system such as MyTardis in the protein
-crystallography community is that while the model coordinates and (less often)
-the structure factors (processed experimental data) are stored in the
-community Protein Data Bank (PDB) the raw diffraction data is often not
-available. There are several reasons why this is important, which can be
-summarised as:
+`Read more... <http://www.mytardis.org/about/>`_
 
--  The availability of raw data is extremely useful for the development
-   of improved methods of image analysis and data processing.
+Key features for users
+----------------------
+The MyTardis data management platform is a software solution that manages research data and the associated metadata. MyTardis handles the underlying storage to ensure that data is securely archived and provides access to the data through a web portal. You can also access your data using an SFTP client like `Cyberduck <https://cyberduck.io/>`_.
 
--  Fostering the archival of raw data at an institutional level is one
-   the best ways of ensuring that this data is not lost (laboratory
-   archives are typically volatile).
+`Read more... <http://www.mytardis.org/introduction/>`_
 
+Key features for instrument facilities
+--------------------------------------
+MyTardis takes care of distributing data to your users. Its instrument integration technology takes care of securely and automatically shifting data from instrument to repository, accessible by the right users, in real-time.
+
+`Read more... <http://www.mytardis.org/for-facilities/>`_
+
+Developing for MyTardis
+-----------------------
+MyTardis is mostly written in the `Python programming language <https://www.python.org/>`_ and is built on top of the `Django web framework <https://www.djangoproject.com/>`_. A complete installation of the service also includes an `Elasticsearch <https://www.elastic.co/>`_ index, a `RabbitMQ <https://www.rabbitmq.com/>`_-based task queue, an `Nginx <http://nginx.org/>`_ server, and a `PostgreSQL <http://www.postgresql.org/>`_ database.
+
+To set up and manage these services we employ the `SaltStack <https://saltstack.com/>`_ orchestration software and cloud technologies.
+
+_`Read more...`: http://www.mytardis.org/for-developers/
 
 Find out more
 -------------
@@ -49,6 +58,26 @@ Documentation at http://mytardis.readthedocs.org includes
 - User documentation
 - Administrator documentation
 - Developer documentation
+
+The wiki at https://github.com/mytardis/mytardis/wiki includes
+
+- Links to MyTardis add-ons, including apps and post-save filters
+- Information about MyTardis community events
+
+Known deployments
+-----------------
+- Store.Synchrotron: https://store.synchrotron.org.au/
+- Store.Monash: https://store.erc.monash.edu
+- NIF ImageTrove: https://imagetrove.cai.uq.edu.au/
+- MHTP Medical Genomics: https://mhtp-seq.erc.monash.edu/
+- Monash MyTardis Demo: https://mytardisdemo.erc.monash.edu/
+
+Related Projects and Repositories
+---------------------------------
+- MyData: https://github.com/mytardis/mydata
+- NIF ImageTrove: https://github.com/NIF-au/imagetrove
+- NIF Trusted Data Repositories: https://github.com/NIF-au/TDR
+- Docker deployment: https://github.com/UWA-FoS/docker-mytardis
 
 Releases
 --------

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,8 @@ MyTardis
   :target: https://coveralls.io/r/mytardis/mytardis?branch=develop
   :alt: Coveralls Badge
 
+Overview
+--------
 MyTardis began at Monash University to solve the problem of users needing to
 store large datasets and share them with collaborators online. Its particular
 focus is on integration with scientific instruments, instrument facilities and


### PR DESCRIPTION
Drafting a proposed restructuring of MyTardis's GitHub README for the purpose of:

1. Providing links to related projects such as ImageTrove
2. Listing some known deployments
3. Using mytardis.org to provide introductory text, replacing introductory text which was focused on X-Ray crystallography data.