### PR TITLE
Upgrade isodate dependency to 0.6.0 to avoid zeep version incompatibility

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -23,7 +23,7 @@ gunicorn==19.7.0
 gevent==1.2.1
 html2text==2016.9.19
 html5lib==1.0.1
-isodate==0.5.1
+isodate==0.6.0
 pyjwt==1.6.4
 lxml==4.1.1
 nose==1.3.7


### PR DESCRIPTION
`zeep` was recently included to replace `suds`, but `zeep` requires `isodate>=0.5.4`.