### PR TITLE
Upgrading Pylint to 1.9.1 and addressing these issues:

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -18,6 +18,10 @@ persistent=yes
 # usually to register additional checkers.
 load-plugins=pylint.extensions.docparams
 
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=lxml.etree
 
 [MESSAGES CONTROL]
 

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -30,7 +30,7 @@ nose==1.3.7
 paramiko==2.4.1
 pillow==3.4.2
 pwgen==0.7
-pylint==1.7.1
+pylint==1.9.1
 pyoai==2.4.4
 pysolr==2.1.0 # pyup: >=2.1.0,<3
 python-dateutil==2.4.0

--- a/tardis/apps/equipment/south_migrations/0001_initial.py
+++ b/tardis/apps/equipment/south_migrations/0001_initial.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
+from django.db import models
 from south.db import db
 from south.v2 import SchemaMigration
-from django.db import models
 
 
 class Migration(SchemaMigration):

--- a/tardis/apps/push_to/models.py
+++ b/tardis/apps/push_to/models.py
@@ -63,6 +63,15 @@ class KeyPair(models.Model):
             super(KeyPair, self).__setattr__(attrname, val)
 
     def _validate_public_key(self, value):
+        """
+        This method is called when we attempt to assign a value to the
+        public_key field of the KeyPair model.  If we attempt to assign
+        a non-empty string, this method, checks if it has multiple
+        components, e.g. "ssh-rsa AAA...", and if so, saves the key type
+        e.g. "ssh-rsa" in self.key_type, and returns the public key string
+        e.g. "AAA...".  If we are attempting to assing an empty (None)
+        value, we just return that value.
+        """
         if value:
             # Check if the public key is in the id_rsa.pub format
             pub_key_fields = value.split()
@@ -73,7 +82,10 @@ class KeyPair(models.Model):
                 # Extract the key type
             self.key_type = KeyPair._get_key_type_from_public_key(public_key)
             return public_key
-        raise ValidationError("Can't validate public key")
+
+        # It's OK for an empty value (None) to be assigned to the public_key
+        # field whtn the model instance is initialized:
+        return value
 
     @property
     def key(self):

--- a/tardis/apps/push_to/models.py
+++ b/tardis/apps/push_to/models.py
@@ -73,6 +73,7 @@ class KeyPair(models.Model):
                 # Extract the key type
             self.key_type = KeyPair._get_key_type_from_public_key(public_key)
             return public_key
+        raise ValidationError("Can't validate public key")
 
     @property
     def key(self):

--- a/tardis/apps/push_to/oauth_tokens.py
+++ b/tardis/apps/push_to/oauth_tokens.py
@@ -35,7 +35,7 @@ def get_token_data(oauth_service, token):
     :rtype: dict
     """
     if token is None:
-        return
+        return None
     # Verify=False is a bad thing, but I need it for now
     r = requests.get(
         oauth_service.oauth_check_token_url, {
@@ -44,7 +44,7 @@ def get_token_data(oauth_service, token):
         verify=False)
     decoded_token = json.loads(r.text)
     if 'error' in decoded_token:
-        return
+        return None
     return decoded_token
 
 

--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -128,6 +128,7 @@ class MyTardisAuthentication(object):
                         return False
                     request._authentication_backend = apikey_auth
                     return check
+        return False
 
     def get_identifier(self, request):
         try:

--- a/tardis/tardis_portal/filters/diffractionimage.py
+++ b/tardis/tardis_portal/filters/diffractionimage.py
@@ -122,7 +122,6 @@ class DiffractionImageFilter(object):
             self.saveDiffractionImageMetadata(instance, schema, metadata)
         except Exception, e:
             logger.debug(e)
-            return None
 
     def saveDiffractionImageMetadata(self, instance, schema, metadata):
         """Save all the metadata to a DataFiles paramamter set.

--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -118,6 +118,7 @@ class DataFile(models.Model):
         for dfo in self.file_objects.filter(verified=True):
             if dfo.cache_file():
                 return True
