### PR TITLE
Switch to installing `psycopg2-binary` via pip

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -14,7 +14,6 @@ RUN apt-get update && apt-get install \
     libxslt1-dev \
     python-dev \
     zlib1g-dev \
-    postgresql-server-dev-all \
     libmysqlclient-dev
 
 ENV WHEELHOUSE=/wheelhouse
@@ -28,5 +27,5 @@ WORKDIR /home/webapp
 
 CMD . /appenv/bin/activate; \
     pip wheel -r requirements.txt; \
-    pip wheel psycopg2 MySQL-python; \
+    pip wheel MySQL-python; \
     pip wheel -e "git+https://github.com/pypa/pip.git#egg=pip"

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -27,5 +27,6 @@ WORKDIR /home/webapp
 
 CMD . /appenv/bin/activate; \
     pip wheel -r requirements.txt; \
+    pip wheel -r requirements-postgres.txt; \
     pip wheel MySQL-python; \
     pip wheel -e "git+https://github.com/pypa/pip.git#egg=pip"

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -10,7 +10,7 @@ RUN patch -N /usr/share/npm/node_modules/npmconf/config-defs.js npm.patch
 USER webapp
 
 RUN . /appenv/bin/activate; \
-    pip install --no-index -f /wheelhouse psycopg2 mysql-python
+    pip install --no-index -f /wheelhouse mysql-python
 RUN . /appenv/bin/activate; \
     pip install coveralls codacy-coverage
 VOLUME /home/webapp/tardis

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -10,6 +10,8 @@ RUN patch -N /usr/share/npm/node_modules/npmconf/config-defs.js npm.patch
 USER webapp
 
 RUN . /appenv/bin/activate; \
+    pip install --no-index -f /wheelhouse -r requirements-postgres.txt
+RUN . /appenv/bin/activate; \
     pip install --no-index -f /wheelhouse mysql-python
 RUN . /appenv/bin/activate; \
     pip install coveralls codacy-coverage

--- a/install-ubuntu-requirements.sh
+++ b/install-ubuntu-requirements.sh
@@ -3,6 +3,6 @@ apt-get install git ipython libldap2-dev libsasl2-dev \
   libssl-dev libxml2-dev libxslt1-dev nodejs npm python-anyjson \
   python-billiard python-bs4 python-crypto python-dateutil \
   python-dev python-flexmock \
-  python-pip python-psycopg2 python-pystache \
+  python-pip python-pystache \
   python-virtualenv python-wand python-yaml virtualenvwrapper \
   zlib1g-dev libfreetype6-dev libjpeg-dev

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -31,6 +31,7 @@ nosexcover==1.0.11
 # paramiko
 -e git+https://github.com/jasonrig/paramiko.git@rsacert_tardis#egg=paramiko
 pillow==3.4.2
+psycopg2-binary==2.7.4
 pwgen==0.7
 pylint==1.7.1
 pyoai==2.4.4

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -31,7 +31,6 @@ nosexcover==1.0.11
 # paramiko
 -e git+https://github.com/jasonrig/paramiko.git@rsacert_tardis#egg=paramiko
 pillow==3.4.2
-psycopg2-binary==2.7.4
 pwgen==0.7
 pylint==1.7.1
 pyoai==2.4.4

--- a/requirements-osx.txt
+++ b/requirements-osx.txt
@@ -2,6 +2,5 @@ PyYAML==3.12
 anyjson==0.3.3
 flexmock==0.10.2
 mock==2.0.0
-psycopg2==2.7
 pycrypto==2.6.1
 pystache==0.5.4

--- a/requirements-postgres.txt
+++ b/requirements-postgres.txt
@@ -1,0 +1,1 @@
+psycopg2-binary==2.7.4


### PR DESCRIPTION
Removes dependency on system package for `psycopg2` for Ubuntu

Upgrades to version 2.7.4