### PR TITLE
Prevent PyUp-Bot from requesting upgrading pylint-django to v2.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -28,7 +28,7 @@ paramiko==2.4.1
 pillow==5.2.0
 pwgen==0.8.2.post0
 pylint==1.9.3 # pyup: <2.0
-pylint-django==0.11.1
+pylint-django==0.11.1 # pyup: <2.0
 pyoai==2.5.0
 pysolr==2.1.0 # pyup: >=2.1.0,<3
 pystache==0.5.4


### PR DESCRIPTION
which requires Python 3.