### PR TITLE
Reverting change which added an NPM_STATIC_FILES_PREFIX of js/lib/

### DIFF
--- a/tardis/apps/push_to/templates/destination_selector.html
+++ b/tardis/apps/push_to/templates/destination_selector.html
@@ -4,8 +4,8 @@
 <head lang="en">
     <meta charset="UTF-8">
     <title>Push to</title>
-    <script type="application/javascript" src="{% static 'js/lib/jquery/dist/jquery.min.js' %}"></script>
-    <script type="application/javascript" src="{% static 'js/lib/angular/angular.min.js' %}"></script>
+    <script type="application/javascript" src="{% static 'jquery/dist/jquery.min.js' %}"></script>
+    <script type="application/javascript" src="{% static 'angular/angular.min.js' %}"></script>
     <script type="application/javascript" src="{% static 'push-to/typeahead.bundle.js' %}"></script>
     <link href="{% static 'push-to/bootstrap/css/bootstrap.min.css' %}" rel="stylesheet">
     <script type="application/javascript">
@@ -27,6 +27,6 @@
     </body>
 {% endverbatim %}
 <script type="application/javascript" src="{% static 'push-to/angular-typeahead.js' %}"></script>
-<script type="application/javascript" src="{% static 'js/lib/angular-resource/angular-resource.min.js' %}"></script>
+<script type="application/javascript" src="{% static 'angular-resource/angular-resource.min.js' %}"></script>
 <script type="application/javascript" src="{% static 'push-to/push-to.js' %}"></script>
 </html>

--- a/tardis/apps/push_to/templates/host_list.html
+++ b/tardis/apps/push_to/templates/host_list.html
@@ -4,7 +4,7 @@
 <head lang="en">
     <meta charset="UTF-8">
     <title>Push to</title>
-    <script type="text/javascript" src="{% static 'js/lib/angular/angular.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'angular/angular.min.js' %}"></script>
     <link href="{% static 'push-to/bootstrap/css/bootstrap.min.css' %}" rel="stylesheet">
     <script type="text/javascript">
         var accessible_hosts_url = '{{ accessible_hosts_url }}';
@@ -33,6 +33,6 @@
     </body>
 {% endverbatim %}
 <script type="application/javascript" src="{% static 'push-to/angular-typeahead.js' %}"></script>
-<script type="application/javascript" src="{% static 'js/lib/angular-resource/angular-resource.min.js' %}"></script>
+<script type="application/javascript" src="{% static 'angular-resource/angular-resource.min.js' %}"></script>
 <script type="application/javascript" src="{% static 'push-to/push-to.js' %}"></script>
 </html>

--- a/tardis/default_settings/static_files.py
+++ b/tardis/default_settings/static_files.py
@@ -40,4 +40,3 @@ NPM_FILE_PATTERNS = {
     'underscore': ['*'],
     'underscore.string': ['*']
 }
-NPM_STATIC_FILES_PREFIX = path.join('js', 'lib')

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/access_list_tokens.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/access_list_tokens.html
@@ -1,5 +1,5 @@
 {% load static from staticfiles %}
-<script type="text/javascript" src="{% static 'js/lib/clipboard/dist/clipboard.min.js' %}"></script>
+<script type="text/javascript" src="{% static 'clipboard/dist/clipboard.min.js' %}"></script>
 <script type="text/javascript">
     var clipboard = new Clipboard('.btn.clipboard');
     {% comment %}

--- a/tardis/tardis_portal/templates/tardis_portal/javascript_libraries.html
+++ b/tardis/tardis_portal/templates/tardis_portal/javascript_libraries.html
@@ -8,38 +8,37 @@ Third-party JS dependencies which are not yet npm-installed are in:
 
     tardis/tardis_portal/static/js/lib/
 
-NPM_STATIC_FILES_PREFIX is set to js/lib/ in tardis/default_settings/static_files.py
-so npm-installed dependencies in node_modules/ will be available in static/js/lib/
-after running collectstatic.
+For JS dependencies installed by npm, collectstatic will copy them from node_modules/
+into static/, e.g. node_modules/angular/angular.min.js becomes static/angular/angular.min.js
 
 {% endcomment %}
-<script type="text/javascript" src="{% static 'js/lib/jquery/dist/jquery.min.js' %}"></script>
-<script type="text/javascript" src="{% static 'js/lib/jquery-ui-dist/jquery-ui.min.js' %}"></script>
+<script type="text/javascript" src="{% static 'jquery/dist/jquery.min.js' %}"></script>
+<script type="text/javascript" src="{% static 'jquery-ui-dist/jquery-ui.min.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/lib/jquery.cookie.js' %}"></script>
 
 <!-- angular and related scripts -->
-<script type="text/javascript" src="{% static 'js/lib/angular/angular.min.js' %}"></script>
-<script type="text/javascript" src="{% static 'js/lib/angular-resource/angular-resource.min.js' %}"></script>
-<script type="text/javascript" src="{% static 'js/lib/ng-dialog/js/ngDialog.min.js' %}"></script>
+<script type="text/javascript" src="{% static 'angular/angular.min.js' %}"></script>
+<script type="text/javascript" src="{% static 'angular-resource/angular-resource.min.js' %}"></script>
+<script type="text/javascript" src="{% static 'ng-dialog/js/ngDialog.min.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/angular-mytardis.js' %}"></script>
 
 <script type="text/javascript" src="{% static 'js/lib/jstree/jquery.jstree.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/lib/flash_detect_min.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/lib/async.min.js' %}"></script>
