### PR TITLE
Ensuring documentation links point to current version

### DIFF
--- a/tardis/tardis_portal/context_processors.py
+++ b/tardis/tardis_portal/context_processors.py
@@ -59,9 +59,11 @@ def global_contexts(request):
     site_title = getattr(settings, 'SITE_TITLE', None)
     sponsored_by = getattr(settings, 'SPONSORED_TEXT', None)
     site_styles = getattr(settings, 'SITE_STYLES', '')
+    version = getattr(settings, 'MYTARDIS_VERSION', None)
     return {'site_title': site_title,
             'sponsored_by': sponsored_by,
-            'site_styles': site_styles, }
+            'site_styles': site_styles,
+            'version': version, }
 
 
 def google_analytics(request):

--- a/tardis/tardis_portal/templates/tardis_portal/about.html
+++ b/tardis/tardis_portal/templates/tardis_portal/about.html
@@ -17,11 +17,11 @@
             <h2><i class="fa fa-question-sign fa-lg"></i> Help</h2>
             <ul class="unstyled">
                 <li>
-                    <a href="http://mytardis.readthedocs.io/en/latest/userguide.html"
+                    <a href="http://mytardis.readthedocs.io/en/{{ version.tag|lower }}/userguide.html"
                        target="_blank">User Guide</a>
                 </li>
                 <li>
-                    <a href="http://mytardis.readthedocs.org/en/latest/index.html"
+                    <a href="http://mytardis.readthedocs.org/en/{{ version.tag|lower }}/index.html"
                        target="_blank">Documentation</a>
                 </li>
             </ul>

--- a/tardis/tardis_portal/templates/tardis_portal/portal_template.html
+++ b/tardis/tardis_portal/templates/tardis_portal/portal_template.html
@@ -101,7 +101,7 @@
               {% if facility_manager %}
               <li><a href="{% url 'tardis.tardis_portal.views.facility_overview' %}">Facility Overview</a></li>
               {% endif %}{% endwith %}
-              <li><a href="http://mytardis.readthedocs.io/en/develop/userguide.html" target="_blank"><b>Help</b></a></li>
+              <li><a href="http://mytardis.readthedocs.io/en/{{ version.tag|lower }}/userguide.html" target="_blank"><b>Help</b></a></li>
             </ul>
             <ul class="login-nav nav pull-right">
             {% if is_authenticated %}

--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -353,7 +353,6 @@ def about(request):
     c = {'subtitle': 'About',
          'about_pressed': True,
          'nav': [{'name': 'About', 'link': '/about/'}],
-         'version': settings.MYTARDIS_VERSION,
          'custom_about_section': getattr(
              settings, 'CUSTOM_ABOUT_SECTION_TEMPLATE',
              'tardis_portal/about_include.html'),


### PR DESCRIPTION
The MyTardis version (obtained via a git command in tardis/default_settings/__init__.py) was passed into the about.html template, but we also need it in the portal_template.html template, so the "version" template variable has been moved to the global context processor.

Now that the "Help" link points to mytardis.readthedocs.io (rather than locally built documentation), it is important to make it point to the correct version, otherwise clicking "Help" in MyTardis 3.8 will open the documentation for the develop branch with a confusing webpage title like "MyTardis 3.9 documentation".

Each time we tag a new version (e.g. v3.8.0-RC2), we need to activate the readthedocs build for that version.