### PR TITLE
[WIP] Submit coverage data to Codecov, which we could use instead of Coveralls

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -14,7 +14,7 @@ RUN . /appenv/bin/activate; \
 RUN . /appenv/bin/activate; \
     pip install --no-index -f /wheelhouse -r requirements-mysql.txt
 RUN . /appenv/bin/activate; \
-    pip install coveralls codacy-coverage
+    pip install codecov coveralls codacy-coverage
 VOLUME /home/webapp/tardis
 VOLUME /home/webapp/docs
 

--- a/test.sh
+++ b/test.sh
@@ -20,6 +20,9 @@ function run_test {
 	if [ -v COVERALLS_REPO_TOKEN ]; then
 	    coveralls
 	fi
+	if [ -v CODECOV_TOKEN ]; then
+	    codecov -X gcov
+	fi
 	if [ -v CODACY_PROJECT_TOKEN ]; then
 	    coverage xml
 	    python-codacy-coverage -r coverage.xml


### PR DESCRIPTION
the CODECOV_TOKEN has been added to Sempahore's settings for the mytardis repository as an encrypted environment variable.