### PR TITLE
Pin `urllib3==1.22` to satisfy `requests` compatibility requirements

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -42,4 +42,5 @@ pytz==2016.10
 rdflib==4.2.2
 requests==2.18.4
 six==1.11.0
+urllib3==1.22
 wsgiref==0.1.2


### PR DESCRIPTION
Recent upgrade of `requests` to 2.18.4 caused an incompatibility with transitive dep on urllib3:
> requests 2.18.4 has requirement urllib3<1.23,>=1.21.1, but you'll have urllib3 1.23 which is incompatible.

This PR pins `urllib3==1.22` to avoid incompatibility.