### PR TITLE
Rename "Edit Dataset Description" button to "Edit Dataset" to be

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
@@ -377,7 +377,7 @@ $(document).on('click', '#modal-metadata .submit-button', function() {
     <a class="btn btn-warning btn-mini" title="Edit Dataset"
        href="{{ dataset.get_edit_url }}">
       <i class="fa fa-pencil"></i>
-      Edit Dataset Description
+      Edit Dataset
     </a>
   {% endif %}
     </div>


### PR DESCRIPTION
consistent with the Experiment view's "Edit Experiment" button.
Clicking the "Edit Dataset [Description]" button allows editing
other fields besides just the description (e.g. changing the
instrument associated with the dataset).