### PR TITLE
Use is_authenticated property instead of method for Django 1.10 and later

### DIFF
--- a/tardis/tardis_portal/templatetags/approved_user_tags.py
+++ b/tardis/tardis_portal/templatetags/approved_user_tags.py
@@ -12,7 +12,7 @@ def check_if_user_not_approved(request):
     Custom template filter to identify whether a user account
     is approved.
     """
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         user = request.user
         if not hasattr(request, "session"):
             # This should only happen in unit tests


### PR DESCRIPTION
The is_authenticated() method should be replaced by the is_authenticated property for Django 1.10 and later