### PR TITLE
Switching to PEP 328 relative imports, which are more explicit

### DIFF
--- a/tardis/default_settings/__init__.py
+++ b/tardis/default_settings/__init__.py
@@ -1,35 +1,35 @@
 # pylint: disable=wildcard-import
 
 # first apps, so other files can add to INSTALLED_APPS
-from tardis.default_settings.apps import *
+from .apps import *
 
-from tardis.default_settings.admins import *
-from tardis.default_settings.analytics import *
-from tardis.default_settings.auth import *
-from tardis.default_settings.caches import *
-from tardis.default_settings.celery_settings import *
-from tardis.default_settings.custom_views import *
-from tardis.default_settings.database import *
-from tardis.default_settings.debug import *
-from tardis.default_settings.downloads import *
-from tardis.default_settings.email import *
-from tardis.default_settings.filters import *
-from tardis.default_settings.frontend import *
-from tardis.default_settings.i18n import *
-from tardis.default_settings.localisation import *
-from tardis.default_settings.logging import *
-from tardis.default_settings.middlewares import *
-from tardis.default_settings.publication import *
-from tardis.default_settings.search import *
-from tardis.default_settings.sftp import *
-from tardis.default_settings.sharing import *
-from tardis.default_settings.site_customisations import *
-from tardis.default_settings.staging import *
-from tardis.default_settings.static_files import *
-from tardis.default_settings.storage import *
-from tardis.default_settings.templates import *
-from tardis.default_settings.uploads import *
-from tardis.default_settings.urls import *
+from .admins import *
+from .analytics import *
+from .auth import *
+from .caches import *
+from .celery_settings import *
+from .custom_views import *
+from .database import *
+from .debug import *
+from .downloads import *
+from .email import *
+from .filters import *
+from .frontend import *
+from .i18n import *
+from .localisation import *
+from .logging import *
+from .middlewares import *
+from .publication import *
+from .search import *
+from .sftp import *
+from .sharing import *
+from .site_customisations import *
+from .staging import *
+from .static_files import *
+from .storage import *
+from .templates import *
+from .uploads import *
+from .urls import *
 
 
 # Get version from git to be displayed on About page.

--- a/tardis/default_settings/search.py
+++ b/tardis/default_settings/search.py
@@ -1,4 +1,4 @@
-from tardis.default_settings.apps import INSTALLED_APPS
+from .apps import INSTALLED_APPS
 
 # Settings for the single search box
 SINGLE_SEARCH_ENABLED = False

--- a/tardis/default_settings/static_files.py
+++ b/tardis/default_settings/static_files.py
@@ -1,5 +1,5 @@
 from os import path
-from tardis.default_settings.storage import DEFAULT_STORAGE_BASE_DIR
+from .storage import DEFAULT_STORAGE_BASE_DIR
 
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"

--- a/tardis/default_settings/uploads.py
+++ b/tardis/default_settings/uploads.py
@@ -1,4 +1,4 @@
-from tardis.default_settings.urls import MEDIA_URL, STATIC_URL
+from .urls import MEDIA_URL, STATIC_URL
 
 UPLOAD_METHOD = False
 '''

--- a/tardis/settings_changeme.py
+++ b/tardis/settings_changeme.py
@@ -1,2 +1,2 @@
 # pylint: disable=wildcard-import
-from tardis.default_settings import *  # noqa # pylint: disable=W0614
+from .default_settings import *  # noqa # pylint: disable=W0614

--- a/tardis/tardis_portal/ParameterSetManager.py
+++ b/tardis/tardis_portal/ParameterSetManager.py
@@ -4,9 +4,9 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.timezone import is_aware, make_aware
 
-from tardis.tardis_portal.models import Experiment
-from tardis.tardis_portal.models import Dataset
-from tardis.tardis_portal.models import DataFile
+from .models.experiment import Experiment
+from .models.dataset import Dataset
+from .models.datafile import DataFile
 
 LOCAL_TZ = pytz.timezone(settings.TIME_ZONE)
 
@@ -42,13 +42,14 @@ class ParameterSetManager(object):
         :param string schema: Schema namespace
         :raises TypeError:
         """
-        from tardis.tardis_portal.models import DatasetParameterSet
-        from tardis.tardis_portal.models import DatafileParameterSet
-        from tardis.tardis_portal.models import ExperimentParameterSet
-        from tardis.tardis_portal.models import DatasetParameter
-        from tardis.tardis_portal.models import DatafileParameter
-        from tardis.tardis_portal.models import ExperimentParameter
-        from tardis.tardis_portal.models.parameters import ParameterSet
+        from .models.parameters import (
+            DatasetParameterSet,
+            DatafileParameterSet,
+            ExperimentParameterSet,
+            DatasetParameter,
+            DatafileParameter,
+            ExperimentParameter,
+            ParameterSet)
 
         if issubclass(type(self), ParameterSet):
             pass
@@ -124,7 +125,7 @@ class ParameterSetManager(object):
             raise TypeError("Missing arguments")
 
     def get_schema(self):
-        from tardis.tardis_portal.models import Schema
+        from .models.parameters import Schema
         try:
             schema = Schema.objects.get(
                 namespace=self.namespace)
@@ -208,7 +209,7 @@ class ParameterSetManager(object):
 
     def _get_create_parname(self, parname,
                             fullparname=None, example_value=None):
-        from tardis.tardis_portal.models import ParameterName
+        from .models.parameters import ParameterName
         try:
             paramName = ParameterName.objects.get(
                 name=parname, schema__id=self.get_schema().id)

--- a/tardis/tardis_portal/admin.py
+++ b/tardis/tardis_portal/admin.py
@@ -36,7 +36,7 @@ import django.db
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericTabularInline
 
-from tardis.tardis_portal import models
+from . import models
 
 # from south.models import MigrationHistory
 

--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -34,36 +34,33 @@ from tastypie.utils import trailing_slash
 from tastypie.contrib.contenttypes.fields import GenericForeignKeyField
 
 from tardis.analytics.tracker import IteratorTracker
-from tardis.tardis_portal import tasks
-from tardis.tardis_portal.auth.decorators import \
-    get_accessible_datafiles_for_user
-from tardis.tardis_portal.auth.decorators import has_datafile_access
-from tardis.tardis_portal.auth.decorators import has_datafile_download_access
-from tardis.tardis_portal.auth.decorators import has_dataset_access
-from tardis.tardis_portal.auth.decorators import has_dataset_write
-from tardis.tardis_portal.auth.decorators import has_delete_permissions
-from tardis.tardis_portal.auth.decorators import has_experiment_access
-from tardis.tardis_portal.auth.decorators import has_write_permissions
-from tardis.tardis_portal.auth.localdb_auth import django_user
-from tardis.tardis_portal.models import ObjectACL
-from tardis.tardis_portal.models.datafile import DataFile, compute_checksums
-from tardis.tardis_portal.models.datafile import DataFileObject
-from tardis.tardis_portal.models.dataset import Dataset
-from tardis.tardis_portal.models.experiment import Experiment
-from tardis.tardis_portal.models.parameters import DatafileParameter
-from tardis.tardis_portal.models.parameters import DatafileParameterSet
-from tardis.tardis_portal.models.parameters import DatasetParameter
-from tardis.tardis_portal.models.parameters import DatasetParameterSet
-from tardis.tardis_portal.models.parameters import ExperimentParameter
-from tardis.tardis_portal.models.parameters import ExperimentParameterSet
-from tardis.tardis_portal.models.parameters import ParameterName
-from tardis.tardis_portal.models.parameters import Schema
-from tardis.tardis_portal.models.storage import StorageBox
-from tardis.tardis_portal.models.storage import StorageBoxOption
-from tardis.tardis_portal.models.storage import StorageBoxAttribute
-from tardis.tardis_portal.models.facility import Facility
-from tardis.tardis_portal.models.facility import facilities_managed_by
-from tardis.tardis_portal.models.instrument import Instrument
+from . import tasks
+from .auth.decorators import (
+    get_accessible_datafiles_for_user,
+    has_datafile_access,
+    has_datafile_download_access,
+    has_dataset_access,
+    has_dataset_write,
+    has_delete_permissions,
+    has_experiment_access,
+    has_write_permissions)
+from .auth.localdb_auth import django_user
+from .models.access_control import ObjectACL
+from .models.datafile import DataFile, DataFileObject, compute_checksums
+from .models.dataset import Dataset
+from .models.experiment import Experiment
+from .models.parameters import (
+    DatafileParameter,
+    DatafileParameterSet,
+    DatasetParameter,
+    DatasetParameterSet,
+    ExperimentParameter,
+    ExperimentParameterSet,
+    ParameterName,
+    Schema)
+from .models.storage import StorageBox, StorageBoxOption, StorageBoxAttribute
+from .models.facility import Facility, facilities_managed_by
+from .models.instrument import Instrument
 
 
 class PrettyJSONSerializer(Serializer):

--- a/tardis/tardis_portal/auth/__init__.py
+++ b/tardis/tardis_portal/auth/__init__.py
@@ -29,7 +29,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from tardis.tardis_portal.auth.authservice import AuthService
+from .authservice import AuthService
 
 # The auth_service ``singleton``
 auth_service = AuthService()

--- a/tardis/tardis_portal/auth/authentication.py
+++ b/tardis/tardis_portal/auth/authentication.py
@@ -7,13 +7,13 @@ views.py.
 import logging
 
 from django.conf import settings
+from django.contrib.auth.models import Group
 from django.http import HttpResponse
 
-from tardis.tardis_portal.models import UserProfile, UserAuthentication, \
-    ObjectACL, Group
-from tardis.tardis_portal.auth import localdb_auth
-from tardis.tardis_portal.forms import createLinkedUserAuthenticationForm
-from tardis.tardis_portal.shortcuts import render_response_index
+from ..models import UserProfile, UserAuthentication, ObjectACL
+from . import localdb_auth
+from ..forms import createLinkedUserAuthenticationForm
+from ..shortcuts import render_response_index
 
 
 logger = logging.getLogger(__name__)
@@ -99,7 +99,7 @@ def add_auth_method(request):
         authentication methods
     :rtype: HttpResponse
     """
-    from tardis.tardis_portal.auth import auth_service
+    from . import auth_service
 
     supportedAuthMethods = _getSupportedAuthMethods()
     LinkedUserAuthenticationForm = \
@@ -185,7 +185,7 @@ def merge_auth_method(request):
     :rtype: HttpResponse
     """
 
-    from tardis.tardis_portal.auth import auth_service
+    from . import auth_service
 
     supportedAuthMethods = _getSupportedAuthMethods()
     LinkedUserAuthenticationForm = \

--- a/tardis/tardis_portal/auth/authorisation.py
+++ b/tardis/tardis_portal/auth/authorisation.py
@@ -8,8 +8,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.db.models.query import QuerySet
 
-from tardis.tardis_portal.auth.token_auth import TokenGroupProvider
-from tardis.tardis_portal.models import ObjectACL
+from ..models.access_control import ObjectACL
+from .token_auth import TokenGroupProvider
 
 
 class ACLAwareBackend(object):

--- a/tardis/tardis_portal/auth/authservice.py
+++ b/tardis/tardis_portal/auth/authservice.py
@@ -44,8 +44,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.contrib.auth.models import User
 from django.contrib.auth.models import Permission
 
-from tardis.tardis_portal.auth.localdb_auth import auth_key as localdb_auth_key
-from tardis.tardis_portal.auth.utils import get_or_create_user
+from ..auth.localdb_auth import auth_key as localdb_auth_key
+from ..auth.utils import get_or_create_user
 
 logger = logging.getLogger(__name__)
 
@@ -196,7 +196,7 @@ class AuthService():
             except (NotImplementedError, AttributeError):
                 # For backwards compatibility
                 try:
-                    from tardis.tardis_portal.models import UserAuthentication
+                    from ..models.access_control import UserAuthentication
                     # Check if the given username in combination with the
                     # auth method is already in the UserAuthentication table
                     user = UserAuthentication.objects.get(username=user_id,

--- a/tardis/tardis_portal/auth/decorators.py
+++ b/tardis/tardis_portal/auth/decorators.py
@@ -29,15 +29,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
 from django.contrib.sessions.models import Session
 from django.http import HttpResponse, HttpRequest
 from django.http import HttpResponseRedirect
 from django.db.models import Q
 from django.conf import settings
 
-from tardis.tardis_portal.models import Experiment, Dataset, DataFile, \
-    GroupAdmin, User
-from tardis.tardis_portal.shortcuts import return_response_error
+from ..models import Experiment, Dataset, DataFile, GroupAdmin
+from ..shortcuts import return_response_error
 
 
 def get_accessible_experiments(request):
@@ -160,7 +160,7 @@ def has_read_or_owner_ACL(request, experiment_id):
     general read permission.
     """
     from datetime import datetime
-    from tardis.tardis_portal.auth.localdb_auth import django_user
+    from .localdb_auth import django_user
 
     experiment = Experiment.safe.get(request.user, experiment_id)
 
@@ -195,7 +195,7 @@ def has_read_or_owner_ACL(request, experiment_id):
                       | Q(expiryDate__isnull=True))
 
     # is there at least one ACL rule which satisfies the rules?
-    from tardis.tardis_portal.models import ObjectACL
+    from ..models.access_control import ObjectACL
     acl = ObjectACL.objects.filter(query)
     return bool(acl)
 

--- a/tardis/tardis_portal/auth/fix_circular.py
+++ b/tardis/tardis_portal/auth/fix_circular.py
@@ -1,4 +1,4 @@
-from tardis.tardis_portal.auth import auth_service
+from . import auth_service
 
 
 def getGroups(user):

--- a/tardis/tardis_portal/auth/httpbasicendpoint_auth.py
+++ b/tardis/tardis_portal/auth/httpbasicendpoint_auth.py
@@ -7,8 +7,9 @@ Created on Dec 15, 2011
 import urllib2
 from django.conf import settings
 from django.contrib.auth.models import User
-from tardis.tardis_portal.auth.interfaces import AuthProvider
-from tardis.tardis_portal.auth.utils import configure_user
+from .interfaces import AuthProvider
+from .utils import configure_user
+
 
 class HttpBasicEndpointAuth(AuthProvider):
     '''

