### PR TITLE
Add minor and patch release issue templates to help with releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/monthly_issue.md
+++ b/.github/ISSUE_TEMPLATE/monthly_issue.md
@@ -1,0 +1,75 @@
+## First working day after 7th
+
+Stable branch should be created after the 7th. The 7th is the last date to reliably get things in.
+
+- [ ] Create the `Pick into series-X.Y` label if it doesn't exist: [https://github.com/mytardis/mytardis/labels](https://github.com/mytardis/mytardis/labels)
+  - Label name: `Pick into series-X.Y`
+  - Description: ``Pull requests to cherry-pick into the `series-X.Y` branch.``
+  - Color: `#5319e7`
+- [ ] In Slack MyTardis `#general` channel:
+
+    ```
+    @channel
+
+    I am about to create the `series-X.Y` branch. Everything merged into `develop`
+    after this point will go into next month's release. Only regression and security fixes
+    will be cherry-picked into `series-X.Y`.
+
+    If your PR is targeting this release and has been approved but hasn't
+    been merged yet, please ping me here. Also, please update your pull requests with the correct milestone (`X.Y` for this release).
+
+    Please submit regression and security fixes as PRs to `develop` and ensure that
+    they are labelled with the `Pick into series-X.Y` label.
+    ```
+- [ ] Merge any approved PRs into `develop`
+- [ ] Create branch `series-X.Y` from `develop`
+- [ ] Create a PR against `develop` that increments the version numbers to `X.{Y + 1}.0`:
+  - [ ] `README.md`
+  - [ ] `package.json`
+  - [ ] Add new section to `docs/CHANGELOG.rst`
+  - [ ] `tardis/__init__.py`
+
+
+## RC1
+
+- Follow the [Creating RC1] guide:
+  - [ ] Create an PR on `develop` updating the `docs/admin/install.rst` guide.
+  - [ ] Create an PR on `develop` updating the dependencies license list
+
+
+[Creating RC1]: https://github.com/mytardis/release/blob/master/general/release-candidates.md#creating-rc1
+
+## Subsequent RCs
+
+- Create additional release candidates as needed, using [Creating subsequent RCs] guide.
+
+Keep in mind that:
+
+1. After the feature freeze only regression and security fixes should be
+   cherry-picked into stable branches.
+2. The final RC should point to the same commit as the final release.
+
+[Creating subsequent RCs]: https://github.com/mytardis/release/blob/master/general/release-candidates.md#creating-subsequent-rcs
+
+## Final RC
+
+The final RC should be created on the 20th of the month.
+
+## 22nd: release day
+
+No new code can added to the release that was not included in the final RC.
+
+- At 11:00 AEST, final release is ready for tagging:
+  - [ ] Ensure tests are green on `series-X.Y` branch.
+  - [ ] Create PR against `develop` updating [changelog.rst][changelog] with an overview of new features and fixes.
+  - [ ] [Pick][cherry-pick] changelog changes into a PR against `series-X.Y` branch.
+
+- Before 14:00 AEST:
+  - [ ] Tag the `X.Y.0` version from `series-X.Y` branch
+  - [ ] Check tag build passes on Semaphore.
+  - [ ] Create a new release on Github releases page that includes changes
+      mentioned in the changelog.
+
+
+[changelog]:
+https://github.com/mytardis/mytardis/blob/develop/docs/changelog.rst

--- a/.github/ISSUE_TEMPLATE/patch_issue.md
+++ b/.github/ISSUE_TEMPLATE/patch_issue.md
@@ -1,0 +1,16 @@
+## Patch release tasks
+
+- [ ] Follow the [cherry-pick] guide to create a PR against each supported `series-X.Y` stable branch with all the changes to be included in this patch release.
+- [ ] Monitor Semaphore build and to check that all tests pass.
+- [ ] Create PR against `develop` updating [changelog.rst][changelog] with an overview of new features and fixes.
+- [ ] [Pick][cherry-pick] changelog changes into a PR against `series-X.Y` branch.
+- [ ] Ping another maintainer to review and merge your PR.
+- [ ] Tag the `X.Y.Z` version from `series-X.Y` branch.
+- [ ] Check tag build passes on Semaphore.
+- [ ] Create a new release on Github releases page that includes changes
+    mentioned in the changelog.
+
+[cherry-pick]: https://github.com/mytardis/release/blob/develop/general/picking-changes-into-stable.md
+
+
+


### PR DESCRIPTION
Help release managers to create issues for tracking minor and patch releases.