### PR TITLE
Displaying full auth method display name in migration success message

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "qunit": "^2.6.1"
   },
   "scripts": {
-    "eslint.jquery": "eslint -c .eslintrc.jquery tardis/tardis_portal/static/js/jquery/tardis_portal/ tardis/tardis_portal/static/js/main.js js_tests/jquery/tardis_portal/ tardis/apps/sftp/static/js/sftp/sftp.js",
+    "eslint.jquery": "eslint -c .eslintrc.jquery tardis/tardis_portal/static/js/jquery/tardis_portal/ tardis/tardis_portal/static/js/main.js js_tests/jquery/tardis_portal/ tardis/apps/sftp/static/js/sftp/sftp.js tardis/apps/openid_migration/static/js/openid_migration/migrate_accounts.js",
     "eslint.angular": "eslint -c .eslintrc.angular tardis/tardis_portal/static/js/facility_view.js",
     "pretest": "npm run eslint.jquery && npm run eslint.angular",
     "test": "grunt test --verbose"

--- a/tardis/apps/openid_migration/migration.py
+++ b/tardis/apps/openid_migration/migration.py
@@ -50,89 +50,94 @@ def do_migration(request):
 
     # if has already registered to use the provided auth method, then we can't
     # link the auth method to the user
-    if user != request.user:
-        logger.info("starting migration from %s to %s", user.username,
-                    request.user.username)
-        # check if the "request.user" has a userProfile
-        userProfile, created = UserProfile.objects.get_or_create(
-            user=request.user)
-        # get request user authentication method
-        data = _setupJsonData(old_user=user, new_user=request.user)
-        # get authenticated user backend
-        backend = request.session['_auth_user_backend']
-        # get key from backend class name
-        auth_method = get_matching_authmethod(backend)
+    if user == request.user:
+        errorMessage = 'User has already registered to use the provided auth method'
+        return _getJsonFailedResponse(errorMessage)
 
-        logger.info("linking user authentication")
-        # in most of the case it should return one authentication method
-        # but in case it returns more than one we need to throw an exception
-        # and notify admin about this.
-        try:
-            userAuths = UserAuthentication.objects.filter(
-                        userProfile__user=user)
-            if userAuths.count() > 1:
-                logger.error("Multiple authentication methods found for user %s" % user)
-                return _getJsonFailedResponse("Something went wrong")
-            elif userAuths.count() < 1:
-                logger.error("No authentication methods found for user %s" % user)
-                return _getJsonFailedResponse("Something went wrong")
-        except ValueError:
-            logger.error("issue with authentication methods for user %s" % user)
+    logger.info("starting migration from %s to %s", user.username,
+                request.user.username)
+    # check if the "request.user" has a userProfile
+    userProfile, created = UserProfile.objects.get_or_create(
+        user=request.user)
+    # get request user authentication method
+    data = _setupJsonData(old_user=user, new_user=request.user)
+    # get authenticated user backend
+    backend = request.session['_auth_user_backend']
+    # get key from backend class name
+    auth_provider = get_matching_auth_provider(backend)
 
-        authenticationMethod = userAuths[0].authenticationMethod
-        logger.info("authentication method is %s", authenticationMethod)
+    logger.info("linking user authentication")
+    # in most of the case it should return one authentication method
+    # but in case it returns more than one we need to throw an exception
+    # and notify admin about this.
+    try:
+        userAuths = UserAuthentication.objects.filter(
+                    userProfile__user=user)
+        if userAuths.count() > 1:
+            logger.error("Multiple authentication methods found for user %s" % user)
+            return _getJsonFailedResponse("Something went wrong")
+        elif userAuths.count() < 1:
+            logger.error("No authentication methods found for user %s" % user)
+            return _getJsonFailedResponse("Something went wrong")
+    except ValueError:
+        logger.error("issue with authentication methods for user %s" % user)
 
-        # let's search for the ACLs that refer to 'user' and transfer them
-        # to request.user
-        userIdToBeReplaced = user.id
-        replacementUserId = request.user.id
-        # for logging migration event
-        user_migration_record = OpenidUserMigration(old_user=user, new_user=request.user,
-                                                    old_user_auth_method=authenticationMethod,
-                                                    new_user_auth_method=auth_method)
-        user_migration_record.save()
-        logger.info("Staring object ACL migration")
-        acl_migration(userIdToBeReplaced, replacementUserId,
-                      user_migration_record)
-        # let's also change the group memberships of all the groups that 'user'
-        # is a member of
-        logger.info("Migrating user groups")
-        groups = Group.objects.filter(user=user)
-        logger.info("Number of groups found : %s", groups.count())
-        for group in groups:
-            request.user.groups.add(group)
-        # change old user username to username_authmethod amd make it inactive
-        old_username = user.username
-        user.username = old_username + '_' + authenticationMethod
-        logger.info("setting old use to inactive")
-        user.is_active = False
-        user.save()
+    old_authentication_method = userAuths[0].authenticationMethod
+    logger.info("Old authentication method is %s", old_authentication_method)
 
-        # change new user username to old user
-        new_user = request.user
-        new_user.username = old_username
-        logger.info("changing new username %s to old username %s",
-                    request.user.username, old_username)
-        new_user.save()
+    # let's search for the ACLs that refer to 'user' and transfer them
+    # to request.user
+    userIdToBeReplaced = user.id
+    replacementUserId = request.user.id
+    # for logging migration event
+    user_migration_record = OpenidUserMigration(
+        old_user=user, new_user=request.user,
+        old_user_auth_method=old_authentication_method,
+        new_user_auth_method=auth_provider[0])
+    user_migration_record.save()
+    logger.info("Staring object ACL migration")
+    acl_migration(userIdToBeReplaced, replacementUserId,
+                  user_migration_record)
+    # let's also change the group memberships of all the groups that 'user'
+    # is a member of
+    logger.info("Migrating user groups")
+    groups = Group.objects.filter(user=user)
+    logger.info("Number of groups found : %s", groups.count())
+    for group in groups:
+        request.user.groups.add(group)
+    # change old user username to username_authmethod amd make it inactive
+    old_username = user.username
+    user.username = old_username + '_' + old_authentication_method
+    logger.info("setting old use to inactive")
+    user.is_active = False
+    user.save()
 
-        # copy api key from old user to new user so that MyData works seamlessly post migration
-        logger.info("migrating api key")
-        migrate_api_key(user, request.user)
+    # change new user username to old user
+    new_user = request.user
+    new_user.username = old_username
+    logger.info("changing new username %s to old username %s",
+                request.user.username, old_username)
+    new_user.save()
 
-        # migrate user permissions
-        logger.info("migrating user permissions")
-        migrate_user_permissions(user, request.user)
+    # copy api key from old user to new user so that MyData works seamlessly post migration
+    logger.info("migrating api key")
+    migrate_api_key(user, request.user)
 
-        # Add migration event record
-        user_migration_record.migration_status = True
-        user_migration_record.save()
-        # send email for successful migration
-        # TODO : get request user auth method
-        logger.info("sending email to %s", user.email)
-        notify_migration_status.delay(user, old_username, 'AAF')
-        logger.info("migration complete")
+    # migrate user permissions
+    logger.info("migrating user permissions")
+    migrate_user_permissions(user, request.user)
 
-    data['auth_method'] = auth_method
+    # Add migration event record
+    user_migration_record.migration_status = True
+    user_migration_record.save()
+    # send email for successful migration
+    # TODO : get request user auth method
+    logger.info("sending email to %s", user.email)
+    notify_migration_status.delay(user, old_username, 'AAF')
+    logger.info("migration complete")
+
+    data['auth_method'] = auth_provider[0]
+    data['auth_method_display_name'] = auth_provider[1]
     return _getJsonSuccessResponse(data=data)
 
 
@@ -242,9 +247,10 @@ def confirm_migration(request):
     # get request user auth method
     backend = request.session['_auth_user_backend']
     # get key from backend class name
-    auth_method = get_matching_authmethod(backend)
+    auth_provider = get_matching_auth_provider(backend)
     data = _setupJsonData(user, request.user)
-    data['auth_method'] = auth_method
+    data['auth_method'] = auth_provider[0]
+    data['auth_method_display_name'] = auth_provider[1]
     return _getJsonConfirmResponse(data)
 
 
@@ -285,8 +291,9 @@ def get_api_key(user):
     return apikey
 
 
-def get_matching_authmethod(backend):
-    for authKey, authDisplayName, authBackend in settings.AUTH_PROVIDERS:
-        if backend == authBackend:
-            return authKey
+def get_matching_auth_provider(backend):
+    for auth_provider in settings.AUTH_PROVIDERS:
+        # Each auth provider is a tuple with (key, display name, backend)
+        if backend == auth_provider[2]:
+            return auth_provider
     return None

--- a/tardis/apps/openid_migration/static/js/openid_migration/migrate_accounts.js
+++ b/tardis/apps/openid_migration/static/js/openid_migration/migrate_accounts.js
@@ -8,11 +8,11 @@ var updateUserData = function(data) {
     $("#old_email").append("<td>" + data.data.old_user_email + "</td>");
     $("#new_username").append("<td>" + data.data.old_username + "</td>");
     // display Google or AAF image based on user current auth method
-    var auth_method = data.data.auth_method
-    if(auth_method.toLowerCase() == 'google'){
-        $("#google_img").css("display","block")
-    }else if(auth_method.toLowerCase() == 'aaf') {
-        $("#aaf_img").css("display","block")
+    var authMethod = data.data.auth_method;
+    if (authMethod.toLowerCase() === "google") {
+        $("#google_img").css("display", "block");
+    } else if(authMethod.toLowerCase() === "aaf") {
+        $("#aaf_img").css("display", "block");
     }
 
 };
@@ -70,7 +70,7 @@ var migrateAccount = function() {
             $("#confirm-migrate").css("display", "none");
             $("#message").css("display", "none");
             $("#migration-success-message").css("display", "block");
-            $("#migration-success-message span span").text(data.data.auth_method);
+            $("#migration-success-message span span").text(data.data.auth_method_display_name);
         }
         else {
             $("#spinner").css("display", "none");


### PR DESCRIPTION
- Renamed get_matching_authmethod to get_matching_auth_provider and made it return the whole auth provider tuple, instead of just the auth method key.
- Updated the view methods which return the auth method key in their JSON, so they now also include the auth method display name in their JSON.
- Updated the Javascript which displays the migration-success-message so that it now uses the auth provider's full display name instead of the authMethod key.
- Fixed a bug in do_migration where user == request.user could lead to an attempt to access an undefined "data" variable.
- Added openid_migration/migrate_accounts.js to ESLint checks