-<script type="text/javascript" src="{% static 'js/lib/underscore/underscore-min.js' %}"></script>
-<script type="text/javascript" src="{% static 'js/lib/underscore.string/lib/underscore.string.js' %}"></script>
+<script type="text/javascript" src="{% static 'underscore/underscore-min.js' %}"></script>
+<script type="text/javascript" src="{% static 'underscore.string/lib/underscore.string.js' %}"></script>
 <script type="text/javascript">
   // Mixin Underscore.String to Underscore.js
   _.mixin(_.string.exports());
 </script>
 <!-- Backbone.js -->
-<script type="text/javascript" src="{% static 'js/lib/backbone/backbone-min.js' %}"></script>
+<script type="text/javascript" src="{% static 'backbone/backbone-min.js' %}"></script>
 <!-- Backbone Forms -->
 <link rel="stylesheet" type="text/css"
-        href="{% static 'js/lib/backbone-forms/distribution/templates/default.css' %}"/>
-<script src="{% static 'js/lib/backbone-forms/distribution/backbone-forms.js' %}"></script>
-<script src="{% static 'js/lib/backbone-forms/distribution/editors/jquery-ui.js' %}"></script>
-<script src="{% static 'js/lib/backbone-forms/distribution/templates/bootstrap.js' %}"></script>
+        href="{% static 'backbone-forms/distribution/templates/default.css' %}"/>
+<script src="{% static 'backbone-forms/distribution/backbone-forms.js' %}"></script>
+<script src="{% static 'backbone-forms/distribution/editors/jquery-ui.js' %}"></script>
+<script src="{% static 'backbone-forms/distribution/templates/bootstrap.js' %}"></script>
 
 {# Supplied by django-mustachejs #}
 <script type="text/javascript" src="{% static 'mustache/js/mustache-0.3.0.js' %}"></script>
@@ -47,9 +46,9 @@ after running collectstatic.
 
 {% block css_libraries %}
 <link type="text/css" href="{% static 'css/lib/smoothness/jquery-ui-1.8.18.custom.css' %}" rel="stylesheet" />
-<link type="text/css" href="{% static 'js/lib/ng-dialog/css/ngDialog.min.css' %}" rel="stylesheet" />
-<link type="text/css" href="{% static 'js/lib/ng-dialog/css/ngDialog-theme-plain.min.css' %}" rel="stylesheet" />
-<link type="text/css" href="{% static 'js/lib/ng-dialog/css/ngDialog-theme-default.min.css' %}" rel="stylesheet" />
+<link type="text/css" href="{% static 'ng-dialog/css/ngDialog.min.css' %}" rel="stylesheet" />
+<link type="text/css" href="{% static 'ng-dialog/css/ngDialog-theme-plain.min.css' %}" rel="stylesheet" />
+<link type="text/css" href="{% static 'ng-dialog/css/ngDialog-theme-default.min.css' %}" rel="stylesheet" />
 
 <!-- Twitter Bootstrap: http://twitter.github.com/bootstrap/ -->
 <link href="{% static 'js/lib/bootstrap-2.0.4/css/bootstrap.css' %}" rel="stylesheet">
@@ -74,7 +73,7 @@ Academicons are licensed under the SIL OFL 1.1 license:
 -->
 <link href="{% static 'academicons-1.8.0/css/academicons.css' %}" rel="stylesheet"/>
 
-<link rel="stylesheet" href="{% static 'js/lib/blueimp-file-upload/css/jquery.fileupload.css' %}"/>
+<link rel="stylesheet" href="{% static 'blueimp-file-upload/css/jquery.fileupload.css' %}"/>
 
 {% endblock %}
 

--- a/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
@@ -715,11 +715,11 @@ $(document).ready(function(){
 });
 </script>
 <!-- jQuery UI widgets -->
-<script src="{% static 'js/lib/blueimp-file-upload/js/vendor/jquery.ui.widget.js' %}"></script>
+<script src="{% static 'blueimp-file-upload/js/vendor/jquery.ui.widget.js' %}"></script>
 <!-- The Iframe Transport is required for browsers without support for XHR file uploads -->
-<script src="{% static 'js/lib/blueimp-file-upload/js/jquery.iframe-transport.js' %}"></script>
+<script src="{% static 'blueimp-file-upload/js/jquery.iframe-transport.js' %}"></script>
 <!-- The basic File Upload plugin -->
-<script src="{% static 'js/lib/blueimp-file-upload/js/jquery.fileupload.js' %}"></script>
+<script src="{% static 'blueimp-file-upload/js/jquery.fileupload.js' %}"></script>
 <script type="text/javascript">
 $(function () {
     $('#dropzone').hide();


### PR DESCRIPTION
to tardis/default_settings/static_files.py, because we don't want
django-npm to add a js/lib/ prefix to everything it copies from
node_modules/ during collectstatic.  Third party dependencies which
are not yet in package.json are still in
tardis/tardis_portal/static/js/lib/