### PR TITLE
User menu modifiers need the request object so they can check

### DIFF
--- a/tardis/apps/sftp/user_menu_modifiers.py
+++ b/tardis/apps/sftp/user_menu_modifiers.py
@@ -1,9 +1,11 @@
 from django.urls import reverse
 
 
-def add_ssh_keys_menu_item(user_menu):
+def add_ssh_keys_menu_item(request, user_menu):
     """Add a 'Manage SSH Keys' item to the user menu
 
+    :param request: an HTTP Request instance
+    :type request: :class:`django.http.HttpRequest`
     :param user_menu: user menu context to modify
     :type user_menu: list
     :return: user_menu list

--- a/tardis/default_settings/apps.py
+++ b/tardis/default_settings/apps.py
@@ -35,6 +35,9 @@ The modifications will be applied in order, so it is possible for one
 app to overwrite changes made by another app whose modifier method is
 earlier in the list.
 
+Each modifier method should take a django.http.HttpRequest object and a
+list of user menu items, and return a modified list of user menu items.
+
 An example from the SFTP app is below:
 
 USER_MENU_MODIFIERS.extend([

--- a/tardis/tardis_portal/context_processors.py
+++ b/tardis/tardis_portal/context_processors.py
@@ -112,5 +112,5 @@ def user_menu_processor(request):
         module_path, method_name = user_menu_modifier.rsplit('.', 1)
         module = import_module(module_path)
         method = getattr(module, method_name)
-        user_menu = method(user_menu)
+        user_menu = method(request, user_menu)
     return dict(user_menu=user_menu)


### PR DESCRIPTION
permissions of the user associated with the request