### PR TITLE
Changed default BROKER_URL to use RabbitMQ, because in-memory broker

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,11 +9,27 @@ exit
 # # sudo apt-get install memcached python-memcache
 
 
-# for OS X we need these dependencies installed via brew
-# brew install imagemagick --with-libtiff
+# For macOS we need these dependencies installed via brew:
+# brew install imagemagick@6
+#   The Python Wand library is not yet compatible with ImageMagick 7.
+#   If you have trouble running the tests requiring Wand, ensure that
+#   your homebrew imagemagick is installed with compatible versions
+#   of jpeg and libtiff by doing the following:
+#
+#   brew uninstall jpeg libtiff
+#   brew install imagemagick@6
+#   brew link --force imagemagick@6
+#
 # brew install libmagic freetype
-# brew install postgresql
-# or for a local development server, install http://postgresapp.com/
+# brew install postgresql # or SQLite may be sufficient for local development
+#   or for a local development server, install http://postgresapp.com/
+# If you want to test asynchronous processing locally on macOS, you'll need
+# to install a broker such as RabbitMQ, which can be installed with:
+#   brew install rabbitmq
+# However, doing so can pull in a newer version of libtiff which is
+# incompatible with ImageMagick 6 (see above), so it is usually easier to
+# set CELERY_ALWAYS_EAGER = True on macOS.
+# Or you can try a different broker, e.g. Redis
 
 # for Ubuntu 18.04:
 # source /etc/bash_completion.d/virtualenvwrapper

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ exit
 
 
 # For macOS we need these dependencies installed via brew:
+#
 # brew install imagemagick@6
 #   The Python Wand library is not yet compatible with ImageMagick 7.
 #   If you have trouble running the tests requiring Wand, ensure that
@@ -21,21 +22,30 @@ exit
 #   brew link --force imagemagick@6
 #
 # brew install libmagic freetype
+#
 # brew install postgresql # or SQLite may be sufficient for local development
 #   or for a local development server, install http://postgresapp.com/
+#
 # If you want to test asynchronous processing locally on macOS, you'll need
 # to install a broker such as RabbitMQ, which can be installed with:
+#
+#   brew install erlang --without-wxmac
 #   brew install rabbitmq
-# However, doing so can pull in a newer version of libtiff which is
-# incompatible with ImageMagick 6 (see above), so it is usually easier to
-# set CELERY_ALWAYS_EAGER = True on macOS.
-# Or you can try a different broker, e.g. Redis
+#
+# The erlang dependency would be pulled in automatically if you simply ran
+# "brew install rabbimq", however installing erlang with wxmac can pull in
+# a newer version of libtiff which is incompatible with ImageMagick 6 (see above)
+# If you don't need to test asynchronous processing on macOS, you can just set
+# CELERY_ALWAYS_EAGER = True in your tardis/settings.py, to run all tasks
+# synchronously, so that you don't require a broker like RabbitMQ.
 
-# for Ubuntu 18.04:
+# For Ubuntu 18.04:
 # source /etc/bash_completion.d/virtualenvwrapper
-# for Ubuntu 16.04:
+
+# For Ubuntu 16.04:
 # source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
-# for OS X
+
+# For macOS:
 # source /usr/local/bin/virtualenvwrapper.sh
 
 mkvirtualenv mytardis

--- a/tardis/celery.py
+++ b/tardis/celery.py
@@ -1,7 +1,15 @@
 from __future__ import absolute_import
+from datetime import timedelta
 from celery import Celery  # pylint: disable=import-error
 from django.apps import apps  # pylint: disable=wrong-import-order
 
 tardis_app = Celery('tardis')
 tardis_app.config_from_object('django.conf:settings')
 tardis_app.autodiscover_tasks(lambda: [n.name for n in apps.get_app_configs()])
+
+tardis_app.conf.CELERYBEAT_SCHEDULE = {
+    "verify-files": {
+        "task": "tardis_portal.verify_dfos",
+        "schedule": timedelta(seconds=300)
+    },
+}

--- a/tardis/default_settings/celery_settings.py
+++ b/tardis/default_settings/celery_settings.py
@@ -1,18 +1,8 @@
 # Celery queue
-from datetime import timedelta
 
-CELERYBEAT_SCHEDULE = {
-    "verify-files": {
-        "task": "tardis_portal.verify_dfos",
-        "schedule": timedelta(seconds=300)
-    },
-}
-
-CELERY_IMPORTS = ('tardis.tardis_portal.tasks',)
-
-# Use a real broker (e.g. RabbitMQ) for production, but memory is OK for
+# Use a strong password for production, but guest credentials are OK for
 # local development:
-BROKER_URL = 'memory://'
+BROKER_URL = 'amqp://guest:guest@localhost:5672//'
 
 # For local development, you can force Celery tasks to run synchronously:
 # CELERY_ALWAYS_EAGER = True


### PR DESCRIPTION
only works for a single process (now that we're not using django-celery).

Removed CELERY_IMPORTS because this is handled by autodiscover_tasks
in tardis/celery.py

Moved CELERYBEAT_SCHEDULE default configuration into tardis/celery.py

Added some notes on installing ImageMagick and optionally RabbitMQ via
Homebrew