### PR TITLE
Add dirs, matches count+download to Dataset view

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/ajax/datafile_list.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/datafile_list.html
@@ -35,7 +35,7 @@
 
 {{ paginator_block }}
 
-<p id="filename-search" class="js-required" data-action="/ajax/datafile_list/{{dataset.id}}/" data-method="GET" style="padding: 5px 0 5px 10px; border: 1px solid #DDDDDD;">
+<p id="filename-search" class="js-required" data-action="/ajax/datafile_list/{{dataset.id}}/{% if show_dirs %}?dirs=y{% endif %}" data-method="GET" style="padding: 5px 0 5px 10px; border: 1px solid #DDDDDD;">
   <input id="filename-search-text" style="width: 95%; font-size: 120%; margin-top: 5px;"
       title='Enter part or all of a filename, then press enter. e.g. Enter "175" to show only files containing "175" in their filename.'
       placeholder='Search: Enter part or all of a filename, then press enter.'
@@ -44,6 +44,25 @@
       name="filename"
       onkeypress="javascript:filename_search_handler(event)"
       value="{{filename_search|default:''}}" />
+
+  <form id="matches-download" method="POST" action="{% url 'tardis.tardis_portal.download.streaming_download_datafiles' %}" target="_blank">{% csrf_token %}
+      {% if filename_search %}
+      <div class="row-fluid">
+	<span id="num_search_results">{{ num_search_results|default:'0' }}</span> match{% if not num_search_results or num_search_results != 1 %}es{% endif %}
+	{% if has_download_permissions and num_search_results > 0 %}
+	<div class="pull-right">
+	  <button type="submit" id="download_all_matches_btn" class="btn btn-mini download-selected">
+	    <i class="fa fa-download"></i>
+	    Download All Matches
+	  </button>
+	  <input type="hidden" name="datafileids" id="download_all_matches_ids"/>
+	  <input type="hidden" name="comptype" value="{{default_format}}"/>
+	  <input type="hidden" name="organization" value="{{default_organization}}"/>
+	</div>
+	{% endif %}
+      </div>
+      {% endif %}
+  </form>
 </p>
 
 <form id="datafile-download" method="POST" action="{% url 'tardis.tardis_portal.download.streaming_download_datafiles' %}" target="_blank">{% csrf_token %}
@@ -51,9 +70,13 @@
     <div class="clearfix"></div>
     <table class="datafiles table table-condensed">
         {% if has_download_permissions %}
-            <thead>
+        <thead>
             <tr id="datafile-selectors" class="js-required">
                 <td colspan="3">
+		    <div style="margin-bottom: 1ex;">
+		      Directories: <a id="toggle_dirs_btn" class="btn btn-mini">{% if show_dirs %}Hide{% else %}Show{% endif %}</a>
+		    </div>
+		    {% if has_download_permissions %}
                     Select: <a class="dataset_selector_all btn btn-mini">All</a> / <a class="dataset_selector_none btn btn-mini">None</a>
                     <div class="pull-right">
                         <button type="submit" class="btn btn-mini download-selected">
@@ -62,14 +85,16 @@
                         </button>
                         <input type="hidden" name="comptype" value="{{default_format}}"/>
                         <input type="hidden" name="organization" value="{{default_organization}}"/>
-                    </div></td>
-            </tr>
-            </thead>
+                    </div>
+		    {% endif %}
+		</td>
+	    </tr>
+        </thead>
         {% endif %}
         <tbody>
         {% for datafile in datafiles.object_list %}
             <tr class="datafile search_match_file">
-                <td>
+                <td style="width: 2.5ex;" >
                     {% if has_download_permissions and datafile.verified %}
                         <input type="checkbox" style="" class="datafile_checkbox" name="datafile" value="{{datafile.id}}" />
                     {% endif %}
@@ -79,12 +104,12 @@
                         <a class="filelink datafile_name"
                            href="{{ datafile.get_view_url }}"
                            title="View"
