### PR TITLE
Use volumes to allow re-running Docker CI tests with modified MyTardis code

### DIFF
--- a/docker-ci/docker-test.yml
+++ b/docker-ci/docker-test.yml
@@ -10,6 +10,9 @@ services:
       context: ..
       dockerfile: docker-ci/Dockerfile-test
     image: mytardis/mytardis-test
+    volumes:
+      - ../tardis:/home/webapp/tardis
+      - ../docs:/home/webapp/docs
     depends_on:
       - run
       - pg


### PR DESCRIPTION
Use volumes to allow re-running Docker CI tests (after modifying MyTardis code) without rebuilding Docker images.  These volumes were temporarily removed when docker-test.yml was moved into
the docker-ci/ directory.  Now they are being reinstated.