### PR TITLE
Marking deprecated functionality.

### DIFF
--- a/tardis/search/views.py
+++ b/tardis/search/views.py
@@ -1,8 +1,8 @@
 """
 views relevant to search
 """
-
 import logging
+import warnings
 
 from django.contrib.auth.models import User
 from django.http import HttpResponse
@@ -11,6 +11,7 @@ from haystack.generic_views import SearchView
 from tardis.search.forms import GroupedSearchForm
 from tardis.search.utils import SearchQueryString
 from tardis.tardis_portal.auth import decorators as authz
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
 from tardis.tardis_portal.forms import createSearchDatafileSelectionForm
 from tardis.tardis_portal.hacks import oracle_dbops_hack
 from tardis.tardis_portal.models import Experiment
@@ -101,7 +102,12 @@ def search_datafile(request):  # too complex # noqa
     datafile query.
 
     """
-
+    warnings.warn(
+        "The old DataFile search form (triggered by the /search/datafile/ "
+        "URL) was only useful for X-Ray Diffraction data.  It needs to be "
+        "rewritten if it is to be useful for other data types.",
+        RemovedInMyTardis310Warning
+    )
     if 'type' in request.GET:
         searchQueryType = request.GET.get('type')
     else:

--- a/tardis/search/views.py
+++ b/tardis/search/views.py
@@ -11,7 +11,7 @@ from haystack.generic_views import SearchView
 from tardis.search.forms import GroupedSearchForm
 from tardis.search.utils import SearchQueryString
 from tardis.tardis_portal.auth import decorators as authz
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 from tardis.tardis_portal.forms import createSearchDatafileSelectionForm
 from tardis.tardis_portal.hacks import oracle_dbops_hack
 from tardis.tardis_portal.models import Experiment
@@ -106,7 +106,7 @@ def search_datafile(request):  # too complex # noqa
         "The old DataFile search form (triggered by the /search/datafile/ "
         "URL) was only useful for X-Ray Diffraction data.  It needs to be "
         "rewritten if it is to be useful for other data types.",
-        RemovedInMyTardis310Warning
+        RemovedInMyTardis311Warning
     )
     if 'type' in request.GET:
         searchQueryType = request.GET.get('type')

--- a/tardis/tardis_portal/MultiPartForm.py
+++ b/tardis/tardis_portal/MultiPartForm.py
@@ -5,10 +5,13 @@ import itertools
 import logging
 import mimetypes
 import urllib2
+import warnings
 
 from cStringIO import StringIO
 
 import mimetools
+
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 
 
 logger = logging.getLogger(__name__)
@@ -18,6 +21,10 @@ class MultiPartForm(object):
     """Accumulate the data to be used when posting a form."""
 
     def __init__(self):
+        warnings.warn(
+            "The MultiPartForm class will be removed in MyTardis 3.11. ",
+            RemovedInMyTardis311Warning
+        )
         self.form_fields = []
         self.files = []
         self.boundary = mimetools.choose_boundary()

--- a/tardis/tardis_portal/ands_doi.py
+++ b/tardis/tardis_portal/ands_doi.py
@@ -12,7 +12,7 @@ from django.utils.importlib import import_module
 
 from tardis.tardis_portal.models import ExperimentParameter, \
     ExperimentParameterSet, ParameterName, Schema
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ class DOIService(object):
             "This old DOI minting mechanism used an ANDS service which is no "
             "longer available.  DOI minting should now be implemented using "
             "the tardis.apps.publication_forms.doi.DOI class.",
-            RemovedInMyTardis310Warning
+            RemovedInMyTardis311Warning
         )
         if hasattr(settings, 'DOI_ENABLE') and settings.DOI_ENABLE:
             self.experiment = experiment
@@ -157,7 +157,7 @@ class DOIXMLProvider(object):
             "This old DOI minting mechanism used an ANDS service which is no "
             "longer available.  DOI minting should now be implemented using "
             "the tardis.apps.publication_forms.doi.DOI class.",
-            RemovedInMyTardis310Warning
+            RemovedInMyTardis311Warning
         )
         self.experiment = experiment
 

--- a/tardis/tardis_portal/ands_doi.py
+++ b/tardis/tardis_portal/ands_doi.py
@@ -4,6 +4,7 @@ import re
 import urllib2
 from urllib2 import HTTPError
 import logging
+import warnings
 
 from django.conf import settings
 from django.template.loader import render_to_string
@@ -11,6 +12,8 @@ from django.utils.importlib import import_module
 
 from tardis.tardis_portal.models import ExperimentParameter, \
     ExperimentParameterSet, ParameterName, Schema
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +34,12 @@ class DOIService(object):
         :type experiment: :class: `tardis.tardis_portal.models.Experiment`
         :raises Exception:
         """
