### PR TITLE
Renamed tardis/celery_app.py to tardis/celery.py as recommended by

### DIFF
--- a/tardis/apps/push_to/tasks.py
+++ b/tardis/apps/push_to/tasks.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 from six import string_types
 
 from tardis.tardis_portal.models import Experiment, Dataset, DataFile
-from tardis.celery_app import tardis_portal_app
+from tardis.celery import tardis_app
 from tardis.tardis_portal.util import split_path
 from tardis.tardis_portal.util import get_filesystem_safe_experiment_name
 from tardis.tardis_portal.util import get_filesystem_safe_dataset_name
@@ -12,7 +12,7 @@ from tardis.tardis_portal.util import get_filesystem_safe_dataset_name
 from .models import Credential, RemoteHost
 
 
-@tardis_portal_app.task
+@tardis_app.task
 def push_experiment_to_host(
         user_id, credential_id, remote_host_id, experiment_id, base_dir=None
 ):
@@ -35,7 +35,7 @@ def push_experiment_to_host(
         raise
 
 
-@tardis_portal_app.task
+@tardis_app.task
 def push_dataset_to_host(user_id, credential_id, remote_host_id, dataset_id,
                          base_dir=None):
     try:
@@ -55,7 +55,7 @@ def push_dataset_to_host(user_id, credential_id, remote_host_id, dataset_id,
         raise
 
 
-@tardis_portal_app.task
+@tardis_app.task
 def push_datafile_to_host(user_id, credential_id, remote_host_id, datafile_id,
                           base_dir=None):
     try:

--- a/tardis/celery.py
+++ b/tardis/celery.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from celery import Celery
+from celery import Celery  # pylint: disable=import-error
 from django.apps import apps  # pylint: disable=wrong-import-order
 
 tardis_app = Celery('tardis')

--- a/tardis/celery.py
+++ b/tardis/celery.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+from celery import Celery
+from django.apps import apps  # pylint: disable=wrong-import-order
+
+tardis_app = Celery('tardis')
+tardis_app.config_from_object('django.conf:settings')
+tardis_app.autodiscover_tasks(lambda: [n.name for n in apps.get_app_configs()])

--- a/tardis/celery_app.py
+++ b/tardis/celery_app.py
@@ -1,6 +1,0 @@
-from celery import Celery
-from django.apps import apps  # pylint: disable=wrong-import-order
-
-tardis_portal_app = Celery('tardis_portal')
-tardis_portal_app.config_from_object('django.conf:settings')
-tardis_portal_app.autodiscover_tasks(lambda: [n.name for n in apps.get_app_configs()])

--- a/tardis/test_settings.py
+++ b/tardis/test_settings.py
@@ -1,9 +1,9 @@
 # pylint: disable=wildcard-import,unused-wildcard-import
-
+from __future__ import absolute_import
 from glob import glob
 from os import path
 
-from celery import Celery
+from celery import Celery  # pylint: disable=import-error
 from django.apps import apps  # pylint: disable=wrong-import-order
 
 from .default_settings import *  # noqa # pylint: disable=W0401,W0614

--- a/tardis/test_settings.py
+++ b/tardis/test_settings.py
@@ -30,9 +30,9 @@ DATABASES = {
 CELERY_ALWAYS_EAGER = True
 BROKER_URL = 'memory://'
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
-tardis_portal_app = Celery('tardis_portal')
-tardis_portal_app.config_from_object('django.conf:settings')
-tardis_portal_app.autodiscover_tasks(lambda: [n.name for n in apps.get_app_configs()])
+tardis_app = Celery('tardis')
+tardis_app.config_from_object('django.conf:settings')
+tardis_app.autodiscover_tasks(lambda: [n.name for n in apps.get_app_configs()])
 
 TEMPLATES[0]['DIRS'].append('.')
 TEMPLATES[0]['OPTIONS']['debug'] = DEBUG


### PR DESCRIPTION
http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html
We need to add `from __future__ import absolute_import` for Python 2, so
that the `from celery import Celery` import is unambiguous, given that
the celery.py module within the `tardis` project has the same name as
Celery's official celery module.

Changed `tardis_portal_app = Celery("tardis_portal")` to
`tardis_app = Celery("tardis")` to be consistent with `app = Celery('proj')` in
http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html
as "tardis" is the Django project, and "tardis_portal" is the main app
within the project.

Added some docs on configuring services for Systemd, Supervisor.