### PR TITLE
django.contrib.messages should be in INSTALLED_APPS in order to use

### DIFF
--- a/tardis/default_settings/apps.py
+++ b/tardis/default_settings/apps.py
@@ -5,6 +5,7 @@ INSTALLED_APPS = (
     'django_extensions',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.messages',
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.staticfiles',


### PR DESCRIPTION
django.contrib.messages.middleware.MessageMiddleware