### PR TITLE
Disabling the publication_forms app by default

### DIFF
--- a/tardis/default_settings/apps.py
+++ b/tardis/default_settings/apps.py
@@ -23,7 +23,7 @@ INSTALLED_APPS = (
     'tardis.search',
     'tardis.analytics',
     # these optional apps, may require extra settings
-    'tardis.apps.publication_forms',
+    # 'tardis.apps.publication_forms',
     'tardis.apps.oaipmh',
     # 'tardis.apps.push_to',
 )

--- a/tardis/tardis_portal/context_processors.py
+++ b/tardis/tardis_portal/context_processors.py
@@ -59,6 +59,9 @@ def global_contexts(request):
     site_title = getattr(settings, 'SITE_TITLE', None)
     sponsored_by = getattr(settings, 'SPONSORED_TEXT', None)
     site_styles = getattr(settings, 'SITE_STYLES', '')
+    # Enables UI elements for the publication form:
+    pub_form_enabled = ('tardis.apps.publication_forms'
+                        in settings.INSTALLED_APPS)
     version = getattr(settings, 'MYTARDIS_VERSION', None)
     return {'site_title': site_title,
             'sponsored_by': sponsored_by,

--- a/tardis/tardis_portal/templates/tardis_portal/javascript_libraries.html
+++ b/tardis/tardis_portal/templates/tardis_portal/javascript_libraries.html
@@ -41,7 +41,10 @@
 <link type="text/css" href="{% static 'ng-dialog/css/ngDialog.min.css' %}" rel="stylesheet" />
 <link type="text/css" href="{% static 'ng-dialog/css/ngDialog-theme-plain.min.css' %}" rel="stylesheet" />
 <link type="text/css" href="{% static 'ng-dialog/css/ngDialog-theme-default.min.css' %}" rel="stylesheet" />
+
+{% if pub_form_enabled %}
 <link type="text/css" href="{% static 'publication-form/publication_form.css' %}" rel="stylesheet" />
+{% endif %}
 
 <!-- Twitter Bootstrap: http://twitter.github.com/bootstrap/ -->
 <link href="{% static 'bootstrap/css/bootstrap.css' %}" rel="stylesheet">

--- a/tardis/tardis_portal/templates/tardis_portal/view_experiment.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_experiment.html
@@ -17,7 +17,9 @@
 {% mustachejs "tardis_portal/badges/datafile_count" %}
 {% mustachejs "tardis_portal/badges/size" %}
 
+{% if pub_form_enabled %}
 <script type="text/javascript" src="/static/publication-form/publication_form.js"></script>
+{% endif %}
 <script type="text/javascript">
     var toggle_files = function(loadCallback) {
         var $this = $(this);
@@ -237,11 +239,15 @@ $('#modal-metadata .submit-button').click(function() {
     {% endif %}
   </h4>
   {% if not experiment.public %}
+  {% if pub_form_enabled %}
   <div class="pull-right"
        ng-controller="PublicationFormController as pubFormCtrl"
        experiment_id="{{ experiment.id }}"
        is_publication="{{ experiment.is_publication }}"
        is_publication_draft="{{ experiment.is_publication_draft }}">
+  {% else %}
+  <div class="pull-right">
+  {% endif %}
     {% if has_read_or_owner_ACL and pub_form_enabled %}
     <a class="prepare_to_publish btn btn-mini btn-info"
        title="Prepare To Publish" ng-click="pubFormCtrl.openPublicationForm()" ng-show="pubFormCtrl.isPublicationDraft || !pubFormCtrl.isPublication">

--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -471,10 +471,6 @@ class ExperimentView(TemplateView):
             c['has_read_or_owner_ACL'] = \
                 authz.has_read_or_owner_ACL(request, experiment.id)
 
-        # Enables UI elements for the publication form
-        c['pub_form_enabled'] = 'tardis.apps.publication_forms' in \
-                                settings.INSTALLED_APPS
-
         # Enables UI elements for the push_to app
         c['push_to_enabled'] = PushToConfig.name in settings.INSTALLED_APPS
         if c['push_to_enabled']:


### PR DESCRIPTION
Disabling the publication_forms app by default and ensuring that
running MyTardis with it disabled doesn't trigger 404 errors
relating to publication_form.css or publication_form.js