### PR TITLE
Remove billiard requirement

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,7 +1,6 @@
 Django==1.11.20 # pyup: >=1.11,<2.0
 Wand==0.5.2
 amqp==2.4.2
-billiard==3.5.0.5 # pyup: >=3.5.0.2,<3.6.0
 bleach==3.1.0
 celery==4.3.0
 django-bootstrap-form==3.4


### PR DESCRIPTION
Better to let celery's pip install decide which billiard version to use
Add newline missing from end of file