-                           target="_blank">{{ datafile.filename }}</a>
+                           target="_blank">{% if show_dirs %}{{ datafile.file_path }}{% else %}{{ datafile.filename }}{% endif %}</a>
                     {% else %}
                         {% if datafile.verified %}
-                            <span class="datafile_name{% if not datafile.is_online %} archived-file{% endif %}">{{ datafile.filename }}</span>
+                            <span class="datafile_name">{% if not datafile.is_online %} archived-file{% endif %}{% if show_dirs %}{{ datafile.file_path }}{% else %}{{ datafile.filename }}{% endif %}</span>
                         {% else %}
-                            <span class="datafile_name" style="color:red;">{{ datafile.filename }}</span>
+                            <span class="datafile_name" style="color:red;">{% if show_dirs %}{{ datafile.file_path }}{% else %}{{ datafile.filename }}{% endif %}</span>
                         {% endif %}
                     {% endif %}
                     {% if datafile.verified %}

--- a/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
@@ -19,6 +19,58 @@
     jQuery('.dataset_selector_none').live('click', function() {
         $(this).parents('.datafiles').find('.datafile_checkbox').removeAttr("checked");
     });
+    jQuery('#download_all_matches_btn').live('click', function(event) {
+        search_val = $('#filename-search-text').val();
+        if (search_val) {
+            nsr_str = $('#num_search_results').text();
+            if (/^[0-9]+$/.test(nsr_str)) {
+                num_search_results = Number(nsr_str);
+            } else {
+                num_search_results = 0;
+            }
+            // If all the search result ids are already on the page, use them
+            if ($(".datafile").length == num_search_results) {
+		file_checkboxes = $(".datafile_checkbox");
+                data = file_checkboxes.map(function() { return this.value; })
+                                      .get().join(' ');
+                $('#download_all_matches_ids').val(data);
+                $('#matches-download').submit();
+                return;
+            }
+            // Else if all the search result ids aren't on the page, fetch them
+            let url = '{% url 'tardis.tardis_portal.views.retrieve_datafile_search_ids' dataset.id %}';
+            $.ajax({
+              async: false,
+              url: url,
+              data: { 'search' : search_val },
+              success: function (data, textStatus, jqXHR) {
+                $('#download_all_matches_ids').val(data);
+                $('#matches-download').submit();
+              }
+            });
+        }
+    });
+    jQuery('#toggle_dirs_btn').live('click', function() {
+        const
+            pane_wide =   "span12",
+            pane_narrow = "span4";
+        let pane = $('#datafiles-wrapper-pane');
+        let old_width, new_width, params;
+        if (pane.hasClass(pane_wide)) {
+            old_width = pane_wide;
+            new_width = pane_narrow;
+            params = '';
+        } else {
+            old_width = pane_narrow;
+            new_width = pane_wide;
+            params = '?dirs=y';
+        }
+        pane.removeClass(old_width);
+        pane.addClass(new_width);
+        $('#datafiles-pane').html(loadingHTML);
+        url = '{% url 'tardis.tardis_portal.views.retrieve_datafile_list' dataset.id %}' + params;
+        $('#datafiles-pane').load(url);
+    });
 
     function get_new_parameter_name(name)
     {
@@ -212,12 +264,9 @@
             // file selectors
             $(document).find('.dataset_selector_all').click(function() {
                 $(this).parent().find('.datafile_checkbox').attr("checked", "checked");
-
             });
-
             $(document).find('.dataset_selector_none').click(function() {
                 $(this).parent().find('.datafile_checkbox').removeAttr("checked");
-
             });
         });
         return false;
@@ -230,8 +279,26 @@
     e.preventDefault();
     // Build form submission, and reload pane with results
     var form = $('#filename-search');
