### PR TITLE
Removing search autocomplete for now, because if you type what

### DIFF
--- a/js_tests/jquery/main.test.js
+++ b/js_tests/jquery/main.test.js
@@ -1,5 +1,5 @@
-/* global QUnit activateSearchAutocomplete */
-/* eslint global-strict: 0, strict: 0, no-console: 0, object-shorthand: 0, no-unused-vars: [2, {"vars": "local", "args": "none"}] */
+/* global QUnit */
+/* eslint global-strict: 0, strict: 0, no-console: 0, no-unused-vars: [2, {"vars": "local", "args": "none"}] */
 "use strict";
 
 // Tests for tardis/tardis_portal/static/js/main.js
@@ -13,23 +13,10 @@ QUnit.module("tardis_portal.main", {
     }
 });
 
-QUnit.test("Test activating search autocomplete", function(assert) {
+QUnit.test("Test loading main.js", function(assert) {
 
     $.getScript("../tardis/tardis_portal/static/js/main.js", function(data, textStatus, jqxhr) {
         assert.equal(jqxhr.status, 200);
         console.log("Loaded main.js");
     });
-
-    //url: "/search/parameter_field_list/?authMethod=localdb",
-    $.mockjax({
-        url: "/search/parameter_field_list/",
-        contentType: "text/plain",
-        responseText:
-            "Test User1:username+Test User2:username+" +
-            "dataset_id_stored:search_field+" +
-            "experiment_id_stored:search_field+" +
-            "datafile_filename:search_field"
-    });
-
-    activateSearchAutocomplete();
 });

--- a/tardis/default_settings/search.py
+++ b/tardis/default_settings/search.py
@@ -24,5 +24,3 @@ HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
 
 # Setting this to False can speed up indexing and searching:
 DATAFILE_SEARCH_ENABLED = False
-
-SEARCH_AUTOCOMPLETE_ENABLED = True

--- a/tardis/search/urls.py
+++ b/tardis/search/urls.py
@@ -1,17 +1,12 @@
 from django.conf.urls import url, include
 
-from tardis.search.views import (
-    retrieve_field_list,
-    search_experiment
-)
+from tardis.search.views import search_experiment
 
 # from tardis.search.views import SingleSearchView,
 
 urlpatterns = [
     # url(r'^\?$', SingleSearchView.as_view(), name='haystack_search'),
     url(r'', include('haystack.urls')),
-    url(r'^parameter_field_list/$', retrieve_field_list,
-        name='search_retrieve_field_list'),
     url(r'^experiment/$', search_experiment,
         name='tardis.search.views.search_experiment'),
 

--- a/tardis/search/views.py
+++ b/tardis/search/views.py
@@ -3,9 +3,6 @@ views relevant to search
 """
 import logging
 
-from django.contrib.auth.models import User
-from django.conf import settings
-from django.http import HttpResponse
 from haystack.generic_views import SearchView
 
 from tardis.search.forms import GroupedSearchForm
@@ -143,40 +140,6 @@ class ExperimentSearchView(SearchView):
         context.update(self.extra_context())
 
         return render_response_index(self.request, self.template, context)
-
-
-def retrieve_field_list(request):
-    """
-    Used by activateSearchAutocomplete() in tardis/tardis_portal/static/js/main.js
-    via the /search/parameter_field_list/ URL
-    """
-    if not getattr(settings, 'SEARCH_AUTOCOMPLETE_ENABLED', True):
-        return HttpResponse('')
-
-    auto_list = []
-
-    if request.user.is_authenticated:
-        users = User.objects.all()
-        usernames = [u.first_name + ' ' + u.last_name + ':username' for u in users]
-        auto_list += usernames
-
-    if getattr(settings, 'DATAFILE_SEARCH_ENABLED', True):
-        from .datafile_index import DataFileIndex
-        # Get all of the fields in the indexes
-        #
-        # TODO: these should be only read from registered indexes
-        #
-        allFields = DataFileIndex.fields.items()
-
-        # Collect all of the indexed (searchable) fields, except
-        # for the main search document ('text')
-        searchableFields = ([key + ':search_field' for key, f in allFields
-                             if f.indexed is True and key != 'text'])
-
-        auto_list += searchableFields
-
-    fieldList = '+'.join([str(fn) for fn in auto_list])
-    return HttpResponse(fieldList)
 
 
 class SingleSearchView(SearchView):

--- a/tardis/tardis_portal/static/js/main.js
+++ b/tardis/tardis_portal/static/js/main.js
@@ -1,32 +1,6 @@
 /* global $ */
 /* global _ */
-/* eslint global-strict: 0, strict: 0, object-shorthand: 0 */
-var activateSearchAutocomplete = function() {
-    var authMethod = "localdb";
-    var authMethodDict = { authMethod: authMethod };
-    $.ajax({
-        "global": false,
-        "data": authMethodDict,
-        "url": "/search/parameter_field_list/",
-        "success": function(data) {
-            data = data.split("+");
-            var list = _.map(data, function(line) {
-                var name = line.split(":")[0];
-                var type = line.split(":")[1];
-                if (type === "search_field") {
-                    return name + ":";
-                }
-                else {
-                    return name;
-                }
-            });
-            $("#id_q").typeahead({
-                "source": list,
-                "items": 10
-            });
-        }
-    });
-};
+/* eslint global-strict: 0, strict: 0 */
 
 var activateHoverDetection = function() {
     // Hover events
@@ -79,8 +53,5 @@ var isLoggedIn = function() {
 };
 
 $(document).ready(function() {
-    if ($("#id_q").length > 0) {
-        activateSearchAutocomplete();
-    }
     activateHoverDetection();
 });


### PR DESCRIPTION
is intended to be partial match (e.g. James) into the search box
and press enter, the Bootstrap typeahead plugin was populating
the search box with a matching user's name from the autcomplete
dropdown, whereas users would expect that pressing enter would
submit the search immediately.