### PR TITLE
Enhancing MyTardis's Django Admin view by making more models searchable

### DIFF
--- a/tardis/tardis_portal/admin.py
+++ b/tardis/tardis_portal/admin.py
@@ -123,6 +123,7 @@ class StorageBoxForm(forms.ModelForm):
 
 
 class StorageBoxAdmin(admin.ModelAdmin):
+    search_fields = ['name']
     inlines = [StorageBoxOptionInline,
                StorageBoxAttributeInline]
     form = StorageBoxForm
@@ -185,8 +186,25 @@ class ObjectACLAdmin(admin.ModelAdmin):
 class FreeTextSearchFieldAdmin(admin.ModelAdmin):
     pass
 
-admin.site.register(models.Facility)
-admin.site.register(models.Instrument)
+
+class UserAuthenticationAdmin(admin.ModelAdmin):
+    search_fields = [
+        'username',
+        'authenticationMethod',
+        'userProfile__user__username'
+        ]
+
+
+class FacilityAdmin(admin.ModelAdmin):
+    search_fields = ['name']
+
+
+class InstrumentAdmin(admin.ModelAdmin):
+    search_fields = ['name']
+
+
+admin.site.register(models.Facility, FacilityAdmin)
+admin.site.register(models.Instrument, InstrumentAdmin)
 admin.site.register(models.Experiment, ExperimentAdmin)
 admin.site.register(models.License)
 admin.site.register(models.Dataset, DatasetAdmin)
@@ -205,7 +223,7 @@ admin.site.register(models.InstrumentParameterSet, InstrumentParameterSetAdmin)
 admin.site.register(models.Token)
 admin.site.register(models.ExperimentParameterSet, ExperimentParameterSetAdmin)
 admin.site.register(models.GroupAdmin)
-admin.site.register(models.UserAuthentication)
+admin.site.register(models.UserAuthentication, UserAuthenticationAdmin)
 admin.site.register(models.ObjectACL, ObjectACLAdmin)
 admin.site.register(models.FreeTextSearchField, FreeTextSearchFieldAdmin)
 # admin.site.register(MigrationHistory)

--- a/tardis/tardis_portal/models/facility.py
+++ b/tardis/tardis_portal/models/facility.py
@@ -14,6 +14,7 @@ class Facility(models.Model):
     class Meta:
         app_label = 'tardis_portal'
         verbose_name_plural = 'Facilities'
+        ordering = ('name',)
 
     def __str__(self):
         return self.name

--- a/tardis/tardis_portal/models/instrument.py
+++ b/tardis/tardis_portal/models/instrument.py
@@ -16,6 +16,7 @@ class Instrument(models.Model):
         app_label = 'tardis_portal'
         verbose_name_plural = 'Instruments'
         unique_together = ['name', 'facility']
+        ordering = ('name', )
 
     def __str__(self):
         return self.name

--- a/tardis/tardis_portal/models/storage.py
+++ b/tardis/tardis_portal/models/storage.py
@@ -111,6 +111,7 @@ class StorageBox(models.Model):
     class Meta:
         app_label = 'tardis_portal'
         verbose_name_plural = 'storage boxes'
+        ordering = ('name',)
 
     @property
     def cache_box(self):


### PR DESCRIPTION
(UserAuthentication, Facility, Instrument) and setting a default
ordering for the Facility, Instrument and StorageBox models, so
when you're selecting a storage box from a combo-box in Django Admin
they are sorted by storage box name.