+    var url = form.attr('data-action');
+    // Keep existing show/hide dirs setting when searching
+    const pane_wide = "span12";
+    let pane = $('#datafiles-wrapper-pane');
+    if (pane.hasClass(pane_wide)) { // show dirs
+        if (!/[?&]dirs=y(&|$)/.test(url)) {
+            if (/[&]/.test(url)) {
+                url = url.replace(/([&])/, '$1dirs=y$1');
+            } else if (/[?]/.test(url)) {
+                url = url.replace(/([?])/, '$1dirs=y&');
+            } else {
+                url += '?dirs=y'
+            }
+        }
+    } else { // do not show dirs
+        url = url.replace(/([?&])dirs=y[&]?/,'$1').replace(/[?&]$/,'');
+    }
+    // Search, reloading pane with new set of matching datafiles
     $.ajax({
-      'url': form.attr('data-action'),
+      'url': url,
       'type': form.attr('data-method'),
       'data': form.children('input').serialize(),
       'success': function(data) {
@@ -551,7 +618,7 @@ $('#modal-metadata .submit-button').live('click', function() {
   </div>
   <hr class="visible-phone"/>
 
-  <div class="span4"> {# side bar #}
+  <div id="datafiles-wrapper-pane" class="span4" style="margin-left: 0">
   <div class="row-fluid">
     <div class="span8">
       <h3 style="display: inline">
@@ -654,7 +721,8 @@ $(document).ready(function(){
     }
   });
 
-  // load datafiles on page load
+  // Load datafiles on page load
+  $('#datafiles-pane').html(loadingHTML);
   $('#datafiles-pane').load('{% url 'tardis.tardis_portal.views.retrieve_datafile_list' dataset.id %}');
 
   // Create a reload event handler

--- a/tardis/tardis_portal/views/ajax_pages.py
+++ b/tardis/tardis_portal/views/ajax_pages.py
@@ -9,7 +9,7 @@ from urllib import urlencode
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.core.paginator import Paginator, EmptyPage, InvalidPage
+from django.core.paginator import Paginator, EmptyPage, InvalidPage, Page
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseNotFound, \
     HttpResponseForbidden
@@ -208,6 +208,43 @@ def retrieve_parameters(request, datafile_id):
                         'tardis_portal/ajax/parameters.html', c))
 
 
+def _get_filepath_query_str(**args):
+    """Generate various raw SQL query strings for DataFile paths (internal)"""
+    where = []
+    tail = []
+    have_dataset = 'dataset' in args
+    have_search = 'search' in args and args['search'] is True
+    file_path_expr = "TRIM(LEADING '/' FROM CONCAT(directory,'/',filename))"
+    collate_expr = ' COLLATE "C"' # Postgres only allows double quoted locale
+    if have_dataset:
+        where = ['dataset_id=' + str(args['dataset'])]
+    if have_search:
+        where += ['POSITION(LOWER(%s) IN LOWER(' + file_path_expr + ')) > 0']
+    if 'count' in args:
+        if 'cols' in args or not have_dataset:
+            return ''          # non-count queries come after a dataset filter
+        cols = ['COUNT(*)']
+    elif 'cols' in args:
+        cols = args['cols']
+        if 'path' in cols:
+            cols.remove('path')
+            cols.insert(0, file_path_expr + collate_expr + ' AS file_path')
+        if 'order' in args:
+            tail += ['ORDER BY ' + file_path_expr + collate_expr]
+        if 'limit' in args:
+            tail += ['LIMIT ' + str(args['limit'])]
+        if 'offset' in args:
+            tail += ['OFFSET ' + str(args['offset'])]
+    else:
+        return ''
+    q = 'SELECT ' + ', '.join(cols) + ' FROM tardis_portal_datafile'
+    if where:
+        q += ' WHERE ' + ' AND '.join(where)
+    if tail:
+        q += ' ' + ' '.join(tail)
+    return q
+
+
 @never_cache  # too complex # noqa
 @authz.dataset_access_required
 def retrieve_datafile_list(
@@ -215,7 +252,6 @@ def retrieve_datafile_list(
         template_name='tardis_portal/ajax/datafile_list.html'):
 
     params = {}
-
     query = None
     highlighted_dsf_pks = []
 
@@ -229,48 +265,97 @@ def retrieve_datafile_list(
         highlighted_dsf_pks = [int(r.pk) for r in results
                                if r.model_name == 'datafile' and
                                r.dataset_id_stored == int(dataset_id)]
-
         params['query'] = query.query_string()
 
     elif 'datafileResults' in request.session and 'search' in request.GET:
         highlighted_dsf_pks = [r.pk
                                for r in request.session['datafileResults']]
 
-    dataset_results = \
-        DataFile.objects.filter(
-            dataset__pk=dataset_id,
-        ).order_by('filename')
+    dataset_results = DataFile.objects.filter(dataset__pk=dataset_id)
 
     if request.GET.get('limit', False) and highlighted_dsf_pks:
         dataset_results = dataset_results.filter(pk__in=highlighted_dsf_pks)
         params['limit'] = request.GET['limit']
 
     filename_search = None
+    num_search_results = None
+    if 'filename' in request.GET:
+        val = request.GET['filename']
+        if val:
+            filename_search = val
+            params['filename'] = val
 
-    if 'filename' in request.GET and request.GET['filename']:
-        filename_search = request.GET['filename']
-        dataset_results = \
-            dataset_results.filter(filename__icontains=filename_search)
-
-        params['filename'] = filename_search
-
-    # pagination was removed by someone in the interface but not here.
-    # need to fix.
-    pgresults = 100
-
-    paginator = Paginator(dataset_results, pgresults)
-
+    results_per_page = 100
     try:
         page = int(request.GET.get('page', '1'))
+        if page < 1:
+            page = 1
     except ValueError:
         page = 1
 
-    # If page request (9999) is out of range, deliver last page of results.
+    if 'dirs' not in request.GET:
+        show_dirs = False
+        if filename_search is not None:
+            dataset_results = \
+                dataset_results.filter(filename__icontains=filename_search)
+            # Defering QuerySet evaluation (num_search_results = len()) until
+            # after sort below eliminates a database query
 
-    try:
-        dataset = paginator.page(page)
-    except (EmptyPage, InvalidPage):
-        dataset = paginator.page(paginator.num_pages)
+        dataset_results = dataset_results.order_by('filename')
+        if filename_search is not None:
+            num_search_results = len(dataset_results)
+
+        # pagination was removed by someone in the interface but not here.
+        # need to fix.
+        paginator = Paginator(dataset_results, results_per_page)
+        # If page request (9999) is out of range, deliver last page of results.
+        try:
+            dataset = paginator.page(page)
+        except (EmptyPage, InvalidPage):
+            dataset = paginator.page(paginator.num_pages)
+    else:
+        show_dirs = True
+        params['dirs'] = request.GET['dirs']
+        if filename_search is not None:
+            query_params = [filename_search]
+        else:
+            query_params = []
+
+        count = 0
+        count_query_str = (
+            _get_filepath_query_str(count=True, dataset=dataset_id,
+                                    search=filename_search is not None))
+        logger.debug("Count query:\n    " + count_query_str + "\n    params='"
+                     + str(query_params) + "'")
+        from django.db import connection
+        with connection.cursor() as cursor:
+            cursor.execute(count_query_str, query_params)
+            row = cursor.fetchone()
+            count = row[0]
+            if filename_search is not None:
+                num_search_results = count
+            logger.debug("Count query: " + str(count) + " matches found")
+        num_pages = (count + results_per_page - 1) / results_per_page
+        if num_pages and page > num_pages:
+            page = num_pages
+
+        query_str = (
+            _get_filepath_query_str(cols=['id','size', 'created_time','path'],
+                                    search=filename_search is not None,
+                                    order=True,
+                                    limit=results_per_page,
+                                    offset=(page - 1) * results_per_page))
+        logger.debug("Paths query:\n    " + query_str + "\n    params='"
+                     + str(query_params) + "'")
+        dataset_results = dataset_results.raw(query_str, query_params)
+
+        # The RawQuerySet returned above doesn't implement length(), so fake an
+        # obj_list for the Paginator and Page used in the Django view template.
+        class RawQueryMinimalObjList(object):
+            def __init__(self, n): self.n = n; self.ordered = True
+            def __len__(self): return self.n
+        paginator = Paginator(RawQueryMinimalObjList(count), results_per_page)
+        dataset = Page(dataset_results, page, paginator)
 
     is_owner = False
     has_download_permissions = authz.has_dataset_download_access(request,
@@ -289,15 +374,43 @@ def retrieve_datafile_list(
         'immutable': immutable,
         'dataset': Dataset.objects.get(id=dataset_id),
         'filename_search': filename_search,
+        'num_search_results': num_search_results,
         'is_owner': is_owner,
         'highlighted_datafiles': highlighted_dsf_pks,
         'has_download_permissions': has_download_permissions,
         'has_write_permissions': has_write_permissions,
         'search_query': query,
+        'show_dirs': show_dirs,
         'params': urlencode(params),
     }
     _add_protocols_and_organizations(request, None, c)
     return HttpResponse(render_response_index(request, template_name, c))
+
+
+@never_cache
+@authz.dataset_access_required
+def retrieve_datafile_search_ids(request, dataset_id):
+    """
+    Return a space-separated list of ids for all DataFiles in the specified
+    Dataset which have a path (directory + '/' + filename) matching the
+    'search' parameter.
+    """
+
+    ids_str = ''
+    search_param = 'search'
+    if search_param in request.GET:
+        search = request.GET[search_param]
+        if search:
+            ids_query = _get_filepath_query_str(dataset=dataset_id, cols=['id'],
+                                                search=True)
+            logger.debug('retrieve_datafile_search_ids("' + search
+                         + '") QUERY:\n    ' + ids_query)
+            datafiles_results = DataFile.objects.raw(ids_query, [search])
+            for row in datafiles_results:
+                if not row.verified: continue
+                row_id_str = str(row.id)
+                ids_str += (' ' + row_id_str) if ids_str else row_id_str
+    return HttpResponse(ids_str)
 
 
 @authz.dataset_write_permissions_required

--- a/tardis/urls.py
+++ b/tardis/urls.py
@@ -196,6 +196,7 @@ ajax_urls = patterns(
     (r'^experiment_metadata/(?P<experiment_id>\d+)/$',
         'retrieve_experiment_metadata'),
     (r'^datafile_list/(?P<dataset_id>\d+)/$', 'retrieve_datafile_list'),
+    (r'^datafile_search/(?P<dataset_id>\d+)/$', 'retrieve_datafile_search_ids'),
     url(r'^cache_dataset/(?P<dataset_id>\d+)/$', 'cache_dataset',
         name='cache_dataset'),
     (r'^user_list/$', 'retrieve_user_list'),


### PR DESCRIPTION
This code sorts A-Z in a block before a-z (collate="C").  It's not ideal but it's a step in the right direction.  See my posts on the MyTardis UWA Slack channel about env["LANG"], collation and sorting file paths.

Sorting properly probably means building a recursive directory tree for each Dataset in a new table, checked / updated every time a newly ingested DataFile is verified.  Without the explicit "C" collation, the sort order used by the database should be a better match to the (internationalised) user's expectations (locale-wise, anyway).  On the bright side, that extra table should make building a tree view of a Dataset's files a lot simpler.

I'd normally move the show_dirs code in ajax_pages.py:retrieve_datafile_list() into a separate function, but I've seen some unexpected behaviour returning Django / MyTardis query results from functions in the past.  With raw SQL added to the mix, I decided not to risk it.

A couple of the automated tests didn't pass (test_get_uploader_by_id, test_post_experiment), but they appeared to be due to my authentication config.