--- a/tardis/tardis_portal/auth/ldap_auth.py
+++ b/tardis/tardis_portal/auth/ldap_auth.py
@@ -41,9 +41,8 @@ import ldap
 
 from django.conf import settings
 
-from tardis.tardis_portal.auth.interfaces import AuthProvider, \
-    GroupProvider, UserProvider
-from tardis.tardis_portal.models import UserAuthentication
+from ..models import UserAuthentication
+from .interfaces import AuthProvider, GroupProvider, UserProvider
 
 
 logger = logging.getLogger(__name__)

--- a/tardis/tardis_portal/auth/localdb_auth.py
+++ b/tardis/tardis_portal/auth/localdb_auth.py
@@ -9,7 +9,7 @@ import logging
 from django.contrib.auth.models import User, Group
 from django.contrib.auth.backends import ModelBackend
 
-from tardis.tardis_portal.auth.interfaces import AuthProvider, GroupProvider, UserProvider
+from .interfaces import AuthProvider, GroupProvider, UserProvider
 
 
 logger = logging.getLogger(__name__)

--- a/tardis/tardis_portal/auth/token_auth.py
+++ b/tardis/tardis_portal/auth/token_auth.py
@@ -1,8 +1,8 @@
 """
 token authentication module
 """
-from tardis.tardis_portal.models import Token, ObjectACL, Experiment
-from tardis.tardis_portal.auth.interfaces import GroupProvider
+from ..models import Token, ObjectACL, Experiment
+from ..auth.interfaces import GroupProvider
 
 TOKEN_EXPERIMENT = '_token_experiment'
 

--- a/tardis/tardis_portal/auth/utils.py
+++ b/tardis/tardis_portal/auth/utils.py
@@ -6,7 +6,8 @@ Created on 15/03/2011
 
 from django.conf import settings
 from django.contrib.auth.models import User, Group
-from tardis.tardis_portal.models import UserAuthentication
+
+from ..models.access_control import UserAuthentication
 
 
 def get_or_create_user(auth_method, user_id, email=''):

--- a/tardis/tardis_portal/context_processors.py
+++ b/tardis/tardis_portal/context_processors.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from tardis.tardis_portal.staging import get_full_staging_path
+from .staging import get_full_staging_path
 
 
 def single_search_processor(request):