+        warnings.warn(
+            "This old DOI minting mechanism used an ANDS service which is no "
+            "longer available.  DOI minting should now be implemented using "
+            "the tardis.apps.publication_forms.doi.DOI class.",
+            RemovedInMyTardis310Warning
+        )
         if hasattr(settings, 'DOI_ENABLE') and settings.DOI_ENABLE:
             self.experiment = experiment
 
@@ -144,6 +153,12 @@ class DOIXMLProvider(object):
     """
 
     def __init__(self, experiment):
+        warnings.warn(
+            "This old DOI minting mechanism used an ANDS service which is no "
+            "longer available.  DOI minting should now be implemented using "
+            "the tardis.apps.publication_forms.doi.DOI class.",
+            RemovedInMyTardis310Warning
+        )
         self.experiment = experiment
 
     def datacite_xml(self):

--- a/tardis/tardis_portal/deprecations.py
+++ b/tardis/tardis_portal/deprecations.py
@@ -1,0 +1,40 @@
+'''
+Deprecation warnings
+'''
+import warnings
+
+warnings.simplefilter('always')
+
+
+class RemovedInMyTardis310Warning(PendingDeprecationWarning):
+    '''
+    Used to raise warnings about deprecated functionality.
+
+    Usage:
+
+    import warnings
+
+    warnings.warn(
+        "This method will be removed in MyTardis 3.10. "
+        "Please use method2 instead.",
+        RemovedInMyTardis310Warning
+    )
+    '''
+    pass
+
+
+class RemovedInMyTardis39Warning(DeprecationWarning):
+    '''
+    Used to raise warnings about deprecated functionality.
+
+    Usage:
+
+    import warnings
+
+    warnings.warn(
+        "This method will be removed in MyTardis 3.9. "
+        "Please use method2 instead.",
+        RemovedInMyTardis39Warning
+    )
+    '''
+    pass

--- a/tardis/tardis_portal/deprecations.py
+++ b/tardis/tardis_portal/deprecations.py
@@ -6,7 +6,24 @@ import warnings
 warnings.simplefilter('always')
 
 
-class RemovedInMyTardis310Warning(PendingDeprecationWarning):
+class RemovedInMyTardis311Warning(PendingDeprecationWarning):
+    '''
+    Used to raise warnings about deprecated functionality.
+
+    Usage:
+
+    import warnings
+
+    warnings.warn(
+        "This method will be removed in MyTardis 3.11. "
+        "Please use method2 instead.",
+        RemovedInMyTardis311Warning
+    )
+    '''
+    pass
+
+
+class RemovedInMyTardis310Warning(DeprecationWarning):
     '''
     Used to raise warnings about deprecated functionality.
 
@@ -18,23 +35,6 @@ class RemovedInMyTardis310Warning(PendingDeprecationWarning):
         "This method will be removed in MyTardis 3.10. "
         "Please use method2 instead.",
         RemovedInMyTardis310Warning
-    )
-    '''
-    pass
-
-
-class RemovedInMyTardis39Warning(DeprecationWarning):
-    '''
-    Used to raise warnings about deprecated functionality.
-
-    Usage:
-
-    import warnings
-
-    warnings.warn(
-        "This method will be removed in MyTardis 3.9. "
-        "Please use method2 instead.",
-        RemovedInMyTardis39Warning
     )
     '''
     pass

--- a/tardis/tardis_portal/filters/diffractionimage.py
+++ b/tardis/tardis_portal/filters/diffractionimage.py
@@ -42,7 +42,7 @@ import subprocess
 import tempfile
 import warnings
 
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 from tardis.tardis_portal.models import Schema, DatafileParameterSet
 from tardis.tardis_portal.models import ParameterName, DatafileParameter
 
@@ -108,11 +108,11 @@ class DiffractionImageFilter(object):
         type created: bool
         """
         warnings.warn(
-            "The diffractionimage filter will be removed in MyTardis 3.10. "
+            "The diffractionimage filter will be removed in MyTardis 3.11. "
             "It is no longer used in the MyTardis deployment it was developed "
             "for, and it is too deployment-specific to be included in the "
             "core MyTardis repository.",
-            RemovedInMyTardis310Warning
+            RemovedInMyTardis311Warning
         )
         instance = kwargs.get('instance')
 

