### PR TITLE
Remove unused `nosexcover` dependency

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -27,7 +27,6 @@ isodate==0.6.0
 pyjwt==1.6.4
 lxml==4.1.1
 nose==1.3.7
-nosexcover==1.0.11
 # paramiko
 -e git+https://github.com/jasonrig/paramiko.git@rsacert_tardis#egg=paramiko
 pillow==3.4.2


### PR DESCRIPTION
MyTardis tests don't appear to use this at all. Removing it yields same coverage result.