### PR TITLE
Setting BROKER_URL to 'memory://' for local development/testing,

### DIFF
--- a/tardis/default_settings/celery_settings.py
+++ b/tardis/default_settings/celery_settings.py
@@ -9,3 +9,11 @@ CELERYBEAT_SCHEDULE = {
 }
 
 CELERY_IMPORTS = ('tardis.tardis_portal.tasks',)
+
+# Use a real broker (e.g. RabbitMQ) for production, but memory is OK for
+# local development:
+BROKER_URL = 'memory://'
+
+# For local development, you can force Celery tasks to run synchronously:
+# CELERY_ALWAYS_EAGER = True
+# CELERY_EAGER_PROPAGATES_EXCEPTIONS = True

--- a/tardis/test_settings.py
+++ b/tardis/test_settings.py
@@ -27,7 +27,7 @@ DATABASES = {
 
 # During testing it's always eager
 CELERY_ALWAYS_EAGER = True
-BROKER_BACKEND = 'memory'
+BROKER_URL = 'memory://'
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 tardis_portal_app = Celery('tardis_portal')
 tardis_portal_app.config_from_object('django.conf:settings')


### PR DESCRIPTION
because Celery's default of 'amqp://' assumes that you have a
broker like RabbitMQ running.