### PR TITLE
Updating `develop` version numbers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,10 +1,20 @@
 Releases
 ========
 
-In development
---------------
-* Revert behaviour that allowed 'Staff' users to modify experiment ownership and
-  sharing permissions via the web UI.
+3.8
+---
+* Refactored settings
+* Added pagination to My Data view
+* BDD tests using behave and phantomjs
+* Added download MD5 checksum buttons to Dataset View
+* Add `autocaching` task that allows data from a StorageBox to be cached to
+  another StorageBox
+* Re-wrote user documentation and switched to hosting docs on RTD
+* Switched to using NPM to manage JS deps.
+* Facility and instrument are now visible on Experiment and dataset views -
+  thanks @avrljk
+* Added setting that allows datasets ordered by id on the Experiment page.
+* Added setting to make sha512 checksums optional.
 
 3.7 - 17 March 2016
 -------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mytardis",
-  "version": "1.0.0",
+  "version": "3.8.0",
   "license": "SEE LICENSE IN COPYING.rst",
   "repository": {
     "type": "git",

--- a/tardis/__init__.py
+++ b/tardis/__init__.py
@@ -11,4 +11,4 @@ except ImportError:
     from pkgutil import extend_path
     __path__ = extend_path(__path__, __name__)
 
-__version__ = '3.7'
+__version__ = '3.8'


### PR DESCRIPTION
`develop` branch should really reflect the version we are currently
working on and should get bumped to the next version when we release.