### PR TITLE
Making dataset thumbnails optional

### DIFF
--- a/tardis/default_settings/frontend.py
+++ b/tardis/default_settings/frontend.py
@@ -39,3 +39,4 @@ SHARED_EXPS_PER_PAGE = 20
 
 # Used in "Experiment" view:
 DATASET_ORDERING = 'description'
+SHOW_DATASET_THUMBNAILS = True

--- a/tardis/tardis_portal/jstemplates/tardis_portal/dataset_tile.html
+++ b/tardis/tardis_portal/jstemplates/tardis_portal/dataset_tile.html
@@ -33,16 +33,18 @@
   </p>
 
 </div>
-<div class="pull-left ds-thumb" style="margin-right: 10px">
-  {{#thumbnail}}
-      <img alt="Thumbnail for Dataset #{{ id }}"
-           src="{{ thumbnail }}"
-           onerror="$(this).parent().append('<canvas></canvas>');$(this).remove();"/>
-  {{/thumbnail}}
-  {{^thumbnail}}
-      <canvas style="width: 100px"></canvas>
-  {{/thumbnail}}
-</div>
+{{#show_dataset_thumbnails}}
+  <div class="pull-left ds-thumb" style="margin-right: 10px">
+    {{#thumbnail}}
+        <img alt="Thumbnail for Dataset #{{ id }}"
+             src="{{ thumbnail }}"
+             onerror="$(this).parent().append('<canvas></canvas>');$(this).remove();"/>
+    {{/thumbnail}}
+    {{^thumbnail}}
+        <canvas style="width: 100px"></canvas>
+    {{/thumbnail}}
+  </div>
+{{/show_dataset_thumbnails}}
 <p>
   <a class="dataset-link" href="{{ url }}">
   {{#description}}

--- a/tardis/tardis_portal/views/utils.py
+++ b/tardis/tardis_portal/views/utils.py
@@ -492,6 +492,13 @@ def get_dataset_info(dataset, include_thumbnail=False, exclude=None):  # too com
             and (exclude is None or 'facility' not in exclude)):
             obj['facility'] = dataset.instrument.facility.name
 
+    # Whether dataset thumbnails are enabled, i.e.
+    # include a thumbnail <div> in every tile:
+    obj['show_dataset_thumbnails'] = getattr(
+        settings, "SHOW_DATASET_THUMBNAILS", True)
+
+    # Whether this dataset tile's thumbnail is enabled.
+    # If not, still include a blank thumbnail <div>:
     if include_thumbnail:
         try:
             obj['thumbnail'] = reverse(


### PR DESCRIPTION
Experiment view's page load time is too slow for large numbers of datasets each containing large numbers of image files, so there needs to be a way to disable dataset thumbnail images until we
have a more efficient way of serving them.  The default value of the new SHOW_DATASET_THUMBNAILS setting preserves the existing behaviour.