### PR TITLE
Fix facilities managed by issue

### DIFF
--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -214,15 +214,12 @@ class DataFile(models.Model):
     def get_size(self):
         return self.size
 
-    def getParameterSets(self, schemaType=None):
+    def getParameterSets(self):
         """Return datafile parametersets associated with this datafile.
-
         """
         from .parameters import Schema
-        if schemaType == Schema.DATAFILE or schemaType is None:
-            return self.datafileparameterset_set.filter(
-                schema__type=Schema.DATAFILE)
-        raise Schema.UnsupportedType
+        return self.datafileparameterset_set.filter(
+            schema__type=Schema.DATAFILE)
 
     def __str__(self):
         if self.sha512sum is not None and len(self.sha512sum) > 31:

--- a/tardis/tardis_portal/models/dataset.py
+++ b/tardis/tardis_portal/models/dataset.py
@@ -62,16 +62,14 @@ class Dataset(models.Model):
     def is_online(self):
         return all(df.is_online for df in self.datafile_set.all())
 
-    def getParameterSets(self, schemaType=None):
+    def getParameterSets(self):
         """Return the dataset parametersets associated with this
         experiment.
 
         """
         from .parameters import Schema
-        if schemaType == Schema.DATASET or schemaType is None:
-            return self.datasetparameterset_set.filter(
-                schema__type=Schema.DATASET)
-        raise Schema.UnsupportedType
+        return self.datasetparameterset_set.filter(
+            schema__type=Schema.DATASET)
 
     def __str__(self):
         return self.description

--- a/tardis/tardis_portal/models/experiment.py
+++ b/tardis/tardis_portal/models/experiment.py
@@ -105,16 +105,14 @@ class Experiment(models.Model):
                 self.PUBLICATION_SCHEMA_ROOT)
         ).count() > 0
 
-    def getParameterSets(self, schemaType=None):
+    def getParameterSets(self):
         """Return the experiment parametersets associated with this
         experiment.
 
         """
         from .parameters import Schema
-        if schemaType == Schema.EXPERIMENT or schemaType is None:
-            return self.experimentparameterset_set.filter(
-                schema__type=Schema.EXPERIMENT)
-        raise Schema.UnsupportedType
+        return self.experimentparameterset_set.filter(
+            schema__type=Schema.EXPERIMENT)
 
     def __str__(self):
         return self.title

--- a/tardis/tardis_portal/models/facility.py
+++ b/tardis/tardis_portal/models/facility.py
@@ -48,4 +48,6 @@ def facilities_managed_by(user):
     '''
     Returns a list of facilities managed by a user
     '''
+    if not user.is_authenticated:
+        return Facility.objects.none()
     return Facility.objects.filter(manager_group__user=user)

--- a/tardis/tardis_portal/models/instrument.py
+++ b/tardis/tardis_portal/models/instrument.py
@@ -28,16 +28,13 @@ class Instrument(models.Model):
     def __str__(self):
         return self.name
 
-    def getParameterSets(self, schemaType=None):
+    def getParameterSets(self):
         '''Return the instrument parametersets associated with this
         instrument.
-
         '''
         from .parameters import Schema
-        if schemaType == Schema.INSTRUMENT or schemaType is None:
-            return self.instrumentparameterset_set.filter(
-                schema__type=Schema.INSTRUMENT)
-        raise Schema.UnsupportedType
+        return self.instrumentparameterset_set.filter(
+            schema__type=Schema.INSTRUMENT)
 
     def _has_change_perm(self, user_obj):
         """

--- a/tardis/tardis_portal/tests/api/test_instrument_resource.py
+++ b/tardis/tardis_portal/tests/api/test_instrument_resource.py
@@ -122,3 +122,8 @@ class InstrumentResourceTest(MyTardisResourceTestCase):
         self.testinstrument = Instrument.objects.get(id=self.testinstrument.id)
         self.assertEqual(self.testinstrument.name,
                          "Renamed Test Instrument")
+
+    def test_unauthorized_instrument_access_attempt(self):
+        response = self.api_client.get(
+            '/api/v1/instrument/%d/' % self.testinstrument.id)
+        self.assertHttpUnauthorized(response)


### PR DESCRIPTION
Fix issue where attempting to access an instrument via the REST API without being in the facility manager's group gave an Internal Server Error instead of an Unauthorized error.