### PR TITLE
CI builds now run with Ubuntu 18.04.

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN mkdir -p /home/webapp
 RUN groupadd -r webapp && useradd -r -g webapp webapp

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install \
     libxi6 \
     libgconf-2-4 \
     curl \
-    wget
+    wget \
+    gnupg
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
 RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update && apt-get install -qy google-chrome-stable

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 echo This is a guide only, please either edit or run appropriate commands manually
 exit
 
-# for Ubuntu 14.04
+# for Ubuntu 16.04 or 18.04
 # sudo bash install-ubuntu-requirements.sh
 # # optionally:
 # # sudo apt-get install memcached python-memcache
@@ -15,7 +15,9 @@ exit
 # brew install postgresql
 # or for a local development server, install http://postgresapp.com/
 
-# for Ubuntu 14.04
+# for Ubuntu 18.04:
+# source /etc/bash_completion.d/virtualenvwrapper
+# for Ubuntu 16.04:
 # source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
 # for OS X
 # source /usr/local/bin/virtualenvwrapper.sh

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -11,8 +11,8 @@ capabilities of MyTardis.
 Prerequisites
 -------------
 
-Ubuntu 16.04
-~~~~~~~~~~~~
+Ubuntu (18.04 LTS is recommended)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Run the script::
 
@@ -22,23 +22,6 @@ It will install required packages with this command:
 
 .. literalinclude:: ../../install-ubuntu-requirements.sh
    :language: bash
-
-Redhat/CentOS 7
-~~~~~~~~~~~~~~~
-
-Redhat based distributions are not actively supported. Here is a starting
-point, but you may require additional packages::
-
-  sudo yum install epel-release
-  sudo yum install cyrus-sasl-ldap cyrus-sasl-devel openldap-devel \
-  libxslt libxslt-devel libxslt-python git gcc graphviz-devel \
-  python-virtualenv python-virtualenvwrapper python-pip php-devel php-pear \
-  ImageMagick ImageMagick-devel libevent-devel compat-libevent14-devel
-
-
-Note that at least one of ``libevent-devel`` and ``compat-libevent14-devel``
-needs to be successfully installed as they are alternatives of the same package
-for different distributions.
 
 Download
 --------
@@ -63,13 +46,13 @@ It is recommended that you use a virtualenv. The list of packages above
 includes the ``virtualenvwrapper`` toolkit. Set up your environment with these
 commands::
 
-Ubuntu 14.04::
+Ubuntu 18.04::
+
+  source /etc/bash_completion.d/virtualenvwrapper
+
+For Ubuntu 16.04::
 
   source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
-
-Redhat/CentOS 7::
-
-  source /usr/bin/virtualenvwrapper.sh
 
 Then create the ``mytardis`` virtual environment ::
 
@@ -82,10 +65,6 @@ Note: the next time you want to work with this virtualenv, run the appropriate
 MyTardis dependencies are then installed with pip::
 
   pip install -U -r requirements.txt
-
-For Redhat/CentOS 7, also run::
-
-  pip install -U -r requirements-centos.txt
 
 Javascript dependencies are then installed with npm::
 
@@ -118,7 +97,7 @@ This is important for security reasons.
 A convenient method is to run the following command in your mytardis
 installation location::
 
-  python -c "import os; from random import choice; key_line = '%sSECRET_KEY=\"%s\"  # generated from build.sh\n' % ('from tardis.default_settings import * \n\n' if not os.path.isfile('tardis/settings.py') else '', ''.join([choice('abcdefghijklmnopqrstuvwxyz0123456789\\!@#$%^&*(-_=+)') for i in range(50)])); f=open('tardis/settings.py', 'a+'); f.write(key_line); f.close()"
+  python -c "import os; from random import choice; key_line = '%sSECRET_KEY=\"%s\"  # generated from build.sh\n' % ('from tardis.default_settings import * \n\n' if not os.path.isfile('tardis/settings.py') else '', ''.join([choice('abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)') for i in range(50)])); f=open('tardis/settings.py', 'a+'); f.write(key_line); f.close()"
 
 
 This is the minimum set of changes required to successfully run the
@@ -512,8 +491,6 @@ for your own needs and understand the settings before deploying it.::
           proxy_set_header Host $http_host;
           proxy_redirect off;
           proxy_pass http://mytardis;
-          # this is to solve centos 6 error:
-          # upstream prematurely closed
           client_max_body_size 4G;
           client_body_buffer_size 8192k;
           proxy_connect_timeout 2000;

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,8 +6,7 @@ Releases
 * Django 1.11
 * jQuery 3.3.1
 * Improved test coverage
-* Continuous Integration tests run against Ubuntu 16.04 (MyTardis v3.x used 14.04)
-    TO DO: Switch to Ubuntu 18.04 before v4.0 is released.
+* Continuous Integration tests run against Ubuntu 18.04 (MyTardis v3.x used 14.04)
 * ChromeDriver is used for BDD (Behaviour Driven Development) tests
 
 

--- a/install-ubuntu-requirements.sh
+++ b/install-ubuntu-requirements.sh
@@ -1,3 +1,6 @@
+# for Ubuntu 16.04 or 18.04
+# sudo bash install-ubuntu-requirements.sh
+
 apt-get update
 apt-get install git ipython libldap2-dev libmagickwand-dev libsasl2-dev \
   libssl-dev libxml2-dev libxslt1-dev libmagic-dev nodejs npm \

--- a/requirements-centos.txt
+++ b/requirements-centos.txt
@@ -1,2 +1,0 @@
-pystache==0.5.4
-flexmock==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ python-ldap==2.4.27
 # apps go here
 
 # OS specific packages go here (as build.sh only defines ubuntu packages)
-# -r requirements-centos.txt
 # -r requirements-osx.txt


### PR DESCRIPTION
Updated docs to indicate that Ubuntu 16.04 and Ubuntu 18.04 are supported,
but Ubuntu 18.04 is recommended.  Removed docs on CentOS installation,
as we don't have time to test it.