--- a/tardis/tardis_portal/creativecommonshandler.py
+++ b/tardis/tardis_portal/creativecommonshandler.py
@@ -5,10 +5,9 @@ A wrapper for creative commons interactions on a ParameterSet
 
 .. moduleauthor:: Steve Androulakis <steve.androulakis@monash.edu>
 '''
-from tardis.tardis_portal.ParameterSetManager import\
-    ParameterSetManager
-from tardis.tardis_portal.models import \
-    Experiment, ExperimentParameterSet
+from .ParameterSetManager import ParameterSetManager
+from .models.experiment import Experiment
+from .models.parameters import ExperimentParameterSet
 
 
 class CreativeCommonsHandler():

--- a/tardis/tardis_portal/download.py
+++ b/tardis/tardis_portal/download.py
@@ -36,17 +36,16 @@ from django.core.exceptions import ImproperlyConfigured
 from django.contrib.auth.decorators import login_required
 
 from tardis.analytics.tracker import IteratorTracker
-from tardis.tardis_portal.models import Dataset
-from tardis.tardis_portal.models import DataFile
-from tardis.tardis_portal.models import Experiment
-from tardis.tardis_portal.auth.decorators import has_datafile_download_access
-from tardis.tardis_portal.auth.decorators import experiment_download_required
-from tardis.tardis_portal.auth.decorators import dataset_download_required
-from tardis.tardis_portal.shortcuts import render_error_message
-from tardis.tardis_portal.shortcuts import (return_response_not_found,
-                                            return_response_error)
-from tardis.tardis_portal.util import (get_filesystem_safe_dataset_name,
-                                       get_filesystem_safe_experiment_name)
+from .models import Dataset
+from .models import DataFile
+from .models import Experiment
+from .auth.decorators import has_datafile_download_access
+from .auth.decorators import experiment_download_required
+from .auth.decorators import dataset_download_required
+from .shortcuts import render_error_message
+from .shortcuts import return_response_not_found, return_response_error
+from .util import (get_filesystem_safe_dataset_name,
+                   get_filesystem_safe_experiment_name)
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +64,7 @@ def _create_download_response(request, datafile_id, disposition='attachment'):  
         return return_response_error(request)
     # Send an image that can be seen in the browser
     if disposition == 'inline' and datafile.is_image():
-        from tardis.tardis_portal.iiif import download_image
+        from .iiif import download_image
         args = (request, datafile.id, 'full', 'full', '0', 'native')
         # Send unconverted image if web-compatible
         if datafile.get_mimetype() in ('image/gif', 'image/jpeg', 'image/png'):

--- a/tardis/tardis_portal/filters/__init__.py
+++ b/tardis/tardis_portal/filters/__init__.py
@@ -44,7 +44,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_save
 from django.core.exceptions import MiddlewareNotUsed
 
-from tardis.tardis_portal.models.datafile import DataFileObject
+from ..models.datafile import DataFileObject
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 class FilterInitMiddleware(object):
 
     def __init__(self, get_response, filters=None):  # noqa # TODO too complex
-        from tardis.tardis_portal.models import DataFile
+        from ..models import DataFile
         self.get_response = get_response
         if not filters:
             filters = getattr(settings, 'POST_SAVE_FILTERS', [])

--- a/tardis/tardis_portal/filters/jeolsem.py
+++ b/tardis/tardis_portal/filters/jeolsem.py
@@ -2,9 +2,9 @@ import logging
 from itertools import chain
 from StringIO import StringIO
 
-from tardis.tardis_portal.models import Schema, ParameterName
-from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
-from tardis.tardis_portal.models.parameters import DatasetParameter
+from ..models import Schema, ParameterName
+from ..ParameterSetManager import ParameterSetManager
+from ..models.parameters import DatasetParameter
 
 logger = logging.getLogger(__name__)
 

--- a/tardis/tardis_portal/forms.py
+++ b/tardis/tardis_portal/forms.py
@@ -60,14 +60,14 @@ from haystack.forms import SearchForm
 from form_utils import forms as formutils
 from registration.models import RegistrationProfile
 
-from tardis.tardis_portal import models
-from tardis.tardis_portal.fields import MultiValueCommaSeparatedField
-from tardis.tardis_portal.widgets import CommaSeparatedInput
-from tardis.tardis_portal.models import UserAuthentication, Experiment, License
-from tardis.tardis_portal.auth.localdb_auth \
+from . import models
+from .fields import MultiValueCommaSeparatedField
+from .widgets import CommaSeparatedInput
+from .models import UserAuthentication, Experiment, License
+from .auth.localdb_auth \
     import auth_key as locabdb_auth_key
 
-from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
+from .ParameterSetManager import ParameterSetManager
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +184,7 @@ class RegistrationForm(forms.Form):
 class ChangeUserPermissionsForm(ModelForm):
 
     class Meta:
-        from tardis.tardis_portal.models import ObjectACL
+        from .models import ObjectACL
         model = ObjectACL
         fields = [
             'canDelete',
@@ -522,7 +522,7 @@ class ExperimentForm(forms.ModelForm):
 
 def createSearchExperimentForm():
 
-    from tardis.tardis_portal.models import ParameterName
+    from .models import ParameterName
 
     fields = {}
     fields['title'] = forms.CharField(label='Title',
@@ -633,7 +633,7 @@ class StaticField(forms.Field):
 
 def create_parameterset_edit_form(parameterset, request=None):
 
-    from tardis.tardis_portal.models import ParameterName
+    from .models import ParameterName
 
     # if POST data to save
     if request:
@@ -731,7 +731,7 @@ def save_datafile_edit_form(parameterset, request):
 
 def create_datafile_add_form(schema, parentObject, request=None):
 
-    from tardis.tardis_portal.models import ParameterName
+    from .models import ParameterName
 
     # if POST data to save
     if request:

--- a/tardis/tardis_portal/iiif.py
+++ b/tardis/tardis_portal/iiif.py
@@ -13,8 +13,8 @@ from django.http import HttpResponse, HttpResponseNotFound
 from django.views.decorators.http import etag
 from django.utils.cache import patch_cache_control
 
-from tardis.tardis_portal.models import DataFile
-from tardis.tardis_portal.auth.decorators import has_datafile_download_access
+from .models import DataFile
+from .auth.decorators import has_datafile_download_access
 
 
 MAX_AGE = getattr(settings, 'DATAFILE_CACHE_MAX_AGE', 60*60*24*7)

--- a/tardis/tardis_portal/management/commands/createuser.py
+++ b/tardis/tardis_portal/management/commands/createuser.py
@@ -12,9 +12,8 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import ugettext as _
 from six.moves import input
 
-from tardis.tardis_portal.models import UserAuthentication
-from tardis.tardis_portal.auth.localdb_auth \
-    import auth_key as locabdb_auth_key
+from ...models import UserAuthentication
+from ...auth.localdb_auth import auth_key as locabdb_auth_key
 
 
 RE_VALID_USERNAME = re.compile('[\w.@+-]+$')

--- a/tardis/tardis_portal/management/commands/dumpschemas.py
+++ b/tardis/tardis_portal/management/commands/dumpschemas.py
@@ -7,7 +7,7 @@ from django.db import DEFAULT_DB_ALIAS
 from django.core import serializers
 
 
-from tardis.tardis_portal import models
+from ... import models
 
 
 class Command(BaseCommand):

--- a/tardis/tardis_portal/management/commands/rmexperiment.py
+++ b/tardis/tardis_portal/management/commands/rmexperiment.py
@@ -12,11 +12,11 @@ some cascading.
 import sys
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction, DEFAULT_DB_ALIAS
-from tardis.tardis_portal.models import Experiment, Dataset, DataFile
-from tardis.tardis_portal.models import ExperimentAuthor, ObjectACL
-from tardis.tardis_portal.models import ExperimentParameterSet, ExperimentParameter
-from tardis.tardis_portal.models import DatasetParameterSet
-from tardis.tardis_portal.models import DatafileParameterSet
+from ...models import Experiment, Dataset, DataFile
+from ...models import ExperimentAuthor, ObjectACL
+from ...models import ExperimentParameterSet, ExperimentParameter
+from ...models import DatasetParameterSet
+from ...models import DatafileParameterSet
 
 
 class Command(BaseCommand):

--- a/tardis/tardis_portal/management/commands/runfilters.py
+++ b/tardis/tardis_portal/management/commands/runfilters.py
@@ -40,7 +40,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction, DEFAULT_DB_ALIAS
 from django.core.exceptions import ImproperlyConfigured
 
-from tardis.tardis_portal.models import DataFile
+from ...models import DataFile
 
 
 logger = logging.getLogger(__name__)

--- a/tardis/tardis_portal/managers.py
+++ b/tardis/tardis_portal/managers.py
@@ -12,9 +12,8 @@ from django.db.models import Q
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import User, Group
 
-from tardis.tardis_portal.auth.localdb_auth import django_user,\
-    django_group
-from tardis.tardis_portal.models import ObjectACL
+from .auth.localdb_auth import django_user, django_group
+from .models.access_control import ObjectACL
 
 
 class OracleSafeManager(models.Manager):
@@ -89,7 +88,7 @@ class ExperimentManager(OracleSafeManager):
         # this is almost duplicate code of end of has_perm in authorisation.py
         # should be refactored, but cannot think of good way atm
         if not user.is_authenticated:
-            from tardis.tardis_portal.auth.token_auth import TokenGroupProvider
+            from .auth.token_auth import TokenGroupProvider
             query = Q(id=None)
             tgp = TokenGroupProvider()
             for group in tgp.getGroups(user):
@@ -126,7 +125,7 @@ class ExperimentManager(OracleSafeManager):
         return query
 
     def _query_all_public(self):
-        from tardis.tardis_portal.models import Experiment
+        from .models import Experiment
         return ~Q(public_access=Experiment.PUBLIC_ACCESS_NONE)
 
     def get(self, user, experiment_id):
@@ -304,7 +303,7 @@ class ExperimentManager(OracleSafeManager):
         :returns: system owned groups for experiment
         :rtype: QuerySet
         """
-        from tardis.tardis_portal.models import ObjectACL
+        from .models import ObjectACL
         acl = ObjectACL.objects.filter(
             pluginId='django_group',
             content_type__model='experiment',
@@ -322,7 +321,7 @@ class ExperimentManager(OracleSafeManager):
         :rtype: list
         """
 
-        from tardis.tardis_portal.models import ObjectACL
+        from .models import ObjectACL
         acl = ObjectACL.objects.exclude(pluginId=django_user)
         acl = acl.exclude(pluginId='django_group')
         acl = acl.filter(content_type__model='experiment',
@@ -331,7 +330,7 @@ class ExperimentManager(OracleSafeManager):
         if not acl:
             return None
 
-        from tardis.tardis_portal.auth import AuthService
+        from .auth import AuthService
         authService = AuthService()
 
         result = []

--- a/tardis/tardis_portal/models/__init__.py
+++ b/tardis/tardis_portal/models/__init__.py
@@ -42,27 +42,26 @@ models/__init__.py
 
 from django.contrib.auth.models import User, Group
 
-from tardis.tardis_portal.models.access_control import (
-    UserAuthentication, UserProfile, GroupAdmin)
-from tardis.tardis_portal.models.access_control import ObjectACL
-from tardis.tardis_portal.models.facility import Facility
-from tardis.tardis_portal.models.instrument import Instrument
-from tardis.tardis_portal.models.experiment import Experiment, ExperimentAuthor
-from tardis.tardis_portal.models.dataset import Dataset
-from tardis.tardis_portal.models.datafile import DataFile
-from tardis.tardis_portal.models.datafile import DataFileObject
-from tardis.tardis_portal.models.storage import StorageBox
-from tardis.tardis_portal.models.storage import StorageBoxOption
-from tardis.tardis_portal.models.storage import StorageBoxAttribute
+import tardis.tardis_portal.models.hooks
 
-from tardis.tardis_portal.models.jti import JTI
+from .access_control import UserAuthentication, UserProfile, GroupAdmin
+from .access_control import ObjectACL
+from .facility import Facility
+from .instrument import Instrument
+from .experiment import Experiment, ExperimentAuthor
+from .dataset import Dataset
+from .datafile import DataFile
+from .datafile import DataFileObject
+from .storage import StorageBox
+from .storage import StorageBoxOption
+from .storage import StorageBoxAttribute
 
-from tardis.tardis_portal.models.license import License
-from tardis.tardis_portal.models.parameters import (
+from .jti import JTI
+
+from .license import License
+from .parameters import (
     DatafileParameter, DatafileParameterSet, DatasetParameter,
     DatasetParameterSet, ExperimentParameter, ExperimentParameterSet,
     InstrumentParameter, InstrumentParameterSet, FreeTextSearchField,
     ParameterName, Schema)
-from tardis.tardis_portal.models.token import Token
-
-import tardis.tardis_portal.models.hooks
+from .token import Token

--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -22,7 +22,7 @@ from django.utils import timezone
 
 import magic
 
-from tardis.tardis_portal import tasks
+from .. import tasks
 from .dataset import Dataset
 from .storage import StorageBox, StorageBoxOption, StorageBoxAttribute
 

--- a/tardis/tardis_portal/models/dataset.py
+++ b/tardis/tardis_portal/models/dataset.py
@@ -5,8 +5,8 @@ from django.conf import settings
 from django.urls import reverse
 from django.db import models
 
-from tardis.tardis_portal.managers import OracleSafeManager
-from tardis.tardis_portal.models.storage import StorageBox
+from ..managers import OracleSafeManager
+from .storage import StorageBox
 
 from .experiment import Experiment
 from .instrument import Instrument
@@ -47,7 +47,7 @@ class Dataset(models.Model):
         experiment.
 
         """
-        from tardis.tardis_portal.models.parameters import Schema
+        from .parameters import Schema
         if schemaType == Schema.DATASET or schemaType is None:
             return self.datasetparameterset_set.filter(
                 schema__type=Schema.DATASET)

--- a/tardis/tardis_portal/models/experiment.py
+++ b/tardis/tardis_portal/models/experiment.py
@@ -9,8 +9,8 @@ from django.urls import reverse
 from django.db import models
 from django.utils.safestring import SafeUnicode
 
-from tardis.tardis_portal.managers import OracleSafeManager, ExperimentManager
-from tardis.tardis_portal.models import ObjectACL
+from ..managers import OracleSafeManager, ExperimentManager
+from .access_control import ObjectACL
 
 from .license import License
 
@@ -102,7 +102,7 @@ class Experiment(models.Model):
         experiment.
 
         """
-        from tardis.tardis_portal.models.parameters import Schema
+        from .parameters import Schema
         if schemaType == Schema.EXPERIMENT or schemaType is None:
             return self.experimentparameterset_set.filter(
                 schema__type=Schema.EXPERIMENT)

--- a/tardis/tardis_portal/models/hooks.py
+++ b/tardis/tardis_portal/models/hooks.py
@@ -16,7 +16,7 @@ def publish_public_expt_rifcs(experiment):
         providers = settings.RIFCS_PROVIDERS
     except:
         providers = None
-    from tardis.tardis_portal.publish.publishservice import PublishService
+    from ..publish.publishservice import PublishService
     pservice = PublishService(providers, experiment)
     try:
         pservice.manage_rifcs(settings.OAI_DOCS_PATH)

--- a/tardis/tardis_portal/models/instrument.py
+++ b/tardis/tardis_portal/models/instrument.py
@@ -1,5 +1,5 @@
 from django.db import models
-from tardis.tardis_portal.models import Facility
+from .facility import Facility
 
 
 class Instrument(models.Model):
@@ -22,7 +22,7 @@ class Instrument(models.Model):
         instrument.
 
         '''
