### PR TITLE
Upgrading Django version (from 1.8.18 to 1.8.19)

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,4 +1,4 @@
-Django==1.8.18 # pyup: >=1.8,<1.9
+Django==1.8.19 # pyup: >=1.8,<1.9
 Wand==0.4.4
 amqp==1.4.9 # pyup: <2
 beautifulsoup4==4.5.3


### PR DESCRIPTION
For upgrading to Django 1.11, see: https://github.com/mytardis/mytardis/pull/991