### PR TITLE
Fixes: #243. Bug in tardis_acls.change_experiment permissions check

### DIFF
--- a/tardis/apps/anzsrc_codes/tests/test_oaipmh.py
+++ b/tardis/apps/anzsrc_codes/tests/test_oaipmh.py
@@ -1,5 +1,6 @@
 import json
 
+from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
@@ -12,10 +13,13 @@ from tardis.tardis_portal.models import Experiment, License, ObjectACL, User
 def _create_user_and_login(username='testuser', password='testpass'):
     user = User.objects.create_user(username, '', password)
     user.save()
+    user.user_permissions.add(
+        Permission.objects.get(codename='change_experiment'))
 
     client = Client()
     client.login(username=username, password=password)
     return (user, client)
+
 
 class RifCSTestCase(TestCase):
 

--- a/tardis/apps/related_info/tests/test_oaipmh.py
+++ b/tardis/apps/related_info/tests/test_oaipmh.py
@@ -1,5 +1,6 @@
 import json
 
+from django.contrib.auth.models import Permission
 from django.test import TransactionTestCase
 from django.test.client import Client
 from django.urls import reverse
@@ -12,6 +13,8 @@ from tardis.tardis_portal.models import Experiment, License, ObjectACL, User
 def _create_user_and_login(username='testuser', password='testpass'):
     user = User.objects.create_user(username, '', password)
     user.save()
+    user.user_permissions.add(
+        Permission.objects.get(codename='change_experiment'))
 
     client = Client()
     client.login(username=username, password=password)

--- a/tardis/apps/related_info/tests/tests.py
+++ b/tardis/apps/related_info/tests/tests.py
@@ -1,6 +1,7 @@
 import json
 import six
 
+from django.contrib.auth.models import Permission
 from django.test import TestCase, TransactionTestCase
 from django.test.client import Client
 from django.urls import reverse
@@ -12,6 +13,8 @@ from tardis.tardis_portal.ParameterSetManager import ParameterSetManager
 def _create_user_and_login(username='testuser', password='testpass'):
     user = User.objects.create_user(username, '', password)
     user.save()
+    user.user_permissions.add(
+        Permission.objects.get(codename='change_experiment'))
 
     client = Client()
     client.login(username=username, password=password)

--- a/tardis/tardis_portal/auth/authorisation.py
+++ b/tardis/tardis_portal/auth/authorisation.py
@@ -63,8 +63,8 @@ class ACLAwareBackend(object):
         if perm_label != self.app_label:
             return False
 
-        if perm_type == "change_experiment" and \
-                not user_obj.has_perm("tardis_portal.change_experiment"):
+        if perm_type == 'change_experiment' and \
+                not user_obj.has_perm('tardis_portal.change_experiment'):
             return False
 
         ct = ContentType.objects.get_for_model(obj)

--- a/tardis/tardis_portal/auth/authorisation.py
+++ b/tardis/tardis_portal/auth/authorisation.py
@@ -63,6 +63,10 @@ class ACLAwareBackend(object):
         if perm_label != self.app_label:
             return False
 
+        if perm_type == "change_experiment" and \
+                not user_obj.has_perm("tardis_portal.change_experiment"):
+            return False
+
         ct = ContentType.objects.get_for_model(obj)
         if ct.model != perm_ct:
             return False

--- a/tardis/tardis_portal/tests/test_parametersets.py
+++ b/tardis/tardis_portal/tests/test_parametersets.py
@@ -39,6 +39,7 @@ http://docs.djangoproject.com/en/dev/topics/testing/
 
 from datetime import datetime
 
+from django.contrib.auth.models import Permission
 from django.contrib.auth.models import User
 from django.core.exceptions import SuspiciousOperation
 from django.test import RequestFactory
@@ -351,6 +352,8 @@ class EditParameterSetTestCase(TestCase):
         pwd = 'secret'  # nosec
         email = ''
         self.user = User.objects.create_user(username, email, pwd)
+        self.user.user_permissions.add(
+            Permission.objects.get(codename='change_experiment'))
 
         self.schema = Schema(
             namespace="http://localhost/psmtest/df/",

--- a/tardis/tardis_portal/tests/test_views.py
+++ b/tardis/tardis_portal/tests/test_views.py
@@ -67,6 +67,8 @@ class UploadTestCase(TestCase):
         pwd = 'secret'
         email = ''
         self.user = User.objects.create_user(user, email, pwd)
+        self.user.user_permissions.add(
+            Permission.objects.get(codename='change_experiment'))
 
         self.userProfile = self.user.userprofile
 


### PR DESCRIPTION
A model instance specific permissions check for `tardis_acls.change_experiment`
could return True even when the user was missing the `tardis_portal.change_experiment`
permission.