-        from tardis.tardis_portal.models.parameters import Schema
+        from .parameters import Schema
         if schemaType == Schema.INSTRUMENT or schemaType is None:
             return self.instrumentparameterset_set.filter(
                 schema__type=Schema.INSTRUMENT)

--- a/tardis/tardis_portal/models/parameters.py
+++ b/tardis/tardis_portal/models/parameters.py
@@ -14,9 +14,8 @@ from django.db import models
 from django.utils.safestring import mark_safe
 from django.utils.timezone import is_aware, is_naive, make_aware, make_naive
 
-from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
-from tardis.tardis_portal.managers import OracleSafeManager,\
-    ParameterNameManager, SchemaManager
+from ..ParameterSetManager import ParameterSetManager
+from ..managers import OracleSafeManager, ParameterNameManager, SchemaManager
 
 from .experiment import Experiment
 from .dataset import Dataset

--- a/tardis/tardis_portal/models/token.py
+++ b/tardis/tardis_portal/models/token.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.db import models
 from django.contrib.auth.models import User
 
-from tardis.tardis_portal.managers import OracleSafeManager
+from ..managers import OracleSafeManager
 
 from .experiment import Experiment
 

--- a/tardis/tardis_portal/publish/publishservice.py
+++ b/tardis/tardis_portal/publish/publishservice.py
@@ -9,7 +9,7 @@ class PublishService():
         self.provider = self._get_provider()
 
     def _get_provider(self):
-        from tardis.tardis_portal.publish.provider.rifcsprovider import RifCsProvider
+        from .provider.rifcsprovider import RifCsProvider
         if self.rc_providers:
             from importlib import import_module
             for pmodule in self.rc_providers:
@@ -51,7 +51,7 @@ class PublishService():
             os.remove(filename)
 
     def _write_rifcs_to_oai_dir(self, oaipath):
