### PR TITLE
Upgrading django-registration-redux dependency to v1.10

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -13,7 +13,7 @@ django-haystack==2.5.1
 django-mustachejs==0.6.0
 django-nose==1.4.4
 django-npm==1.0.0
-django-registration-redux==1.4
+django-registration-redux==1.10
 # django-tastypie
 -e git+https://github.com/grischa/django-tastypie.git@mytardis-dj1.7#egg=django-tastypie
 django-tastypie-swagger==0.1.4


### PR DESCRIPTION
This PR updates django-registration-redux from 1.4 to 1.10. The latest version of django-registration-redux is actually 2.4, but this is not compatible with MyTardis.