### PR TITLE
When making an experiment public, ensure that selecting a license

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/ajax/choose_rights.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/choose_rights.html
@@ -118,7 +118,7 @@ $('#legal-section .cancel-button').live("click", function() {
     // Hide any current messages
     $(this).parents('.tab-pane').find('.alert .close').click();
     // Show confirmation window
-    $('#selected-license-text').html($(this).parents('#license-options')
+    $('#selected-license-text').html($(this).parents('.license-option')
            .find('.controls').html());
     $('#legal-section').show();
     $('#license-options').hide();


### PR DESCRIPTION
updates the license text correctly in the Change Public Access dialog.