### PR TITLE
Following on from PR https://github.com/mytardis/mytardis/pull/1242,

### DIFF
--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -378,9 +378,9 @@ class DataFile(models.Model):
             file_path = path.abspath(path.join(settings.METADATA_STORE_PATH,
                                                preview_image_par.string_value))
 
-            preview_image_file = open(file_path)
-
-            return preview_image_file
+            if path.exists(file_path):
+                preview_image_file = open(file_path)
+                return preview_image_file
 
         render_image_size_limit = getattr(settings, 'RENDER_IMAGE_SIZE_LIMIT',
                                           0)


### PR DESCRIPTION
Following on from PR https://github.com/mytardis/mytardis/pull/1242, if a preview image parameter is found in the DataFile metadata,
but it refers to a file which doesn't exist, then fall back to
the old default method of generating the thumbnail, which uses
tardis/tardis_portal/iiif.py