-        from tardis.tardis_portal.xmlwriter import XMLWriter
+        from ..xmlwriter import XMLWriter
         xmlwriter = XMLWriter()
         os.path.isdir(oaipath) or os.makedirs(oaipath)
         xmlwriter.write_template_to_dir(oaipath, "MyTARDIS-%s.xml" % self.experiment.id,

--- a/tardis/tardis_portal/sftp.py
+++ b/tardis/tardis_portal/sftp.py
@@ -22,8 +22,8 @@ from paramiko import OPEN_SUCCEEDED, OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED,\
 from paramiko.common import AUTH_FAILED, AUTH_SUCCESSFUL
 
 from tardis.analytics import tracker
-from tardis.tardis_portal.download import make_mapper
-from tardis.tardis_portal.util import split_path
+from .download import make_mapper
+from .util import split_path
 
 logger = logging.getLogger(__name__)
 path_mapper = make_mapper(settings.DEFAULT_PATH_MAPPER, rootdir=None)
@@ -43,7 +43,7 @@ if getattr(settings, 'SFTP_GEVENT', False):
 from django.contrib.sites.models import Site  # noqa
 from django.contrib.auth.models import AnonymousUser  # noqa
 
-from tardis.tardis_portal.models import DataFile, Experiment  # noqa
+from .models import DataFile, Experiment  # noqa
 
 
 class DynamicTree(object):
@@ -386,7 +386,7 @@ class MyTServerInterface(ServerInterface):
         return ','.join(auth_methods)
 
     def myt_auth(self, username, password):
-        from tardis.tardis_portal.auth import auth_service
+        from .auth import auth_service
 
         class FakeRequest(object):
             POST = {}

--- a/tardis/tardis_portal/shortcuts.py
+++ b/tardis/tardis_portal/shortcuts.py
@@ -9,9 +9,8 @@ from django.http import HttpResponse
 from django.template.loader import render_to_string
 from django.contrib.sites.models import Site
 
-from tardis.tardis_portal.models import \
-    ExperimentParameterSet
-from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
+from .models import ExperimentParameterSet
+from .ParameterSetManager import ParameterSetManager
 
 
 def render_response_index(request, *args, **kwargs):
@@ -57,7 +56,7 @@ def return_response_error(request):
 
 
 def get_experiment_referer(request, dataset_id):
-    from tardis.tardis_portal.auth.decorators import get_accessible_experiments_for_dataset
+    from .auth.decorators import get_accessible_experiments_for_dataset
 
     try:
         from_url = request.META['HTTP_REFERER']
@@ -156,7 +155,7 @@ class RestfulExperimentParameterSet(object):
     view_functions = property(_get_view_functions)
 
     def _list(self, request, experiment_id):
-        from tardis.tardis_portal.auth.decorators import has_experiment_access
+        from .auth.decorators import has_experiment_access
         if not has_experiment_access(request, experiment_id):
             return return_response_error(request)
         sets = ExperimentParameterSet.objects.filter(schema=self.schema,
@@ -167,7 +166,7 @@ class RestfulExperimentParameterSet(object):
 
 
     def _get(self, request, experiment_id, ps_id):
-        from tardis.tardis_portal.auth.decorators import has_experiment_access
+        from .auth.decorators import has_experiment_access
         if not has_experiment_access(request, experiment_id):
             return return_response_error(request)
         try:
@@ -181,7 +180,7 @@ class RestfulExperimentParameterSet(object):
 
 
     def _create(self, request, experiment_id):
-        from tardis.tardis_portal.auth.decorators import has_experiment_write
+        from .auth.decorators import has_experiment_write
         if not has_experiment_write(request, experiment_id):
             return return_response_error(request)
         form = self.form_cls(json.loads(request.body))
@@ -197,7 +196,7 @@ class RestfulExperimentParameterSet(object):
 
 
     def _update(self, request, experiment_id, ps_id):
-        from tardis.tardis_portal.auth.decorators import has_experiment_write
+        from .auth.decorators import has_experiment_write
         if not has_experiment_write(request, experiment_id):
             return return_response_error(request)
 
@@ -218,7 +217,7 @@ class RestfulExperimentParameterSet(object):
 
 
     def _delete(self, request, experiment_id, ps_id):
-        from tardis.tardis_portal.auth.decorators import has_experiment_write
+        from .auth.decorators import has_experiment_write
         if not has_experiment_write(request, experiment_id):
             return return_response_error(request)
 

--- a/tardis/tardis_portal/staging.py
+++ b/tardis/tardis_portal/staging.py
@@ -159,7 +159,7 @@ def get_full_staging_path(username):
     # check if the user is authenticated using the deployment's
     # staging protocol
     try:
-        from tardis.tardis_portal.models import UserAuthentication
+        from .models import UserAuthentication
         UserAuthentication.objects.get(
             userProfile__user__username=username,
             authenticationMethod=settings.STAGING_PROTOCOL)

--- a/tardis/tardis_portal/templatetags/dataset_tags.py
+++ b/tardis/tardis_portal/templatetags/dataset_tags.py
@@ -1,9 +1,9 @@
 from django import template
 from django.template.defaultfilters import pluralize, filesizeformat
 
-from tardis.tardis_portal.util import render_mustache
-from tardis.tardis_portal.views import get_dataset_info
-from tardis.tardis_portal.models.dataset import Dataset
+from ..util import render_mustache
+from ..views import get_dataset_info
+from ..models.dataset import Dataset
 
 register = template.Library()
 

--- a/tardis/tardis_portal/templatetags/experiment_tags.py
+++ b/tardis/tardis_portal/templatetags/experiment_tags.py
@@ -1,10 +1,9 @@
 from django import template
 from django.template.defaultfilters import pluralize, filesizeformat
 from django.contrib.humanize.templatetags.humanize import naturalday
-from tardis.tardis_portal.util import get_local_time
 
-from tardis.tardis_portal.util import render_mustache,\
-    render_public_access_badge
+from ..util import get_local_time
+from ..util import render_mustache, render_public_access_badge
 
 register = template.Library()
 

--- a/tardis/tardis_portal/templatetags/experimentstats.py
+++ b/tardis/tardis_portal/templatetags/experimentstats.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 from django import template
-from tardis.tardis_portal.models import DataFile
+from ..models.datafile import DataFile
 
 register = template.Library()
 

--- a/tardis/tardis_portal/templatetags/facility_tags.py
+++ b/tardis/tardis_portal/templatetags/facility_tags.py
@@ -1,5 +1,5 @@
 from django import template
-from tardis.tardis_portal.models.facility import is_facility_manager
+from ..models.facility import is_facility_manager
 
 register = template.Library()
 

--- a/tardis/tardis_portal/templatetags/xmldate.py
+++ b/tardis/tardis_portal/templatetags/xmldate.py
@@ -1,5 +1,5 @@
 from django import template
-from tardis.tardis_portal.rfc3339 import rfc3339
+from ..rfc3339 import rfc3339
 
 register = template.Library()
 

--- a/tardis/tardis_portal/tests/auth/test_httpbasicendpoint_auth.py
+++ b/tardis/tardis_portal/tests/auth/test_httpbasicendpoint_auth.py
@@ -15,7 +15,8 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 from django.contrib.auth.models import User, Group
 
-from tardis.tardis_portal.auth.httpbasicendpoint_auth import HttpBasicEndpointAuth
+from ...auth.httpbasicendpoint_auth import HttpBasicEndpointAuth
+
 
 class HttpBasicEndpointAuthTestCase(TestCase):
 

--- a/tardis/tardis_portal/tests/filters/test_jeolsem.py
+++ b/tardis/tardis_portal/tests/filters/test_jeolsem.py
@@ -2,12 +2,12 @@ from os import path
 
 from django.test import TransactionTestCase
 
-from tardis.tardis_portal.filters.jeolsem import JEOLSEMFilter
-from tardis.tardis_portal.models import User, \
-    ObjectACL, Experiment, Dataset, DataFile, DataFileObject, StorageBox
-from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
+from ...filters.jeolsem import JEOLSEMFilter
+from ...models import User, ObjectACL, Experiment, Dataset, DataFile, \
+    DataFileObject, StorageBox
+from ...ParameterSetManager import ParameterSetManager
 
-from tardis.tardis_portal.tests.test_download import get_size_and_sha512sum
+from ..test_download import get_size_and_sha512sum
 
 
 class JEOLSEMFilterTestCase(TransactionTestCase):

--- a/tardis/tardis_portal/tests/filters/test_middleware.py
+++ b/tardis/tardis_portal/tests/filters/test_middleware.py
@@ -36,11 +36,11 @@ from django.core.exceptions import MiddlewareNotUsed
 from django.core.management import call_command
 from django.http import HttpResponse
 
-from tardis.tardis_portal.filters import FilterInitMiddleware
-from tardis.tardis_portal.models import User, Experiment, \
+from ...filters import FilterInitMiddleware
+from ...models import User, Experiment, \
     ObjectACL, Dataset, DataFile, DataFileObject, StorageBox
 
-from tardis.tardis_portal.tests.test_download import get_size_and_sha512sum
+from ..test_download import get_size_and_sha512sum
 
 TEST_FILTERS = [
     ('tardis.tardis_portal.tests.filters.test_middleware.Filter1',),

--- a/tardis/tardis_portal/tests/mock_vbl_auth.py
+++ b/tardis/tardis_portal/tests/mock_vbl_auth.py
@@ -4,10 +4,7 @@ Created on 24/01/2011
 @author: gerson
 '''
 from django.contrib.auth.models import User
-from tardis.tardis_portal.models import (
-    UserAuthentication,
-    UserProfile,
-)
+from ..models import UserAuthentication, UserProfile
 
 
 auth_key = 'vbl'

--- a/tardis/tardis_portal/tests/test_api.py
+++ b/tardis/tardis_portal/tests/test_api.py
@@ -17,23 +17,23 @@ from django.test import TestCase
 
 from tastypie.test import ResourceTestCaseMixin
 
-from tardis.tardis_portal.auth.authservice import AuthService
-from tardis.tardis_portal.auth.localdb_auth import django_user
-from tardis.tardis_portal.models import ObjectACL
-from tardis.tardis_portal.models.datafile import DataFile, DataFileObject
-from tardis.tardis_portal.models.dataset import Dataset
-from tardis.tardis_portal.models.experiment import Experiment
-from tardis.tardis_portal.models.parameters import ExperimentParameter
-from tardis.tardis_portal.models.parameters import ExperimentParameterSet
-from tardis.tardis_portal.models.parameters import ParameterName
-from tardis.tardis_portal.models.parameters import Schema
-from tardis.tardis_portal.models.facility import Facility
-from tardis.tardis_portal.models.instrument import Instrument
+from ..auth.authservice import AuthService
+from ..auth.localdb_auth import django_user
+from ..models import ObjectACL
+from ..models.datafile import DataFile, DataFileObject
+from ..models.dataset import Dataset
+from ..models.experiment import Experiment
+from ..models.parameters import ExperimentParameter
+from ..models.parameters import ExperimentParameterSet
+from ..models.parameters import ParameterName
+from ..models.parameters import Schema
+from ..models.facility import Facility
+from ..models.instrument import Instrument
 
 
 class SerializerTest(TestCase):
     def test_pretty_serializer(self):
-        from tardis.tardis_portal.api import PrettyJSONSerializer
+        from ..api import PrettyJSONSerializer
         test_serializer = PrettyJSONSerializer()
         test_data = {"ugly": "json data",
                      "reformatted": 2,

--- a/tardis/tardis_portal/tests/test_authentication.py
+++ b/tardis/tardis_portal/tests/test_authentication.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from django.test.client import Client
 from django.contrib.auth.models import User, Permission
 
-from tardis.tardis_portal.models import UserAuthentication
+from ..models import UserAuthentication
 
 
 class AuthenticationTestCase(TestCase):
@@ -124,7 +124,7 @@ class AuthenticationTestCase(TestCase):
         from django.test.client import RequestFactory
         factory = RequestFactory()
 
-        from tardis.tardis_portal.auth.localdb_auth import DjangoAuthBackend
+        from ..auth.localdb_auth import DjangoAuthBackend
         dj_auth = DjangoAuthBackend()
         request = factory.post('/login', {'username': 'test',
                                           'password': 'test',

--- a/tardis/tardis_portal/tests/test_authorisation.py
+++ b/tardis/tardis_portal/tests/test_authorisation.py
@@ -6,11 +6,12 @@ from django.test.client import Client
 
 from django.contrib.auth.models import User, Group, Permission, AnonymousUser
 
-from tardis.tardis_portal.auth.localdb_auth import django_user
-from tardis.tardis_portal.auth.localdb_auth import auth_key as localdb_auth_key
-from tardis.tardis_portal.models import ObjectACL, Experiment
+from ..auth.localdb_auth import django_user
+from ..auth.localdb_auth import auth_key as localdb_auth_key
+from ..models import ObjectACL, Experiment
 
 logger = logging.getLogger(__name__)
+
 
 class ObjectACLTestCase(TestCase):
     urls = 'tardis.urls'

--- a/tardis/tardis_portal/tests/test_authservice.py
+++ b/tardis/tardis_portal/tests/test_authservice.py
@@ -5,8 +5,8 @@ from django.test.utils import override_settings
 
 from django.http import HttpRequest
 from django.contrib.auth import SESSION_KEY
-from tardis.tardis_portal.models import User
-from tardis.tardis_portal.auth.interfaces import GroupProvider
+from ..models import User
+from ..auth.interfaces import GroupProvider
 
 
 class MockSettings(object):
@@ -83,7 +83,7 @@ class AuthServiceTestCase(TestCase):
         self.userProfile2 = self.user2.userprofile
         self.userProfile3 = self.user3.userprofile
 
-        from tardis.tardis_portal.auth import AuthService, auth_service
+        from ..auth import AuthService, auth_service
         s = MockSettings()
         s.GROUP_PROVIDERS = \
             ('tardis.tardis_portal.tests.test_authservice.MockGroupProvider',)
@@ -98,12 +98,12 @@ class AuthServiceTestCase(TestCase):
         self.user2.delete()
         self.user3.delete()
 
-        from tardis.tardis_portal.auth import auth_service
+        from ..auth import auth_service
         auth_service._group_providers = self._auth_service_group_providers
         auth_service._manual_init()
 
     def testInitialisation(self):
-        from tardis.tardis_portal.auth import AuthService
+        from ..auth import AuthService
         s = MockSettings()
         s.USER_PROVIDERS = \
             ('tardis.tardis_portal.auth.localdb_auth.DjangoUserProvider',)
@@ -135,7 +135,7 @@ class AuthServiceTestCase(TestCase):
         self.assertTrue(',3)' in r)
 
     def testGroupSearch(self):
-        from tardis.tardis_portal.auth import AuthService
+        from ..auth import AuthService
         s = MockSettings()
         s.GROUP_PROVIDERS = \
             ('tardis.tardis_portal.tests.test_authservice.MockGroupProvider',)
@@ -158,7 +158,7 @@ class AuthServiceTestCase(TestCase):
                          '1')
 
     def testGetGroupsForEntity(self):
-        from tardis.tardis_portal.auth import AuthService
+        from ..auth import AuthService
         s = MockSettings()
         s.GROUP_PROVIDERS = \
             ('tardis.tardis_portal.tests.test_authservice.MockGroupProvider',)
@@ -174,7 +174,7 @@ class AuthServiceTestCase(TestCase):
                          1)
 
     def testAuthenticate(self):
-        from tardis.tardis_portal.auth import AuthService
+        from ..auth import AuthService
         s = MockSettings()
         s.USER_PROVIDERS = ()
         s.GROUP_PROVIDERS = ()

--- a/tardis/tardis_portal/tests/test_download.py
+++ b/tardis/tardis_portal/tests/test_download.py
@@ -14,8 +14,9 @@ from django.test.client import Client
 from django.conf import settings
 from django.contrib.auth.models import User
 
-from tardis.tardis_portal.models import \
-    Experiment, Dataset, DataFile, DataFileObject
+from ..models.experiment import Experiment
+from ..models.dataset import Dataset
+from ..models.datafile import DataFile, DataFileObject
 
 
 try:

--- a/tardis/tardis_portal/tests/test_dumpschemas.py
+++ b/tardis/tardis_portal/tests/test_dumpschemas.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from tardis.tardis_portal.models.parameters import Schema
+from ..models.parameters import Schema
 
 
 class DumpSchemasTestCase(TestCase):

--- a/tardis/tardis_portal/tests/test_facility_overview.py
+++ b/tardis/tardis_portal/tests/test_facility_overview.py
@@ -10,15 +10,15 @@ from django.contrib.auth.models import Group
 from django.test import RequestFactory
 from django.test import TestCase
 
-from tardis.tardis_portal.models.datafile import DataFile
-from tardis.tardis_portal.models.datafile import DataFileObject
-from tardis.tardis_portal.models.dataset import Dataset
-from tardis.tardis_portal.models.experiment import Experiment
-from tardis.tardis_portal.models.facility import Facility
-from tardis.tardis_portal.models.instrument import Instrument
+from ..models.datafile import DataFile
+from ..models.datafile import DataFileObject
+from ..models.dataset import Dataset
+from ..models.experiment import Experiment
+from ..models.facility import Facility
+from ..models.instrument import Instrument
 
-from tardis.tardis_portal.views.facilities import facility_overview_datafile_list
-from tardis.tardis_portal.views.facilities import facility_overview_experiments
+from ..views.facilities import facility_overview_datafile_list
+from ..views.facilities import facility_overview_experiments
 
 
 class FacilityOverviewTestCase(TestCase):

--- a/tardis/tardis_portal/tests/test_fetcher.py
+++ b/tardis/tardis_portal/tests/test_fetcher.py
@@ -10,7 +10,7 @@ from SimpleHTTPServer import SimpleHTTPRequestHandler
 from nose.tools import ok_, eq_
 from django.test import TestCase
 
-from tardis.tardis_portal.fetcher import get_privileged_opener
+from ..fetcher import get_privileged_opener
 
 
 class TestWebServer:

--- a/tardis/tardis_portal/tests/test_forms.py
+++ b/tardis/tardis_portal/tests/test_forms.py
@@ -38,8 +38,9 @@ http://docs.djangoproject.com/en/dev/topics/testing/
 """
 from django.test import TestCase
 
-from tardis.tardis_portal.forms import RightsForm
-from tardis.tardis_portal.models import Experiment, License
+from ..forms import RightsForm
+from ..models import Experiment, License
+
 
 class RightsFormTestCase(TestCase):
 

--- a/tardis/tardis_portal/tests/test_iiif.py
+++ b/tardis/tardis_portal/tests/test_iiif.py
@@ -7,15 +7,17 @@ from wand.image import Image
 from lxml import etree
 
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.urls import reverse
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.test import TestCase
 from django.test.client import Client
 # from nose.plugins.skip import SkipTest
 
-from tardis.tardis_portal.models import User, \
-    Experiment, ObjectACL, Dataset, DataFile
-from tardis.tardis_portal.models.datafile import compute_checksums
+from ..models.experiment import Experiment
+from ..models.access_control import ObjectACL
+from ..models.dataset import Dataset
+from ..models.datafile import DataFile, compute_checksums
 
 """
 Tests for IIIF API.

--- a/tardis/tardis_portal/tests/test_ldap.py
+++ b/tardis/tardis_portal/tests/test_ldap.py
@@ -18,7 +18,7 @@ ldap_auth_provider = ('ldap', 'LDAP',
 class LDAPErrorTest(TestCase):
 
     def test_search(self):
-        from tardis.tardis_portal.auth.ldap_auth import ldap_auth
+        from ..auth.ldap_auth import ldap_auth
         l = ldap_auth()
         self.assertEqual(l._query('', '', ''), None)
 
@@ -29,7 +29,7 @@ class LDAPErrorTest(TestCase):
         'ldap_auth is not enabled, skipping tests')
 class LDAPTest(TestCase):
     def setUp(self):
-        from tardis.tardis_portal.tests.ldap_ldif import test_ldif
+        from .ldap_ldif import test_ldif
         import tardis.tardis_portal.tests.slapd as slapd
         global server
         if not slapd.Slapd.check_paths():
@@ -51,7 +51,7 @@ class LDAPTest(TestCase):
 
     def test_search(self):
         from django.conf import settings
-        from tardis.tardis_portal.auth.ldap_auth import ldap_auth
+        from ..auth.ldap_auth import ldap_auth
 
         l = ldap_auth()
         res = l._query(settings.LDAP_USER_BASE, '(objectClass=*)', ['givenName', 'sn'])
@@ -75,7 +75,7 @@ class LDAPTest(TestCase):
         self.assertEqual(res, res1)
 
     def test_getuserbyid(self):
-        from tardis.tardis_portal.auth.ldap_auth import ldap_auth
+        from ..auth.ldap_auth import ldap_auth
         l = ldap_auth()
         user = l.getUserById('testuser1')
         user1 = {'id': 'testuser1',
@@ -88,7 +88,7 @@ class LDAPTest(TestCase):
         self.assertEqual(user, None)
 
     def test_authenticate(self):
-        from tardis.tardis_portal.auth.ldap_auth import ldap_auth
+        from ..auth.ldap_auth import ldap_auth
         from django.contrib.auth.models import User
 
         # Tests Authenticate API
@@ -106,7 +106,7 @@ class LDAPTest(TestCase):
         self.failUnlessEqual(u, u1)
 
         # Test authservice API
-        from tardis.tardis_portal.auth import auth_service
+        from ..auth import auth_service
         req = rf.post('')
         req._post = {'username': 'testuser1',
                      'password': 'kklk',
@@ -115,7 +115,7 @@ class LDAPTest(TestCase):
         self.assertTrue(isinstance(user, User))
 
         # Check that there is an entry in the user authentication table
-        from tardis.tardis_portal.models import UserAuthentication
+        from ..models import UserAuthentication
         userAuth = UserAuthentication.objects.get(
             userProfile__user=user,
             authenticationMethod=l.name)
@@ -127,7 +127,7 @@ class LDAPTest(TestCase):
 
     def test_getgroups(self):
         from django.contrib.auth.models import User
-        from tardis.tardis_portal.auth import auth_service
+        from ..auth import auth_service
         rf = RequestFactory()
         req = rf.post('')
         req._post = {'username': 'testuser1',
@@ -137,14 +137,14 @@ class LDAPTest(TestCase):
         self.assertTrue(isinstance(user, User))
         req.user = user
 
-        from tardis.tardis_portal.auth.ldap_auth import ldap_auth
+        from ..auth.ldap_auth import ldap_auth
         # Tests getGroups
         l = ldap_auth()
         self.assertEqual([g for g in l.getGroups(req.user)],
                          ['full', 'systems'])
 
     def test_getgroupbyid(self):
-        from tardis.tardis_portal.auth.ldap_auth import ldap_auth
+        from ..auth.ldap_auth import ldap_auth
 
         l = ldap_auth()
         self.assertEqual(l.getGroupById('full'),
@@ -152,14 +152,14 @@ class LDAPTest(TestCase):
         self.assertEqual(l.getGroupById('invalid'), None)
 
     def test_getgroupsforentity(self):
-        from tardis.tardis_portal.auth.ldap_auth import ldap_auth
+        from ..auth.ldap_auth import ldap_auth
         l = ldap_auth()
         self.assertEqual([g for g in l.getGroupsForEntity('testuser1')],
                          [{'id': 'full', 'display': 'Full Group'},
                           {'id': 'systems', 'display': 'Systems Services'}])
 
     def test_searchgroups(self):
-        from tardis.tardis_portal.auth.ldap_auth import ldap_auth
+        from ..auth.ldap_auth import ldap_auth
         l = ldap_auth()
         self.assertEqual([g for g in l.searchGroups(id='fu*')],
                          [{'id': 'full',

--- a/tardis/tardis_portal/tests/test_loadschemas.py
+++ b/tardis/tardis_portal/tests/test_loadschemas.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.core.management import call_command
 
-from tardis.tardis_portal.models.parameters import Schema
+from ..models.parameters import Schema
 
 
 class LoadSchemasTestCase(TestCase):

--- a/tardis/tardis_portal/tests/test_parametersets.py
+++ b/tardis/tardis_portal/tests/test_parametersets.py
@@ -46,16 +46,16 @@ from django.test import TestCase
 from django.contrib.contenttypes.models import ContentType
 import pytz
 
-from tardis.tardis_portal.models import Experiment, Dataset, DataFile, \
+from ..models import Experiment, Dataset, DataFile, \
     DataFileObject, Schema, ParameterName, DatafileParameterSet, \
     DatafileParameter, DatasetParameterSet, ExperimentParameterSet, ObjectACL
-from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
-from tardis.tardis_portal.views.parameters import edit_datafile_par
-from tardis.tardis_portal.views.parameters import edit_dataset_par
-from tardis.tardis_portal.views.parameters import edit_experiment_par
-from tardis.tardis_portal.views.parameters import add_datafile_par
-from tardis.tardis_portal.views.parameters import add_dataset_par
-from tardis.tardis_portal.views.parameters import add_experiment_par
+from ..ParameterSetManager import ParameterSetManager
+from ..views.parameters import edit_datafile_par
+from ..views.parameters import edit_dataset_par
+from ..views.parameters import edit_experiment_par
+from ..views.parameters import add_datafile_par
+from ..views.parameters import add_dataset_par
+from ..views.parameters import add_experiment_par
 
 
 class ParameterSetManagerTestCase(TestCase):

--- a/tardis/tardis_portal/tests/test_publishservice.py
+++ b/tardis/tardis_portal/tests/test_publishservice.py
@@ -1,8 +1,8 @@
 from django.test import TestCase
 from django.conf import settings
-from tardis.tardis_portal.models import User, Experiment
-from tardis.tardis_portal.publish.provider.rifcsprovider import RifCsProvider
-from tardis.tardis_portal.publish.publishservice import PublishService
+from ..models import User, Experiment
+from ..publish.provider.rifcsprovider import RifCsProvider
+from ..publish.publishservice import PublishService
 
 BEAMLINE_VALUE = "myBeamline"
 LICENSE_URL_VALUE = "http://some.uri.com"
@@ -50,7 +50,7 @@ class PublishServiceTestCase(TestCase):
     def testInitialisationNoProvider(self):
         service = PublishService(None, self.e1)
         self.assertIsNone(service.rc_providers)
-        from tardis.tardis_portal.publish.provider.rifcsprovider import RifCsProvider
+        from ..publish.provider.rifcsprovider import RifCsProvider
         self.assertTrue(isinstance(service.provider, RifCsProvider))
         self.assertFalse(isinstance(service.provider, MockRifCsProvider))
 

--- a/tardis/tardis_portal/tests/test_rmexperiment.py
+++ b/tardis/tardis_portal/tests/test_rmexperiment.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from django.core.management import call_command
 
-from tardis.tardis_portal.models import \
+from ..models import \
     Experiment, Dataset, DataFile, ObjectACL, License, \
     ExperimentParameterSet, ExperimentParameter, DatasetParameterSet, \
     DatafileParameterSet

--- a/tardis/tardis_portal/tests/test_sftp.py
+++ b/tardis/tardis_portal/tests/test_sftp.py
@@ -14,19 +14,19 @@ from flexmock import flexmock
 from paramiko.common import AUTH_SUCCESSFUL
 from paramiko.ssh_exception import SSHException
 
-from tardis.tardis_portal.download import make_mapper
+from ..download import make_mapper
 
-from tardis.tardis_portal.models import Dataset
-from tardis.tardis_portal.models import DataFile
-from tardis.tardis_portal.models import DataFileObject
-from tardis.tardis_portal.models import Experiment
-from tardis.tardis_portal.models import ObjectACL
+from ..models import Dataset
+from ..models import DataFile
+from ..models import DataFileObject
+from ..models import Experiment
+from ..models import ObjectACL
 
-from tardis.tardis_portal.sftp import MyTSFTPServerInterface
-from tardis.tardis_portal.sftp import MyTServerInterface
+from ..sftp import MyTSFTPServerInterface
+from ..sftp import MyTServerInterface
 
-from tardis.tardis_portal.views.pages import sftp_access
-from tardis.tardis_portal.views.images import cybderduck_connection_window
+from ..views.pages import sftp_access
+from ..views.images import cybderduck_connection_window
 
 
 class SFTPTest(TestCase):

--- a/tardis/tardis_portal/tests/test_storage.py
+++ b/tardis/tardis_portal/tests/test_storage.py
@@ -6,9 +6,9 @@ http://docs.djangoproject.com/en/dev/topics/testing/
 
 """
 from django.test import TestCase
-from tardis.tardis_portal.models import StorageBox, StorageBoxOption
-from tardis.tardis_portal.models import Dataset
-from tardis.tardis_portal.models import DataFile
+from ..models import StorageBox, StorageBoxOption
+from ..models import Dataset
+from ..models import DataFile
 
 
 class ModelTestCase(TestCase):

--- a/tardis/tardis_portal/tests/test_tar_download.py
+++ b/tardis/tardis_portal/tests/test_tar_download.py
@@ -10,7 +10,7 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 from django.test import Client, TestCase
 
-from tardis.tardis_portal.models import Experiment
+from ..models.experiment import Experiment
 
 
 class TarDownloadTestCase(TestCase):

--- a/tardis/tardis_portal/tests/test_tasks.py
+++ b/tardis/tardis_portal/tests/test_tasks.py
@@ -4,9 +4,9 @@ from os import urandom
 from django.core.files.base import ContentFile
 from django.test import TestCase
 
-from tardis.tardis_portal.models import Experiment, Dataset, DataFile, User
+from ..models import Experiment, Dataset, DataFile, User
 
-from tardis.tardis_portal.tasks import verify_dfos
+from ..tasks import verify_dfos
 
 
 class BackgroundTaskTestCase(TestCase):

--- a/tardis/tardis_portal/tests/test_tokens.py
+++ b/tardis/tardis_portal/tests/test_tokens.py
@@ -42,11 +42,11 @@ from django.test import TestCase
 from django.conf import settings
 from django.contrib.auth.models import User
 
-from tardis.tardis_portal.models import Experiment
-from tardis.tardis_portal.models import ObjectACL
-from tardis.tardis_portal.models import Token
+from ..models import Experiment
+from ..models import ObjectACL
+from ..models import Token
 
-from tardis.tardis_portal.views.authorisation import retrieve_access_list_tokens
+from ..views.authorisation import retrieve_access_list_tokens
 
 
 class FrozenTime:

--- a/tardis/tardis_portal/tests/test_views.py
+++ b/tardis/tardis_portal/tests/test_views.py
@@ -50,9 +50,9 @@ from django.test import TestCase
 from django.test.client import Client
 from django.contrib.auth.models import User, Group, Permission
 
-from tardis.tardis_portal.staging import get_full_staging_path
-from tardis.tardis_portal.auth.localdb_auth import django_user
-from tardis.tardis_portal.models import UserAuthentication, \
+from ..staging import get_full_staging_path
+from ..auth.localdb_auth import django_user
+from ..models import UserAuthentication, \
     ObjectACL, Experiment, Dataset, DataFile, Schema, \
     DatafileParameterSet
 
@@ -146,7 +146,7 @@ class UploadTestCase(TestCase):
 
     def testUploadComplete(self):
         from django.http import QueryDict, HttpRequest
-        from tardis.tardis_portal.views import upload_complete
+        from ..views import upload_complete
         data = [('filesUploaded', '1'), ('speed', 'really fast!'),
                 ('allBytesLoaded', '2'), ('errorCount', '0')]
         post = QueryDict('&'.join(['%s=%s' % (k, v) for (k, v) in
@@ -798,7 +798,7 @@ class ContextualViewTest(TestCase):
         test display of view for an existing schema and no display for an
         undefined one.
         """
-        from tardis.tardis_portal.views import display_datafile_details
+        from ..views import display_datafile_details
         request = flexmock(user=self.user, groups=[("testgroup", flexmock())])
         with self.settings(DATAFILE_VIEWS=[
                 ("http://test.com/test/schema", "/test/url"),
@@ -856,7 +856,7 @@ class ViewTemplateContextsTest(TestCase):
         """
         test some template context parameters for an experiment view
         """
-        from tardis.tardis_portal.views import ExperimentView
+        from ..views import ExperimentView
         from django.http import HttpRequest
         import sys
 
@@ -908,7 +908,7 @@ class ViewTemplateContextsTest(TestCase):
         """
         test some context parameters for a dataset view
         """
-        from tardis.tardis_portal.views import DatasetView
+        from ..views import DatasetView
         from django.http import HttpRequest
         import sys
 
@@ -990,9 +990,9 @@ class ExperimentListsTest(TestCase):
         Test My Data view
         """
         from django.http import QueryDict, HttpRequest
-        from tardis.tardis_portal.views import my_data
-        from tardis.tardis_portal.views import retrieve_owned_exps_list
-        from tardis.tardis_portal.views import retrieve_shared_exps_list
+        from ..views import my_data
+        from ..views import retrieve_owned_exps_list
+        from ..views import retrieve_shared_exps_list
 
         request = HttpRequest()
         request.method = 'GET'

--- a/tardis/tardis_portal/tests/tests.py
+++ b/tardis/tardis_portal/tests/tests.py
@@ -45,9 +45,9 @@ from django.test import TestCase
 from django.test.client import Client
 from django.contrib.auth.models import User
 
-from tardis.tardis_portal.models import Experiment, ObjectACL, \
+from ..models import Experiment, ObjectACL, \
     Schema, ParameterName, Dataset
-from tardis.tardis_portal.auth.localdb_auth import django_user
+from ..auth.localdb_auth import django_user
 
 
 class SearchTestCase(TestCase):
@@ -146,7 +146,7 @@ class SearchTestCase(TestCase):
 
         self.assertEqual(len(response.context['experiments']), 1)
 
-        from tardis.tardis_portal.models import Experiment
+        from ..models import Experiment
 
         values = response.context['experiments']
         experiment = values[0]

--- a/tardis/tardis_portal/tests/urls.py
+++ b/tardis/tardis_portal/tests/urls.py
@@ -3,11 +3,11 @@ from django.contrib.auth.urls import urlpatterns
 from django.http import HttpResponse
 from django.template import Template, RequestContext
 
-from tardis.tardis_portal import download
-from tardis.tardis_portal.views.pages import ExperimentView
-from tardis.tardis_portal.views import load_datafile_image
-from tardis.tardis_portal.views import load_dataset_image
-from tardis.tardis_portal.views import load_experiment_image
+from .. import download
+from ..views.pages import ExperimentView
+from ..views import load_datafile_image
+from ..views import load_dataset_image
+from ..views import load_experiment_image
 from . import mock_vbl_download
 
 def groups_view(request):

--- a/tardis/tardis_portal/views/__init__.py
+++ b/tardis/tardis_portal/views/__init__.py
@@ -4,15 +4,15 @@ when importing from tardis.tardis_portal.views
 """
 # pylint: disable=W0401,W0614
 
-from tardis.tardis_portal.views.ajax_actions import *
-from tardis.tardis_portal.views.ajax_json import *
-from tardis.tardis_portal.views.ajax_pages import *
-from tardis.tardis_portal.views.authentication import *
-from tardis.tardis_portal.views.authorisation import *
-from tardis.tardis_portal.views.facilities import *
-from tardis.tardis_portal.views.images import *
-from tardis.tardis_portal.views.machine import *
-from tardis.tardis_portal.views.pages import *
-from tardis.tardis_portal.views.parameters import *
-from tardis.tardis_portal.views.upload import *
-from tardis.tardis_portal.views.utils import *
+from .ajax_actions import *
+from .ajax_json import *
+from .ajax_pages import *
+from .authentication import *
+from .authorisation import *
+from .facilities import *
+from .images import *
+from .machine import *
+from .pages import *
+from .parameters import *
+from .upload import *
+from .utils import *

--- a/tardis/tardis_portal/views/ajax_actions.py
+++ b/tardis/tardis_portal/views/ajax_actions.py
@@ -12,11 +12,10 @@ from django.contrib.sites.models import Site
 from django.http import HttpResponse, HttpResponseForbidden
 from django.views.decorators.cache import never_cache
 
-from tardis.tardis_portal.auth import decorators as authz
-from tardis.tardis_portal.auth.decorators import has_dataset_write
-from tardis.tardis_portal.models import Dataset
-from tardis.tardis_portal.tasks import (
-    cache_done_notify, create_staging_datafiles)
+from ..auth import decorators as authz
+from ..auth.decorators import has_dataset_write
+from ..models import Dataset
+from ..tasks import cache_done_notify, create_staging_datafiles
 
 logger = logging.getLogger(__name__)
 

--- a/tardis/tardis_portal/views/ajax_json.py
+++ b/tardis/tardis_portal/views/ajax_json.py
@@ -11,11 +11,11 @@ from django.http import HttpResponseNotFound, HttpResponseForbidden, \
     HttpResponse
 from django.views.decorators.cache import never_cache
 
-from tardis.tardis_portal.auth import decorators as authz
-from tardis.tardis_portal.models import Dataset, Experiment, License
-from tardis.tardis_portal.shortcuts import return_response_not_found
-from tardis.tardis_portal.views.utils import HttpResponseMethodNotAllowed
-from tardis.tardis_portal.views.utils import get_dataset_info
+from ..auth import decorators as authz
+from ..models import Dataset, Experiment, License
+from ..shortcuts import return_response_not_found
+from ..views.utils import HttpResponseMethodNotAllowed
+from ..views.utils import get_dataset_info
 
 logger = logging.getLogger(__name__)
 

--- a/tardis/tardis_portal/views/ajax_pages.py
+++ b/tardis/tardis_portal/views/ajax_pages.py
@@ -17,17 +17,17 @@ from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from haystack.query import SearchQuerySet
 from tardis.search.utils import SearchQueryString
-from tardis.tardis_portal.auth import decorators as authz
-from tardis.tardis_portal.forms import RightsForm
-from tardis.tardis_portal.models import Experiment, DataFile, Dataset, Schema, \
+from ..auth import decorators as authz
+from ..forms import RightsForm
+from ..models import Experiment, DataFile, Dataset, Schema, \
     DatafileParameterSet, UserProfile
-from tardis.tardis_portal.search_query import FacetFixedSearchQuery
-from tardis.tardis_portal.shortcuts import return_response_error, \
+from ..search_query import FacetFixedSearchQuery
+from ..shortcuts import return_response_error, \
     return_response_not_found, render_response_index
-from tardis.tardis_portal.staging import get_full_staging_path, staging_list
-from tardis.tardis_portal.util import render_public_access_badge
-from tardis.tardis_portal.views.pages import ExperimentView
-from tardis.tardis_portal.views.utils import _add_protocols_and_organizations
+from ..staging import get_full_staging_path, staging_list
+from ..util import render_public_access_badge
+from ..views.pages import ExperimentView
+from ..views.utils import _add_protocols_and_organizations
 
 logger = logging.getLogger(__name__)
 

--- a/tardis/tardis_portal/views/authentication.py
+++ b/tardis/tardis_portal/views/authentication.py
@@ -22,13 +22,12 @@ from django.shortcuts import redirect
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 
-from tardis.tardis_portal.auth import auth_service
-from tardis.tardis_portal.auth.localdb_auth import auth_key as localdb_auth_key
-from tardis.tardis_portal.forms import ManageAccountForm, CreateUserPermissionsForm, \
-    LoginForm
-from tardis.tardis_portal.models import JTI, UserProfile, UserAuthentication
-from tardis.tardis_portal.shortcuts import render_response_index
-from tardis.tardis_portal.views.utils import _redirect_303
+from ..auth import auth_service
+from ..auth.localdb_auth import auth_key as localdb_auth_key
+from ..forms import ManageAccountForm, CreateUserPermissionsForm, LoginForm
+from ..models import JTI, UserProfile, UserAuthentication
+from ..shortcuts import render_response_index
+from ..views.utils import _redirect_303
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +215,7 @@ def login(request):
     '''
     handler for login page
     '''
-    from tardis.tardis_portal.auth import auth_service
+    from ..auth import auth_service
 
     if request.user.is_authenticated:
         # redirect the user to the home page if he is trying to go to the
@@ -265,7 +264,7 @@ def login(request):
 @login_required()
 def manage_auth_methods(request):
     '''Manage the user's authentication methods using AJAX.'''
-    from tardis.tardis_portal.auth.authentication import add_auth_method, \
+    from ..auth.authentication import add_auth_method, \
         merge_auth_method, remove_auth_method, edit_auth_method, \
         list_auth_methods
 

--- a/tardis/tardis_portal/views/authorisation.py
+++ b/tardis/tardis_portal/views/authorisation.py
@@ -20,14 +20,14 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_POST
 
-from tardis.tardis_portal.auth import decorators as authz, auth_service
-from tardis.tardis_portal.auth.localdb_auth import auth_key as localdb_auth_key, \
+from ..auth import decorators as authz, auth_service
+from ..auth.localdb_auth import auth_key as localdb_auth_key, \
     django_user
-from tardis.tardis_portal.forms import ChangeUserPermissionsForm, \
+from ..forms import ChangeUserPermissionsForm, \
     ChangeGroupPermissionsForm, CreateGroupPermissionsForm
-from tardis.tardis_portal.models import UserAuthentication, UserProfile, Experiment, \
+from ..models import UserAuthentication, UserProfile, Experiment, \
     Token, GroupAdmin, ObjectACL
-from tardis.tardis_portal.shortcuts import render_response_index, \
+from ..shortcuts import render_response_index, \
     return_response_error, render_error_message
 
 logger = logging.getLogger(__name__)
@@ -113,7 +113,7 @@ def retrieve_group_list(request):
 @never_cache
 @authz.experiment_ownership_required
 def retrieve_access_list_user(request, experiment_id):
-    from tardis.tardis_portal.forms import AddUserPermissionsForm
+    from ..forms import AddUserPermissionsForm
     user_acls = Experiment.safe.user_acls(experiment_id)
 
     c = {'user_acls': user_acls, 'experiment_id': experiment_id,
@@ -135,7 +135,7 @@ def retrieve_access_list_user_readonly(request, experiment_id):
 @authz.experiment_ownership_required
 def retrieve_access_list_group(request, experiment_id):
 
-    from tardis.tardis_portal.forms import AddGroupPermissionsForm
+    from ..forms import AddGroupPermissionsForm
 
     group_acls_system_owned = Experiment.safe.group_acls_system_owned(
         experiment_id)
@@ -223,7 +223,7 @@ def retrieve_access_list_tokens(request, experiment_id):
 @authz.group_ownership_required
 def retrieve_group_userlist(request, group_id):
 
-    from tardis.tardis_portal.forms import ManageGroupPermissionsForm
+    from ..forms import ManageGroupPermissionsForm
     users = User.objects.filter(groups__id=group_id)
     c = {'users': users, 'group_id': group_id,
          'manageGroupPermissionsForm': ManageGroupPermissionsForm()}
@@ -234,7 +234,7 @@ def retrieve_group_userlist(request, group_id):
 @never_cache
 def retrieve_group_userlist_readonly(request, group_id):
 
-    from tardis.tardis_portal.forms import ManageGroupPermissionsForm
+    from ..forms import ManageGroupPermissionsForm
     users = User.objects.filter(groups__id=group_id)
     c = {'users': users, 'group_id': group_id,
          'manageGroupPermissionsForm': ManageGroupPermissionsForm()}

--- a/tardis/tardis_portal/views/facilities.py
+++ b/tardis/tardis_portal/views/facilities.py
@@ -16,8 +16,8 @@ from django.db.models import Case
 from django.db.models import When
 from django.db.models import IntegerField
 
-from tardis.tardis_portal.models import Dataset, Experiment, DataFile
-from tardis.tardis_portal.models.facility import facilities_managed_by
+from ..models import Dataset, Experiment, DataFile
+from ..models.facility import facilities_managed_by
 
 logger = logging.getLogger(__name__)
 

--- a/tardis/tardis_portal/views/images.py
+++ b/tardis/tardis_portal/views/images.py
@@ -12,10 +12,10 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseNotFound, HttpResponseRedirect
 from django.views.decorators.cache import never_cache
 
-from tardis.tardis_portal.auth import decorators as authz
-from tardis.tardis_portal.models import ExperimentParameter, DatasetParameter, \
+from ..auth import decorators as authz
+from ..models import ExperimentParameter, DatasetParameter, \
     DatafileParameter, Dataset
-from tardis.tardis_portal.shortcuts import return_response_error
+from ..shortcuts import return_response_error
 
 logger = logging.getLogger(__name__)
 

--- a/tardis/tardis_portal/views/machine.py
+++ b/tardis/tardis_portal/views/machine.py
@@ -7,10 +7,10 @@ import logging
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 
-from tardis.tardis_portal.auth import decorators as authz, auth_service
-from tardis.tardis_portal.auth.localdb_auth import auth_key as localdb_auth_key
-from tardis.tardis_portal.models import Experiment
-from tardis.tardis_portal.shortcuts import return_response_error, \
+from ..auth import decorators as authz, auth_service
+from ..auth.localdb_auth import auth_key as localdb_auth_key
+from ..models import Experiment
+from ..shortcuts import return_response_error, \
     return_response_not_found, render_response_index
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ def view_rifcs(request, experiment_id):
     except AttributeError:
         rifcs_provs = ()
 
-    from tardis.tardis_portal.publish.publishservice import PublishService
+    from ..publish.publishservice import PublishService
     pservice = PublishService(rifcs_provs, experiment)
     context = pservice.get_context()
     if context is None:

--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -25,19 +25,18 @@ from django.views.decorators.cache import cache_page
 from django.views.generic.base import TemplateView, View
 
 from tardis.search.utils import SearchQueryString
-from tardis.tardis_portal.auth import decorators as authz
-from tardis.tardis_portal.auth.decorators import (
+from ..auth import decorators as authz
+from ..auth.decorators import (
     has_experiment_download_access, has_experiment_write, has_dataset_write)
-from tardis.tardis_portal.auth.localdb_auth import django_user
-from tardis.tardis_portal.forms import ExperimentForm, DatasetForm
-from tardis.tardis_portal.models import Experiment, Dataset, DataFile, \
-    ObjectACL
-from tardis.tardis_portal.shortcuts import render_response_index, \
+from ..auth.localdb_auth import django_user
+from ..forms import ExperimentForm, DatasetForm
+from ..models import Experiment, Dataset, DataFile, ObjectACL
+from ..shortcuts import render_response_index, \
     return_response_error, return_response_not_found, get_experiment_referer, \
     render_response_search
-from tardis.tardis_portal.views.utils import (
+from ..views.utils import (
     _redirect_303, _add_protocols_and_organizations, HttpResponseSeeAlso)
-from tardis.tardis_portal.util import get_filesystem_safe_dataset_name
+from ..util import get_filesystem_safe_dataset_name
 
 logger = logging.getLogger(__name__)
 
@@ -598,7 +597,7 @@ def sftp_access(request):
     :return: HttpResponse
     :rtype: HttpResponse
     """
-    from tardis.tardis_portal.download import make_mapper
+    from ..download import make_mapper
     object_type = request.GET.get('object_type')
     object_id = request.GET.get('object_id')
     sftp_start_dir = ''

--- a/tardis/tardis_portal/views/parameters.py
+++ b/tardis/tardis_portal/views/parameters.py
@@ -6,13 +6,13 @@ import logging
 
 from django.contrib.auth.decorators import login_required
 
-from tardis.tardis_portal.auth import decorators as authz
-from tardis.tardis_portal.forms import create_parameterset_edit_form, \
+from ..auth import decorators as authz
+from ..forms import create_parameterset_edit_form, \
     save_datafile_edit_form, create_datafile_add_form, save_datafile_add_form
-from tardis.tardis_portal.models import ExperimentParameterSet, DatasetParameterSet, \
+from ..models import ExperimentParameterSet, DatasetParameterSet, \
     DatafileParameterSet, ParameterName, DataFile, Schema, Dataset, Experiment
-from tardis.tardis_portal.shortcuts import return_response_error, render_response_index
-from tardis.tardis_portal.views.utils import remove_csrf_token
+from ..shortcuts import return_response_error, render_response_index
+from ..views.utils import remove_csrf_token
 
 logger = logging.getLogger(__name__)
 

--- a/tardis/tardis_portal/views/upload.py
+++ b/tardis/tardis_portal/views/upload.py
@@ -8,8 +8,8 @@ from django.urls import reverse
 from django.http import HttpResponse
 from django.shortcuts import render_to_response
 
-from tardis.tardis_portal.auth import decorators as authz
-from tardis.tardis_portal.models import Dataset, DataFile
+from ..auth import decorators as authz
+from ..models import Dataset, DataFile
 
 logger = logging.getLogger(__name__)
 

--- a/tardis/tardis_portal/views/utils.py
+++ b/tardis/tardis_portal/views/utils.py
@@ -13,9 +13,9 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.template.defaultfilters import filesizeformat
 
-from tardis.tardis_portal.auth import decorators as authz
-from tardis.tardis_portal.forms import createSearchExperimentForm
-from tardis.tardis_portal.shortcuts import render_response_search
+from ..auth import decorators as authz
+from ..forms import createSearchExperimentForm
+from ..shortcuts import render_response_search
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ def _add_protocols_and_organizations(request, collection_object, c):
     c['default_format'] = filter(
         lambda x: not (cannot_do_zip and x == 'zip'), formats)[0]
 
-    from tardis.tardis_portal.download import get_download_organizations
+    from ..download import get_download_organizations
     c['organization'] = get_download_organizations()
     c['default_organization'] = getattr(
         settings, 'DEFAULT_PATH_MAPPER', 'classic')

--- a/tardis/tardis_portal/xmlwriter.py
+++ b/tardis/tardis_portal/xmlwriter.py
@@ -31,7 +31,7 @@
 import logging
 from os import path
 from django.conf import settings
-from tardis.tardis_portal.shortcuts import render_to_file
+from .shortcuts import render_to_file
 
 logger = logging.getLogger(__name__)
 

--- a/tardis/test_settings.py
+++ b/tardis/test_settings.py
@@ -5,7 +5,7 @@ from os import listdir
 from celery import Celery
 from django.apps import apps  # pylint: disable=wrong-import-order
 
-from tardis.default_settings import *  # noqa # pylint: disable=W0401,W0614
+from .default_settings import *  # noqa # pylint: disable=W0401,W0614
 import logging  # pylint: disable=wrong-import-order
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'


### PR DESCRIPTION
when importing modules from within the same package.  One or more
leading dots are used to specify whether the module path to be
imported is in the current directory or parent directory etc. This
avoids repeatedly writing "from tardis.tardis_portal..." within
the tardis.tardis_portal package and it more clearly distinguishes
relative imports of modules within the package from relative imports
of modules to be found in sys.path.  Apps in tardis/apps/ should still
use "from tardis.tardis_portal" rather than "from ...tardis_portal"
because we shouldn't assume that an app will always be installed
in tardis/apps/.