### PR TITLE
Removing max_length attribute for password

### DIFF
--- a/tardis/tardis_portal/forms.py
+++ b/tardis/tardis_portal/forms.py
@@ -292,7 +292,7 @@ def createLinkedUserAuthenticationForm(authMethods):
         label='Username', max_length=75, required=True)
     fields['password'] = forms.CharField(
         required=True, widget=forms.PasswordInput(),
-        label='Password', max_length=12)
+        label='Password')
 
     return type('LinkedUserAuthenticationForm', (forms.BaseForm, ),
                 {'base_fields': fields})


### PR DESCRIPTION
max length of 12 for password is not consistent with login form or registration form.