### PR TITLE
html5lib is now installed from requirements-base.txt instead

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -28,7 +28,6 @@ RUN apt-get update && apt-get install \
     python-crypto \
     python-dateutil \
     python-flexmock \
-    python-html5lib \
     python-pip \
     python-pystache \
     python-virtualenv \


### PR DESCRIPTION
See also: https://github.com/mytardis/mytardis/pull/1037