### PR TITLE
Prefer image data in DataFileParameters for thumbnails

### DIFF
--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -359,24 +359,15 @@ class DataFile(models.Model):
             and mimetype not in ('image/x-icon', 'image/img')
 
     def get_image_data(self):
-        from .parameters import DatafileParameter
-
-        render_image_size_limit = getattr(settings, 'RENDER_IMAGE_SIZE_LIMIT',
-                                          0)
-        if self.is_image() and (self.size <= render_image_size_limit or
-                                render_image_size_limit == 0):
-            return self.get_file()
+        from .parameters import DatafileParameter, ParameterName
 
         # look for image data in parameters
         preview_image_par = None
         pss = self.getParameterSets()
 
-        if not pss:
-            return None
-
         for ps in pss:
             dps = DatafileParameter.objects.filter(
-                parameterset=ps, name__data_type=5,
+                parameterset=ps, name__data_type=ParameterName.FILENAME,
                 name__units__startswith="image")
 
             if dps:
@@ -389,6 +380,13 @@ class DataFile(models.Model):
             preview_image_file = open(file_path)
 
             return preview_image_file
+
+        render_image_size_limit = getattr(settings, 'RENDER_IMAGE_SIZE_LIMIT',
+                                          0)
+        if self.is_image() and (self.size <= render_image_size_limit or
+                                render_image_size_limit == 0):
+            return self.get_file()
+
         return None
 
     def is_public(self):


### PR DESCRIPTION
When retrieving image data for thumbnails, look for preview images in DataFileParameters first, because generating a thumbnail image on the fly can be time-consuming for large image files.

Also replaced magic number (5) with ParameterName.FILENAME

Removed check for empty QuerySet returned from self.getParameterSets(),
which previously caused get_image_data to bail out and return None,
because we don't want to bail out too early, and the case of an
empty QuerySet is handled automatically - the for loop won't run and
preview_image_par will be None, so the if block won't run either.