### PR TITLE
Reverting to default BROKER_URL of 'django://' as used in v3.9.

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -23,6 +23,7 @@ html2text==2018.1.9
 html5lib==1.0.1
 isodate==0.6.0
 pyjwt==1.6.4
+kombu==3.0.37 # pyup: <4
 lxml==4.2.4
 paramiko==2.4.2
 pillow==5.2.0

--- a/tardis/default_settings/apps.py
+++ b/tardis/default_settings/apps.py
@@ -15,6 +15,7 @@ INSTALLED_APPS = (
     'registration',
     'bootstrapform',
     'jstemplate',
+    'kombu.transport.django',
     'tastypie',
     'tastypie_swagger',
     'tardis.tardis_portal',

--- a/tardis/default_settings/celery_settings.py
+++ b/tardis/default_settings/celery_settings.py
@@ -10,9 +10,14 @@ CELERYBEAT_SCHEDULE = {
 
 CELERY_IMPORTS = ('tardis.tardis_portal.tasks',)
 
-# Use a real broker (e.g. RabbitMQ) for production, but memory is OK for
-# local development:
-BROKER_URL = 'memory://'
+# Using Celery for asynchronous task processing requires a broker e.g. RabbitMQ
+# Use a strong password for production
+# BROKER_URL = 'amqp://guest:guest@localhost:5672//'
+
+# The 'django://' BROKER_URL uses the kombu.transport.django app to allow
+# messages to be passed via the database, which is not suitable for production,
+# but can be used for local development:
+BROKER_URL = 'django://'
 
 # For local development, you can force Celery tasks to run synchronously:
 # CELERY_ALWAYS_EAGER = True


### PR DESCRIPTION
Having followed advice that django-celery was no longer needed,
we had removed both djcelery and kombu.transport.django from the
default INSTALLED_APPS, but for local development, Kombu is
much easier to get up and running than production-worthy brokers
like RabbitMQ, so we are reverting to the old default BROKER_URL
of 'django://'