--- a/tardis/tardis_portal/filters/diffractionimage.py
+++ b/tardis/tardis_portal/filters/diffractionimage.py
@@ -40,7 +40,9 @@ from fractions import Fraction
 import logging
 import subprocess
 import tempfile
+import warnings
 
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
 from tardis.tardis_portal.models import Schema, DatafileParameterSet
 from tardis.tardis_portal.models import ParameterName, DatafileParameter
 
@@ -105,6 +107,13 @@ class DiffractionImageFilter(object):
         param created: A boolean; True if a new record was created.
         type created: bool
         """
+        warnings.warn(
+            "The diffractionimage filter will be removed in MyTardis 3.10. "
+            "It is no longer used in the MyTardis deployment it was developed "
+            "for, and it is too deployment-specific to be included in the "
+            "core MyTardis repository.",
+            RemovedInMyTardis310Warning
+        )
         instance = kwargs.get('instance')
 
         schema = self.getSchema()

--- a/tardis/tardis_portal/management/commands/backupdb.py
+++ b/tardis/tardis_portal/management/commands/backupdb.py
@@ -5,9 +5,12 @@ from os import makedirs
 from os.path import exists, join
 import subprocess
 import time
+import warnings
 
 from optparse import make_option
 from django.core.management.base import BaseCommand
+
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
 
 
 class Command(BaseCommand):
@@ -22,6 +25,16 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         from django.conf import settings
+
+        warnings.warn(
+            "The backupdb command will be removed in MyTardis 3.10. "
+            "Database engines commonly used with MyTardis provide their "
+            "own database backup commands, e.g. pg_dump, mysqldump. "
+            "There are Python packages for doing backups via Django, "
+            "e.g. django-backup, but they are not currently used by the "
+            "MyTardis core developers.",
+            RemovedInMyTardis310Warning
+        )
 
         database = options.get('database')
         if not database:

--- a/tardis/tardis_portal/management/commands/backupdb.py
+++ b/tardis/tardis_portal/management/commands/backupdb.py
@@ -10,7 +10,7 @@ import warnings
 from optparse import make_option
 from django.core.management.base import BaseCommand
 
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 
 
 class Command(BaseCommand):
@@ -27,13 +27,13 @@ class Command(BaseCommand):
         from django.conf import settings
 
         warnings.warn(
-            "The backupdb command will be removed in MyTardis 3.10. "
+            "The backupdb command will be removed in MyTardis 3.11. "
             "Database engines commonly used with MyTardis provide their "
             "own database backup commands, e.g. pg_dump, mysqldump. "
             "There are Python packages for doing backups via Django, "
             "e.g. django-backup, but they are not currently used by the "
             "MyTardis core developers.",
-            RemovedInMyTardis310Warning
+            RemovedInMyTardis311Warning
         )
 
         database = options.get('database')

--- a/tardis/tardis_portal/management/commands/checkhashes.py
+++ b/tardis/tardis_portal/management/commands/checkhashes.py
@@ -8,7 +8,7 @@ from urllib2 import urlopen
 
 from django.core.management.base import BaseCommand, CommandError
 
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 from tardis.tardis_portal.models import DataFile
 
 CHUNK_SIZE = 32*1024
@@ -28,11 +28,11 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         warnings.warn(
-            "The checkhashes command will be removed in MyTardis 3.10. "
+            "The checkhashes command will be removed in MyTardis 3.11. "
             "Attempting to iterate through DataFile.objects.all() and compute "
             "hashes for all files from a management command is not scalable "
             "or useful in large MyTardis deployments.",
-            RemovedInMyTardis310Warning
+            RemovedInMyTardis311Warning
         )
         verbosity = int(options.get('verbosity', 1))
 

--- a/tardis/tardis_portal/management/commands/checkhashes.py
+++ b/tardis/tardis_portal/management/commands/checkhashes.py
@@ -1,12 +1,14 @@
 """
 Management utility to create a token user
 """
-
 import hashlib
+import warnings
 from contextlib import closing
 from urllib2 import urlopen
 
 from django.core.management.base import BaseCommand, CommandError
+
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
 from tardis.tardis_portal.models import DataFile
 
 CHUNK_SIZE = 32*1024
@@ -25,6 +27,13 @@ class Command(BaseCommand):
     help = 'Used to check file hashes against actual files.'
 
     def handle(self, *args, **options):
+        warnings.warn(
+            "The checkhashes command will be removed in MyTardis 3.10. "
+            "Attempting to iterate through DataFile.objects.all() and compute "
+            "hashes for all files from a management command is not scalable "
+            "or useful in large MyTardis deployments.",
+            RemovedInMyTardis310Warning
+        )
         verbosity = int(options.get('verbosity', 1))
 
         for df in DataFile.objects.all():

--- a/tardis/tardis_portal/management/commands/chownexperiment.py
+++ b/tardis/tardis_portal/management/commands/chownexperiment.py
@@ -33,12 +33,14 @@ Management command to change the owner of some experiments
 
 import sys
 import traceback
+import warnings
 from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError
 from django.contrib.auth.models import User
 from django.db import transaction, DEFAULT_DB_ALIAS
 
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
 from tardis.tardis_portal.models import Experiment
 
 
@@ -66,6 +68,11 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        warnings.warn(
+            "The chownexperiment command has been broken since ExperimentACLs were "
+            "replaced by ObjectACLs.  It will be removed in MyTardis 3.10.",
+            RemovedInMyTardis310Warning
+        )
         if len(args) < 1:
             raise CommandError("Expected a user name and some experiment ids")
         try:

--- a/tardis/tardis_portal/management/commands/chownexperiment.py
+++ b/tardis/tardis_portal/management/commands/chownexperiment.py
@@ -40,7 +40,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.contrib.auth.models import User
 from django.db import transaction, DEFAULT_DB_ALIAS
 
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 from tardis.tardis_portal.models import Experiment
 
 
@@ -70,8 +70,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         warnings.warn(
             "The chownexperiment command has been broken since ExperimentACLs were "
-            "replaced by ObjectACLs.  It will be removed in MyTardis 3.10.",
-            RemovedInMyTardis310Warning
+            "replaced by ObjectACLs.  It will be removed in MyTardis 3.11.",
+            RemovedInMyTardis311Warning
         )
         if len(args) < 1:
             raise CommandError("Expected a user name and some experiment ids")

--- a/tardis/tardis_portal/management/commands/cleanuptokens.py
+++ b/tardis/tardis_portal/management/commands/cleanuptokens.py
@@ -1,12 +1,15 @@
 """
 Management utility to clean up tokens
 """
+import warnings
 
 from datetime import datetime as dt
 
 from optparse import make_option
 from django.core.management.base import BaseCommand
 from django.db.models import Count
+
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
 from tardis.tardis_portal.models import Token, ObjectACL
 from tardis.tardis_portal.auth.token_auth import TokenGroupProvider
 
@@ -22,6 +25,11 @@ class Command(BaseCommand):
     help = 'Deletes unused tokens and optionally their ACLs'
 
     def handle(self, *args, **options):
+        warnings.warn(
+            "The cleanuptokens command has been broken since ExperimentACLs were "
+            "replaced by ObjectACLs.  It will be removed in MyTardis 3.10.",
+            RemovedInMyTardis310Warning
+        )
         verbosity = int(options.get('verbosity', 1))
         keep_acls = options.get('keep_acls')
 

--- a/tardis/tardis_portal/management/commands/cleanuptokens.py
+++ b/tardis/tardis_portal/management/commands/cleanuptokens.py
@@ -9,7 +9,7 @@ from optparse import make_option
 from django.core.management.base import BaseCommand
 from django.db.models import Count
 
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 from tardis.tardis_portal.models import Token, ObjectACL
 from tardis.tardis_portal.auth.token_auth import TokenGroupProvider
 
@@ -27,8 +27,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         warnings.warn(
             "The cleanuptokens command has been broken since ExperimentACLs were "
-            "replaced by ObjectACLs.  It will be removed in MyTardis 3.10.",
-            RemovedInMyTardis310Warning
+            "replaced by ObjectACLs.  It will be removed in MyTardis 3.11.",
+            RemovedInMyTardis311Warning
         )
         verbosity = int(options.get('verbosity', 1))
         keep_acls = options.get('keep_acls')

--- a/tardis/tardis_portal/management/commands/createmysuperuser.py
+++ b/tardis/tardis_portal/management/commands/createmysuperuser.py
@@ -5,6 +5,7 @@ Management utility to create superusers.
 import getpass
 import re
 import sys
+import warnings
 
 from optparse import make_option
 from django.contrib.auth.models import User
@@ -12,6 +13,7 @@ from django.core import exceptions
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import ugettext as _
 
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
 from tardis.tardis_portal.models import UserProfile, UserAuthentication
 from tardis.tardis_portal.auth.localdb_auth \
     import auth_key as locabdb_auth_key
@@ -47,6 +49,11 @@ class Command(BaseCommand):
     help = 'Used to create a MyTardis superuser.'
 
     def handle(self, *args, **options):
+        warnings.warn(
+            "The createmysuperuser command will be removed in MyTardis 3.10. "
+            "Please use the createsuperuser command instead.",
+            RemovedInMyTardis310Warning
+        )
         username = options.get('username', None)
         email = options.get('email', None)
         interactive = options.get('interactive')

--- a/tardis/tardis_portal/management/commands/createmysuperuser.py
+++ b/tardis/tardis_portal/management/commands/createmysuperuser.py
@@ -13,7 +13,7 @@ from django.core import exceptions
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import ugettext as _
 
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 from tardis.tardis_portal.models import UserProfile, UserAuthentication
 from tardis.tardis_portal.auth.localdb_auth \
     import auth_key as locabdb_auth_key
@@ -50,9 +50,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         warnings.warn(
-            "The createmysuperuser command will be removed in MyTardis 3.10. "
+            "The createmysuperuser command will be removed in MyTardis 3.11. "
             "Please use the createsuperuser command instead.",
-            RemovedInMyTardis310Warning
+            RemovedInMyTardis311Warning
         )
         username = options.get('username', None)
         email = options.get('email', None)

--- a/tardis/tardis_portal/models/parameters.py
+++ b/tardis/tardis_portal/models/parameters.py
@@ -15,7 +15,7 @@ from django.db import models
 from django.utils.safestring import mark_safe
 from django.utils.timezone import is_aware, is_naive, make_aware, make_naive
 
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
 from tardis.tardis_portal.managers import OracleSafeManager,\
     ParameterNameManager, SchemaManager
@@ -116,8 +116,8 @@ class Schema(models.Model):
     @classmethod
     def get_internal_schema(cls, schema_type):
         warnings.warn(
-            "This method is no longer used and will be removed in MyTardis 3.10.",
-            RemovedInMyTardis310Warning
+            "This method is no longer used and will be removed in MyTardis 3.11.",
+            RemovedInMyTardis311Warning
         )
         name_prefix, ns_prefix = getattr(
             settings, 'INTERNAL_SCHEMA_PREFIXES',
@@ -254,9 +254,9 @@ def _get_string_parameter_as_image_element(parameter):
     :rtype: basestring | types.NoneType
     """
     warnings.warn(
-	"This method is no longer used and will be removed in MyTardis 3.10. "
+	"This method is no longer used and will be removed in MyTardis 3.11. "
         "It was previously used for storing thumbnails in Base64 format.",
-	RemovedInMyTardis310Warning
+	RemovedInMyTardis311Warning
     )
     assert parameter.name.isString(), \
         "'*Image' parameters are expected to be of type STRING"

