### PR TITLE
A more reliable way of logging client IP addresses in request.log

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -10,6 +10,7 @@ django-celery==3.1.17 # pyup: <4
 django-extensions==1.7.7
 django-form-utils==0.2.0
 django-haystack==2.5.1
+django-ipware==2.0.1
 django-mustachejs==0.6.0
 django-nose==1.4.4
 django-npm==1.0.0

--- a/tardis/tardis_portal/logging_middleware.py
+++ b/tardis/tardis_portal/logging_middleware.py
@@ -33,6 +33,7 @@
 import logging
 
 from django.conf import settings
+from ipware.ip2 import get_client_ip
 
 LOGGING = {
     'version': 1,
@@ -100,7 +101,7 @@ class LoggingMiddleware(object):
             user = request.user
         except:
             user = ''
-        ip = request.META['REMOTE_ADDR']
+        ip = get_client_ip(request)[0]
         method = request.method
         status = response.status_code
         extra = {'ip': ip, 'user': user, 'method': method, 'status': status}
@@ -125,7 +126,7 @@ class LoggingMiddleware(object):
             user = request.user
         except:
             user = ''
-        ip = request.META['REMOTE_ADDR']
+        ip = get_client_ip(request)[0]
         method = request.method
         status = 500
 


### PR DESCRIPTION
The mytardis-app-mydata app has used django-ipware for some time
to log client IP addresses, but the method it has been using -
get_ip is now deprecated in favour of get_client_ip, so it will
soon switch to using get_client_ip too.  The old get_ip method
still exists, so installing the django-ipware version which this
PR adds to requirements-base.txt won't break mytardis-app-mydata.