### PR TITLE
Fix for #998

### DIFF
--- a/docker-test.yml
+++ b/docker-test.yml
@@ -28,3 +28,4 @@ services:
     image: mysql
     environment:
       MYSQL_ROOT_PASSWORD: mysql
+    command: --default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
Passes `--default-authentication-plugin=mysql_native_password` to MySQL docker test to revert MySQL to use previous authentication behaviour