### PR TITLE
Downgrade gunicorn to previous version because of --log-syslog error

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -19,7 +19,7 @@ django-registration-redux==1.10
 django-tastypie-swagger==0.1.4
 django-user-agents==0.3.2
 elasticsearch==5.0.1
-gunicorn==19.8.1
+gunicorn==19.7.1
 gevent==1.3.4
 html2text==2018.1.9
 html5lib==1.0.1


### PR DESCRIPTION
Regression in latest 19.8 release of gunicorn

`AttributeError: No configuration setting for: disable_access_log_redirection`