### PR TITLE
Upgrade six and pin html5lib

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -39,5 +39,5 @@ python-dateutil==2.4.0
 -e git+https://github.com/grischa/python-magic.git#egg=python-magic
 pytz==2016.10
 rdflib==4.2.2
-six==1.10.0
+six==1.11.0
 wsgiref==0.1.2

--- a/requirements-osx.txt
+++ b/requirements-osx.txt
@@ -5,3 +5,4 @@ mock==2.0.0
 psycopg2==2.7
 pycrypto==2.6.1
 pystache==0.5.4
+html5lib==0.9999999


### PR DESCRIPTION
This PR addresses #1000 and #1001:
- Upgrade six to 1.11.0
- Pin html5lib to 0.9999999 for Mac OS X