### PR TITLE
Tell pyup-bot that we don't want to upgrade to pylint 2.0.0 yet,

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -27,7 +27,7 @@ lxml==4.2.3
 paramiko==2.4.1
 pillow==5.2.0
 pwgen==0.8.2.post0
-pylint==1.9.2
+pylint==1.9.2 # pyup: <2.0
 pylint-django==0.11.1
 pyoai==2.5.0
 pysolr==2.1.0 # pyup: >=2.1.0,<3


### PR DESCRIPTION
because it is not compatible with Python 2.