### PR TITLE
Switch to `mysqlclient` library as MySQL driver API

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -28,5 +28,5 @@ WORKDIR /home/webapp
 CMD . /appenv/bin/activate; \
     pip wheel -r requirements.txt; \
     pip wheel -r requirements-postgres.txt; \
-    pip wheel MySQL-python; \
+    pip wheel -r requirements-mysql.txt; \
     pip wheel -e "git+https://github.com/pypa/pip.git#egg=pip"

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -12,7 +12,7 @@ USER webapp
 RUN . /appenv/bin/activate; \
     pip install --no-index -f /wheelhouse -r requirements-postgres.txt
 RUN . /appenv/bin/activate; \
-    pip install --no-index -f /wheelhouse mysql-python
+    pip install --no-index -f /wheelhouse -r requirements-mysql.txt
 RUN . /appenv/bin/activate; \
     pip install coveralls codacy-coverage
 VOLUME /home/webapp/tardis

--- a/requirements-mysql.txt
+++ b/requirements-mysql.txt
@@ -1,0 +1,1 @@
+mysqlclient==1.3.12


### PR DESCRIPTION
This is the package recommended by Django. It was forked from the
existing MySQLdb API driver, which now appears to be unmaintained.