+        return False
 
     def get_default_storage_box(self):
         '''

--- a/tardis/tardis_portal/models/experiment.py
+++ b/tardis/tardis_portal/models/experiment.py
@@ -206,15 +206,31 @@ class Experiment(models.Model):
         return [acl.get_related_object() for acl in acls]
 
     def _has_view_perm(self, user_obj):
+        '''
+        Called from the ACLAwareBackend class's has_perm method
+        in tardis/tardis_portal/auth/authorisation.py
+
+        Returning None means we won't override permissions here,
+        i.e. we'll leave it to ACLAwareBackend's has_perm method
+        to determine permissions from ObjectACLs
+        '''
         if not hasattr(self, 'id'):
             return False
 
         if self.public_access >= self.PUBLIC_ACCESS_METADATA:
             return True
 
-        return False
+        return None
 
     def _has_change_perm(self, user_obj):
+        '''
+        Called from the ACLAwareBackend class's has_perm method
+        in tardis/tardis_portal/auth/authorisation.py
+
+        Returning None means we won't override permissions here,
+        i.e. we'll leave it to ACLAwareBackend's has_perm method
+        to determine permissions from ObjectACLs
+        '''
         if not hasattr(self, 'id'):
             return False
 
@@ -224,6 +240,14 @@ class Experiment(models.Model):
         return None
 
     def _has_delete_perm(self, user_obj):
+        '''
+        Called from the ACLAwareBackend class's has_perm method
+        in tardis/tardis_portal/auth/authorisation.py
+
+        Returning None means we won't override permissions here,
+        i.e. we'll leave it to ACLAwareBackend's has_perm method
+        to determine permissions from ObjectACLs
+        '''
         if not hasattr(self, 'id'):
             return False
 

--- a/tardis/tardis_portal/models/experiment.py
+++ b/tardis/tardis_portal/models/experiment.py
@@ -212,6 +212,8 @@ class Experiment(models.Model):
         if self.public_access >= self.PUBLIC_ACCESS_METADATA:
             return True
 
+        return False
+
     def _has_change_perm(self, user_obj):
         if not hasattr(self, 'id'):
             return False

--- a/tardis/tardis_portal/publish/provider/schemarifcsprovider.py
+++ b/tardis/tardis_portal/publish/provider/schemarifcsprovider.py
@@ -71,6 +71,7 @@ class SchemaRifCsProvider(rifcsprovider.RifCsProvider):
         in the rif-cs"""
         if experiment.public_access != experiment.PUBLIC_ACCESS_NONE:
             return "%s/experiment/view/%s/" % (server_url, experiment.id)
+        return None
 
     def get_investigator_list(self, experiment):
         authors = [a.author for a in experiment.experimentauthor_set.all()]
@@ -180,6 +181,7 @@ class SchemaRifCsProvider(rifcsprovider.RifCsProvider):
                 return psm.get_params(key, True)
             except ObjectDoesNotExist:
                 return None
+        return None
 
 
     def _get_params(self, key, namespace, experiment):

--- a/tardis/tardis_portal/shortcuts.py
+++ b/tardis/tardis_portal/shortcuts.py
@@ -86,6 +86,8 @@ def get_experiment_referer(request, dataset_id):
     except:
         pass
 
+    return None
+
 
 def render_to_file(template, filename, context):
     string_for_output = render_to_string(template, context)

--- a/tardis/tardis_portal/tasks.py
+++ b/tardis/tardis_portal/tasks.py
@@ -172,7 +172,7 @@ def cache_done_notify(results, user_id, site_id, ct_id, obj_ids):
 # "method tasks"
 # StorageBox
 @task(name="tardis_portal.storage_box.copy_files", ignore_result=True)
-def sbox_copy_files(sbox_id, dest_box_id=None, *args, **kwargs):
+def sbox_copy_files(sbox_id, dest_box_id=None):
     init_filters()
     from tardis.tardis_portal.models import StorageBox
     sbox = StorageBox.objects.get(id=sbox_id)
@@ -180,11 +180,11 @@ def sbox_copy_files(sbox_id, dest_box_id=None, *args, **kwargs):
         dest_box = StorageBox.objects.get(id=dest_box_id)
     else:
         dest_box = None
-    return sbox.copy_files(dest_box=dest_box, *args, **kwargs)
+    return sbox.copy_files(dest_box=dest_box)
 
 
 @task(name="tardis_portal.storage_box.move_files", ignore_result=True)
-def sbox_move_files(sbox_id, dest_box_id=None, *args, **kwargs):
+def sbox_move_files(sbox_id, dest_box_id=None):
     init_filters()
     from tardis.tardis_portal.models import StorageBox
     sbox = StorageBox.objects.get(id=sbox_id)
@@ -192,7 +192,7 @@ def sbox_move_files(sbox_id, dest_box_id=None, *args, **kwargs):
         dest_box = StorageBox.objects.get(id=dest_box_id)
     else:
         dest_box = None
-    return sbox.move_files(dest_box=dest_box, *args, **kwargs)
+    return sbox.move_files(dest_box=dest_box)
 
 
 @task(name="tardis_portal.storage_box.cache_files", ignore_result=True)
@@ -242,7 +242,7 @@ def dfo_move_file(dfo_id, dest_box_id=None):
 
 
 @task(name='tardis_portal.dfo.copy_file', ignore_result=True)
-def dfo_copy_file(dfo_id, dest_box_id=None, *args, **kwargs):
+def dfo_copy_file(dfo_id, dest_box_id=None):
     init_filters()
     from tardis.tardis_portal.models import DataFileObject, StorageBox
     dfo = DataFileObject.objects.get(id=dfo_id)
@@ -250,7 +250,7 @@ def dfo_copy_file(dfo_id, dest_box_id=None, *args, **kwargs):
         dest_box = StorageBox.objects.get(id=dest_box_id)
     else:
         dest_box = None
-    return dfo.copy_file(dest_box=dest_box, *args, **kwargs)
+    return dfo.copy_file(dest_box=dest_box)
 
 
 @task(name='tardis_portal.dfo.cache_file', ignore_result=True)
@@ -271,4 +271,4 @@ def dfo_verify(dfo_id, *args, **kwargs):
             dfo = DataFileObject.objects.select_for_update().get(id=dfo_id)
             return dfo.verify(*args, **kwargs)
     dfo = DataFileObject.objects.get(id=dfo_id)
-    dfo.verify(*args, **kwargs)
+    return dfo.verify(*args, **kwargs)

--- a/tardis/tardis_portal/util.py
+++ b/tardis/tardis_portal/util.py
@@ -163,6 +163,7 @@ def render_public_access_badge(experiment):
             'label': 'Public',
             'public': True,
         })
+    return None
 
 
 def split_path(p):

--- a/tardis/tardis_portal/views/authentication.py
+++ b/tardis/tardis_portal/views/authentication.py
@@ -121,6 +121,8 @@ def rcauth(request):
         django_logout(request)
         raise PermissionDenied  # Error: Security cookie has expired
 
+    raise PermissionDenied
+
 
 @login_required
 def manage_user_account(request):

--- a/tardis/tardis_portal/views/authorisation.py
+++ b/tardis/tardis_portal/views/authorisation.py
@@ -445,7 +445,7 @@ def remove_experiment_access_user(request, experiment_id, username):
             'All experiments must have at least one user as '
             'owner. Add an additional owner first before '
             'removing this one.')
-    elif expt_acls.count() == 0:
+    else:
         # the user shouldn't really ever see this in normal operation
         return HttpResponse(
             'Experiment has no permissions (of type OWNER_OWNED) !')


### PR DESCRIPTION
************* Module tardis.tardis_portal.tasks
W1113:175,0:sbox_copy_files: Keyword argument before variable positional arguments list in the definition of sbox_copy_files function
W1113:187,0:sbox_move_files: Keyword argument before variable positional arguments list in the definition of sbox_move_files function
W1113:245,0:dfo_copy_file: Keyword argument before variable positional arguments list in the definition of dfo_copy_file function
R1710:265,0:dfo_verify: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.tardis_portal.shortcuts
R1710:65,0:get_experiment_referer: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.tardis_portal.util
R1710:126,0:render_public_access_badge: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.tardis_portal.api
R1710:90,4:MyTardisAuthentication.is_authenticated: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.tardis_portal.iiif
I1101:43,11:_get_iiif_error: Module 'lxml.etree' has not 'tostring' member, but source is unavailable. Consider adding this module to extension-pkg-whitelist if you want to perform analysis based on run-time introspection of living objects.
I1101:219,28:download_info: Module 'lxml.etree' has not 'tostring' member, but source is unavailable. Consider adding this module to extension-pkg-whitelist if you want to perform analysis based on run-time introspection of living objects.
************* Module tardis.tardis_portal.filters.diffractionimage
R1710:100,4:DiffractionImageFilter.__call__: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.tardis_portal.tests.test_iiif
I1101:105,14:Level0TestCase.testCanGetInfoAsXML: Module 'lxml.etree' has not 'fromstring' member, but source is unavailable. Consider adding this module to extension-pkg-whitelist if you want to perform analysis based on run-time introspection of living objects.
************* Module tardis.tardis_portal.models.datafile
R1710:115,4:DataFile.cache_file: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.tardis_portal.models.experiment
R1710:208,4:Experiment._has_view_perm: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.tardis_portal.publish.provider.schemarifcsprovider
R1710:69,4:SchemaRifCsProvider.get_url: Either all return statements in a function should return an expression, or none of them should.
R1710:171,4:SchemaRifCsProvider._get_param: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.tardis_portal.views.authorisation
R1710:418,0:remove_experiment_access_user: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.tardis_portal.views.authentication
R1710:37,0:rcauth: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.apps.anzsrc_codes.tests.test_oaipmh
I1101:87,14:RifCSTestCase.testExistsInOaipmh: Module 'lxml.etree' has not 'fromstring' member, but source is unavailable. Consider adding this module to extension-pkg-whitelist if you want to perform analysis based on run-time introspection of living objects.
************* Module tardis.apps.related_info.tests.test_oaipmh
I1101:83,14:RifCSTestCase.testExistsInOaipmh: Module 'lxml.etree' has not 'fromstring' member, but source is unavailable. Consider adding this module to extension-pkg-whitelist if you want to perform analysis based on run-time introspection of living objects.
************* Module tardis.apps.oaipmh.tests.test_oai
I1101:59,14:EndpointTestCase.testIdentify: Module 'lxml.etree' has not 'fromstring' member, but source is unavailable. Consider adding this module to extension-pkg-whitelist if you want to perform analysis based on run-time introspection of living objects.
I1101:78,14:EndpointTestCase.testGetRecord: Module 'lxml.etree' has not 'fromstring' member, but source is unavailable. Consider adding this module to extension-pkg-whitelist if you want to perform analysis based on run-time introspection of living objects.
I1101:211,14:EndpointTestCase.testListIdentifiers: Module 'lxml.etree' has not 'fromstring' member, but source is unavailable. Consider adding this module to extension-pkg-whitelist if you want to perform analysis based on run-time introspection of living objects.
I1101:235,14:EndpointTestCase.testListMetadataFormats: Module 'lxml.etree' has not 'fromstring' member, but source is unavailable. Consider adding this module to extension-pkg-whitelist if you want to perform analysis based on run-time introspection of living objects.
I1101:255,14:EndpointTestCase.testListMetadataFormats: Module 'lxml.etree' has not 'fromstring' member, but source is unavailable. Consider adding this module to extension-pkg-whitelist if you want to perform analysis based on run-time introspection of living objects.
I1101:279,14:EndpointTestCase.testListRecords: Module 'lxml.etree' has not 'fromstring' member, but source is unavailable. Consider adding this module to extension-pkg-whitelist if you want to perform analysis based on run-time introspection of living objects.
************* Module tardis.apps.push_to.oauth_tokens
R1710:28,0:get_token_data: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.apps.push_to.models
R1710:64,4:KeyPair._validate_public_key: Either all return statements in a function should return an expression, or none of them should.
************* Module tardis.apps.equipment.south_migrations.0001_initial
C0411:4,0:: third party import "from django.db import models" should be placed before "from south.db import db"