--- a/tardis/tardis_portal/models/parameters.py
+++ b/tardis/tardis_portal/models/parameters.py
@@ -1,9 +1,10 @@
 import logging
 import operator
 import json
-import pytz
+import warnings
 
 import dateutil.parser
+import pytz
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -14,6 +15,7 @@ from django.db import models
 from django.utils.safestring import mark_safe
 from django.utils.timezone import is_aware, is_naive, make_aware, make_naive
 
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
 from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
 from tardis.tardis_portal.managers import OracleSafeManager,\
     ParameterNameManager, SchemaManager
@@ -113,6 +115,10 @@ class Schema(models.Model):
 
     @classmethod
     def get_internal_schema(cls, schema_type):
+        warnings.warn(
+            "This method is no longer used and will be removed in MyTardis 3.10.",
+            RemovedInMyTardis310Warning
+        )
         name_prefix, ns_prefix = getattr(
             settings, 'INTERNAL_SCHEMA_PREFIXES',
             ('internal schema', 'http://mytardis.org/schemas/internal'))
@@ -247,6 +253,11 @@ def _get_string_parameter_as_image_element(parameter):
     :return: An HTML formated img element, or None
     :rtype: basestring | types.NoneType
     """
+    warnings.warn(
+	"This method is no longer used and will be removed in MyTardis 3.10. "
+        "It was previously used for storing thumbnails in Base64 format.",
+	RemovedInMyTardis310Warning
+    )
     assert parameter.name.isString(), \
         "'*Image' parameters are expected to be of type STRING"
 

--- a/tardis/tardis_portal/publish/provider/schemarifcsprovider.py
+++ b/tardis/tardis_portal/publish/provider/schemarifcsprovider.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from html2text import html2text
 
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 from tardis.tardis_portal.models import ExperimentParameter, ExperimentParameterSet, ParameterName, Schema
 from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
 
@@ -27,10 +27,10 @@ class SchemaRifCsProvider(rifcsprovider.RifCsProvider):
         self.creative_commons_schema_ns = 'http://www.tardis.edu.au/schemas/creative_commons/2011/05/17'
         self.annotation_schema_ns = 'http://www.tardis.edu.au/schemas/experiment/annotation/2011/07/07'
         warnings.warn(
-            "The SchemaRifCsProvider class will be removed in MyTardis 3.10. "
+            "The SchemaRifCsProvider class will be removed in MyTardis 3.11. "
             "Please use "
             "tardis.tardis_portal.publish.provider.rifcsprovider.RifCsProvider ",
-            RemovedInMyTardis310Warning
+            RemovedInMyTardis311Warning
         )
 
     def can_publish(self, experiment):

--- a/tardis/tardis_portal/publish/provider/schemarifcsprovider.py
+++ b/tardis/tardis_portal/publish/provider/schemarifcsprovider.py
@@ -1,11 +1,18 @@
+import warnings
+
 from django.template import Context
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from html2text import html2text
 
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
 from tardis.tardis_portal.models import ExperimentParameter, ExperimentParameterSet, ParameterName, Schema
 from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
 
+# This schemarifcsprovider module is broken, since it depends on an old
+# unmaintained "ands_register" app which is not included in MyTardis,
+# (see PublishHandler import below), hence the deprecation warning in
+# SchemaRifCsProvider.__init__
 from tardis.apps.ands_register.publishing import PublishHandler
 
 import tardis.tardis_portal.publish.rifcsprovider as rifcsprovider
@@ -19,6 +26,12 @@ class SchemaRifCsProvider(rifcsprovider.RifCsProvider):
         self.related_info_schema_ns = settings.RELATED_INFO_SCHEMA_NAMESPACE
         self.creative_commons_schema_ns = 'http://www.tardis.edu.au/schemas/creative_commons/2011/05/17'
         self.annotation_schema_ns = 'http://www.tardis.edu.au/schemas/experiment/annotation/2011/07/07'
+        warnings.warn(
+            "The SchemaRifCsProvider class will be removed in MyTardis 3.10. "
+            "Please use "
+            "tardis.tardis_portal.publish.provider.rifcsprovider.RifCsProvider ",
+            RemovedInMyTardis310Warning
+        )
 
     def can_publish(self, experiment):
         return experiment.public_access != experiment.PUBLIC_ACCESS_NONE

--- a/tardis/tardis_portal/storage/squashfs.py
+++ b/tardis/tardis_portal/storage/squashfs.py
@@ -13,6 +13,7 @@ set up autofs to auto-mount squashfiles
 
 import logging
 import os
+import warnings
 
 from celery.task import task
 
@@ -21,6 +22,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import FileSystemStorage
 from django.utils.importlib import import_module
 
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
 from tardis.tardis_portal.models import DataFile, DatafileParameterSet, \
     StorageBoxOption
 
@@ -39,6 +41,11 @@ class SquashFSStorage(FileSystemStorage):
     squashfs_dirs = getattr(settings, 'SQUASHFS_DIRS', None)
 
     def __init__(self, sq_filename=None, datafile_id=None, sq_dir=None):
+        warnings.warn(
+            "The SquashFSStorage class will be removed in MyTardis 3.10. "
+            "It is available in https://github.com/mytardis/aus_synch_app.git",
+            RemovedInMyTardis310Warning
+        )
         if SquashFSStorage.squashfs_dirs is None:
             raise ImproperlyConfigured('Please configure SQUASHFS_DIRS')
         autofs_dir, name = None, None

--- a/tardis/tardis_portal/storage/squashfs.py
+++ b/tardis/tardis_portal/storage/squashfs.py
@@ -22,7 +22,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import FileSystemStorage
 from django.utils.importlib import import_module
 
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 from tardis.tardis_portal.models import DataFile, DatafileParameterSet, \
     StorageBoxOption
 
@@ -42,9 +42,9 @@ class SquashFSStorage(FileSystemStorage):
 
     def __init__(self, sq_filename=None, datafile_id=None, sq_dir=None):
         warnings.warn(
-            "The SquashFSStorage class will be removed in MyTardis 3.10. "
+            "The SquashFSStorage class will be removed in MyTardis 3.11. "
             "It is available in https://github.com/mytardis/aus_synch_app.git",
-            RemovedInMyTardis310Warning
+            RemovedInMyTardis311Warning
         )
         if SquashFSStorage.squashfs_dirs is None:
             raise ImproperlyConfigured('Please configure SQUASHFS_DIRS')

--- a/tardis/tardis_portal/tests/test_ands_doi.py
+++ b/tardis/tardis_portal/tests/test_ands_doi.py
@@ -37,7 +37,7 @@ from django.conf import settings
 from django.test import TestCase
 
 from tardis.tardis_portal.ands_doi import DOIService
-from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
+from tardis.tardis_portal.deprecations import RemovedInMyTardis311Warning
 from tardis.tardis_portal.models import User, Experiment, Schema, ParameterName
 
 
@@ -61,7 +61,7 @@ class ANDSDOITestCase(TestCase):
         with warnings.catch_warnings(record=True) as caught_warnings:
             doi_service = DOIService(self.expt)
         for warning in caught_warnings:
-            self.assertEqual(warning.category, RemovedInMyTardis310Warning)
+            self.assertEqual(warning.category, RemovedInMyTardis311Warning)
 
     def test_get_doi_none(self):
         doi_service = DOIService(self.expt)

--- a/tardis/tardis_portal/tests/test_ands_doi.py
+++ b/tardis/tardis_portal/tests/test_ands_doi.py
@@ -31,10 +31,13 @@
 """
 test_ands_doi.py
 """
+import warnings
+
 from django.conf import settings
 from django.test import TestCase
 
 from tardis.tardis_portal.ands_doi import DOIService
+from tardis.tardis_portal.deprecations import RemovedInMyTardis310Warning
 from tardis.tardis_portal.models import User, Experiment, Schema, ParameterName
 
 
@@ -55,7 +58,10 @@ class ANDSDOITestCase(TestCase):
         settings.DOI_ENABLE = False
 
     def test_init(self):
-        doi_service = DOIService(self.expt)
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            doi_service = DOIService(self.expt)
+        for warning in caught_warnings:
+            self.assertEqual(warning.category, RemovedInMyTardis310Warning)
 
     def test_get_doi_none(self):
         doi_service = DOIService(self.expt)


### PR DESCRIPTION
I have marked it as being deprecated in v3.10, which would mean
that the deprecation warnings should appear in v3.8, but it's
up to @keithschulze (as our v3.8 release manager) to decide whether
these deprecation warnings can be included in v3.8, given that
we're in a feature freeze.  If not, I'll update the PR to indicate
that the deprecated code will be removed in v3.11 (not v3.10).