### PR TITLE
Updating the instructions for running ImageMagick v6 via homebrew

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,8 @@ exit
 #   brew uninstall jpeg libtiff
 #   brew install imagemagick@6
 #   brew link --force imagemagick@6
+#   echo "export MAGICK_HOME=/usr/local/opt/imagemagick@6/" >> ~/.bashrc
+#   source ~/.bashrc
 #
 # brew install libmagic freetype
 #


### PR DESCRIPTION
Updating the instructions for running ImageMagick v6 via homebrew
on macOS - setting the MAGICK_HOME environment variable may be required.

ImageMagick v7 (the default version installed by brew) still doesn't
seem to play nicely with the Python Wand package, even after Wand's
recent v0.4.5 update.