### PR TITLE
Removed references to Store.Monash from portal_template.html

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/portal_template.html
+++ b/tardis/tardis_portal/templates/tardis_portal/portal_template.html
@@ -312,10 +312,10 @@
     {% with request|check_if_user_not_approved as not_approved_user %}
     {% if not_approved_user %}
         <script>
-            showMsg.showAlert("Welcome to Store.Monash! Your account has been created and " +
-                "is pending admin approval. It might take up to one-business day to " +
+            showMsg.showAlert("Welcome to {{ site_title|default:'MyTardis' }}! Your account has been created and " +
+                "is pending admin approval. It might take up to one business day to " +
                 "approve your account. We will send you an email when this happens. " +
-                "Until then, you will not be able to use any functionalities from Store.Monash");
+                "Until then, you will not be able to use any of {{ site_title|default:'MyTardis' }}'s functionality.");
         </script>
     {% endif %}
     {% endwith %}

--- a/tardis/tardis_portal/templatetags/approved_user_tags.py
+++ b/tardis/tardis_portal/templatetags/approved_user_tags.py
@@ -35,4 +35,6 @@ def get_matching_authmethod(backend):
     for authKey, authDisplayName, authBackend in settings.AUTH_PROVIDERS:
         if backend == authBackend:
             return authKey
+    if backend == 'django.contrib.auth.backends.ModelBackend':
+        return settings.DEFAULT_AUTH  # 'localdb'
     return None


### PR DESCRIPTION
and modified approved_user_tags so that the approval required
message can be tested with a localdb account for which
request.session['_auth_user_backend'] returns 'django.contrib.auth.backends.ModelBackend'