### PR TITLE
Remove provide plugin

### DIFF
--- a/assets/js/tardis_portal/index/index.js
+++ b/assets/js/tardis_portal/index/index.js
@@ -1,8 +1,4 @@
-/* tardis/tardis_portal/static/js/jquery/tardis_portal/index.js */
-
-/* global attachExpAccordionClickHandlers, expandFirstExperiments, loadRecentDatasetsSummary */
-require("bootstrap");
-import {attachExpAccordionClickHandlers, expandFirstExperiments, loadRecentDatasetsSummary} from "./experiment-accordion";
+import {attachExpAccordionClickHandlers, expandFirstExperiments, loadRecentDatasetsSummary} from "../experiment-accordion";
 
 $(document).ready(function() {
     $("#private-experiments .accordion-body").collapse({parent: "#private-experiments", toggle: false});

--- a/assets/js/tardis_portal/manage_group_members/ready.js
+++ b/assets/js/tardis_portal/manage_group_members/ready.js
@@ -1,10 +1,7 @@
-/* tardis/tardis_portal/static/js/jquery/tardis_portal/view_dataset/ready.js */
-
 /* global _, userAutocompleteHandler */
-require("bootstrap");
 require("jquery-ui-dist/jquery-ui.min.js");
+import {userAutocompleteHandler} from "../main";
 
-const main = require("main");
 var loadingHTML = "<img src=\"/static/images/ajax-loader.gif\"/>";
 
 $(document).ready(function() {
@@ -129,7 +126,7 @@ $(document).ready(function() {
                         "source": _.bind( function(query, callback) {
                             var authMethod = $("#id_authMethod").val();
                             callback(
-                                main.userAutocompleteHandler(
+                                userAutocompleteHandler(
                                     query.term, this.users, authMethod));
                         }, { "users": users })
                     });

--- a/assets/js/tardis_portal/my_data/my_data.js
+++ b/assets/js/tardis_portal/my_data/my_data.js
@@ -1,9 +1,3 @@
-/* tardis/tardis_portal/static/js/jquery/tardis_portal/my_data.js */
-
-/* global attachExpAccordionClickHandlers, expandFirstExperiments, loadLatestDatasetSummary */
-
-require("jquery");
-require("bootstrap");
 import {attachExpAccordionClickHandlers, loadLatestDatasetSummary, expandFirstExperiments} from "../experiment-accordion";
 $(document).ready(function() {
     // Load owned exps on page load

--- a/assets/js/tardis_portal/shared/shared.js
+++ b/assets/js/tardis_portal/shared/shared.js
@@ -1,7 +1,3 @@
-/* tardis/tardis_portal/static/js/jquery/tardis_portal/shared.js */
-
-/* global attachExpAccordionClickHandlers, expandFirstExperiments, loadLatestDatasetSummary */
-require("bootstrap");
 import {attachExpAccordionClickHandlers, loadLatestDatasetSummary, expandFirstExperiments} from "../experiment-accordion";
 
 $(document).ready(function() {

--- a/assets/js/tardis_portal/view_dataset/file-upload.js
+++ b/assets/js/tardis_portal/view_dataset/file-upload.js
@@ -1,7 +1,7 @@
 /* global showMsg */
-require('imports-loader?define=>false&exports=>false!blueimp-file-upload/js/vendor/jquery.ui.widget.js');
-require('imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.fileupload.js');
-require('imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.iframe-transport.js');
+require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/vendor/jquery.ui.widget.js");
+require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.fileupload.js");
+require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.iframe-transport.js");
 
 $(function() {
     $("#dropzone").hide();

--- a/assets/js/tardis_portal/view_dataset/file-upload.js
+++ b/assets/js/tardis_portal/view_dataset/file-upload.js
@@ -1,7 +1,7 @@
 /* global showMsg */
-require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/vendor/jquery.ui.widget.js");
-require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.fileupload.js");
-require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.iframe-transport.js");
+require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/vendor/jquery.ui.widget");
+require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.fileupload");
+require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.iframe-transport");
 
 $(function() {
     $("#dropzone").hide();

--- a/assets/js/tardis_portal/view_dataset/file-upload.js
+++ b/assets/js/tardis_portal/view_dataset/file-upload.js
@@ -1,12 +1,7 @@
-/* tardis/tardis_portal/static/js/jquery/tardis_portal/view_dataset/file-upload.js */
-
-/* eslint global-strict: 0, strict: 0, object-shorthand: 0,
-          no-unused-vars: [2, {"vars": "local", "args": "none"}] */
-
 /* global showMsg */
-require("blueimp-file-upload/js/vendor/jquery.ui.widget");
-require("blueimp-file-upload/js/jquery.fileupload");
-require("blueimp-file-upload/js/jquery.iframe-transport");
+require('imports-loader?define=>false&exports=>false!blueimp-file-upload/js/vendor/jquery.ui.widget.js');
+require('imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.fileupload.js');
+require('imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.iframe-transport.js');
 
 $(function() {
     $("#dropzone").hide();

--- a/assets/js/tardis_portal/view_dataset/ready.js
+++ b/assets/js/tardis_portal/view_dataset/ready.js
@@ -1,12 +1,4 @@
-/* tardis/tardis_portal/static/js/jquery/tardis_portal/view_dataset/ready.js */
-  
-/* eslint global-strict: 0, strict: 0, object-shorthand: 0,
-          no-unused-vars: [2, {"vars": "local", "args": "none"}] */
-
 /* global prevFileSelect */
-
-require("bootstrap");
-require("jquery");
 $(document).ready(function() {
 
     // Create a reload event handler

--- a/assets/js/tardis_portal/view_experiment/activate-tooltips.js
+++ b/assets/js/tardis_portal/view_experiment/activate-tooltips.js
@@ -1,9 +1,3 @@
-/* tardis/tardis_portal/static/js/jquery/tardis_portal/view_experiment/activate_tooltips.js */
-  
-/* eslint global-strict: 0, strict: 0 */
-
-require("bootstrap");
-
 $(document).ready(function() {
     // Activate tooltips
     $("body").tooltip({

--- a/assets/js/tardis_portal/view_experiment/dataset-tiles.js
+++ b/assets/js/tardis_portal/view_experiment/dataset-tiles.js
@@ -1,10 +1,7 @@
-/* tardis/tardis_portal/static/js/jquery/tardis_portal/view_experiment/dataset_tiles.js */
+/* global Backbone, Mustache */
 
-/* eslint global-strict: 0, strict: 0 */
-/* eslint-disable no-unused-vars */
-/* global Backbone, backbonemodels, Mustache */
-
-require("sprintf-js");
+import "sprintf-js";
+import {MyTardis} from "../backbone-models";
 
 $(function() {
     var oldSync = Backbone.sync;
@@ -18,12 +15,12 @@ $(function() {
 
 (function() {
 
-    var datasets = new backbonemodels.MyTardis.Datasets();
+    var datasets = new MyTardis.Datasets();
 
     datasets.experimentId = $("#experiment-id").val();
     datasets.url = "/ajax/json/experiment/" + $("#experiment-id").val() + "/dataset/";
 
-    var datasetTiles = new backbonemodels.MyTardis.DatasetTiles({
+    var datasetTiles = new MyTardis.DatasetTiles({
         "id": "datasets",
         "collection": datasets,
         "el": $("#datasets").get(0)
@@ -36,13 +33,14 @@ $(function() {
 
 (function() {
 
+    // eslint-disable-next-line no-unused-vars
     function getDatasetsForExperiment(experimentId) {
-        var datasets = new backbonemodels.MyTardis.Datasets();
+        var datasets = new MyTardis.Datasets();
         datasets.experimentId = parseInt("10", experimentId),
         // Substitute experiment ID to get collection
         datasets.url = Mustache.to_html("{{ url_pattern }}",
             { "experiment_id": experimentId });
-        var datasetTiles = new backbonemodels.MyTardis.DatasetTiles({
+        var datasetTiles = new MyTardis.DatasetTiles({
             "id": "other-experiment-datasets",
             "collection": datasets,
             "el": $("#other-experiment-datasets").get(0)

--- a/assets/js/tardis_portal/view_experiment/share/share.js
+++ b/assets/js/tardis_portal/view_experiment/share/share.js
@@ -1,11 +1,6 @@
-/* tardis/tardis_portal/static/js/jquery/tardis_portal/ajax/share.js */
+/* global _ */
+import {userAutocompleteHandler} from "../../main";
 
-/* eslint global-strict: 0, strict: 0, object-shorthand: 0,
-          no-extend-native: [2, {"exceptions": ["Date", "String"]}],
-          no-unused-vars: [2, {"vars": "local", "args": "none"}] */
-
-/* global userAutocompleteHandler, _ */
-require("bootstrap");
 var loadingHTML = "<img src=\"/static/images/ajax-loader.gif\"/><br />";
 
 

--- a/docker-ci/Dockerfile-base
+++ b/docker-ci/Dockerfile-base
@@ -35,6 +35,6 @@ RUN chown -R webapp:webapp /appenv
 RUN chown -R webapp:webapp /home/webapp
 USER webapp
 RUN virtualenv --system-site-packages /appenv
-RUN . /appenv/bin/activate; pip install -U -e "git+https://github.com/pypa/pip.git#egg=pip" wheel
+RUN . /appenv/bin/activate; pip install -U "git+https://github.com/pypa/pip.git#egg=pip" wheel
 COPY . /home/webapp/
 USER root

--- a/docker-ci/Dockerfile-base
+++ b/docker-ci/Dockerfile-base
@@ -35,6 +35,6 @@ RUN chown -R webapp:webapp /appenv
 RUN chown -R webapp:webapp /home/webapp
 USER webapp
 RUN virtualenv --system-site-packages /appenv
-RUN . /appenv/bin/activate; pip install -U "git+https://github.com/pypa/pip.git#egg=pip" wheel
+RUN . /appenv/bin/activate; pip install -U pip wheel
 COPY . /home/webapp/
 USER root

--- a/docker-ci/Dockerfile-build
+++ b/docker-ci/Dockerfile-build
@@ -29,5 +29,4 @@ CMD . /appenv/bin/activate; \
     pip install -U setuptools; \
     pip wheel -r requirements.txt; \
     pip wheel -r requirements-postgres.txt; \
-    pip wheel -r requirements-mysql.txt; \
-    pip wheel -e "git+https://github.com/pypa/pip.git#egg=pip"
+    pip wheel -r requirements-mysql.txt;

--- a/features/steps/create_dataset.py
+++ b/features/steps/create_dataset.py
@@ -79,6 +79,6 @@ def they_see_newly_created_dataset(context):
             context.browser.execute_script("return jQuery.active == 0"))
     # The ajax-loaded "share.html" experiment tab loads some of its content via ajax
     # so we'll give it some time to finish loading:
-    time.sleep(2.0)
+    time.sleep(0.5)
     dataset_link = context.browser.find_element_by_css_selector("a.dataset-link")
     context.test.assertIn("new dataset", dataset_link.get_attribute("innerHTML"))

--- a/js_tests/tardis_portal/main.test.js
+++ b/js_tests/tardis_portal/main.test.js
@@ -1,8 +1,9 @@
-/* global QUnit, main, JSON */
-"use strict";
+/* global QUnit, $ */
 
 // Tests for assets/js/tardis_portal/main.js
-require("main");
+
+import {userAutocompleteHandler} from "../../assets/js/tardis_portal/main";
+
 QUnit.module("tardis_portal.main", {
     beforeEach: function(assert) {
         $.ajaxSetup({async: false});
@@ -11,14 +12,6 @@ QUnit.module("tardis_portal.main", {
         $.ajaxSetup({async: true});
     }
 });
-
-/*QUnit.test("Test loading main.js", function(assert) {
-
-    $.getScript("../assets/js/tardis_portal/main.js", function(data, textStatus, jqxhr) {
-        assert.equal(jqxhr.status, 200);
-
-    });
-});*/
 
 QUnit.test("Test userAutocompleteHandler", function(assert) {
 
@@ -55,6 +48,6 @@ QUnit.test("Test userAutocompleteHandler", function(assert) {
             "value": "testuser2"
         }
     ];
-    var actual = main.userAutocompleteHandler("Test", mockUsersList, "localdb");
+    var actual = userAutocompleteHandler("Test", mockUsersList, "localdb");
     assert.equal(JSON.stringify(actual), JSON.stringify(expected));
 });

--- a/js_tests/tardis_portal/view_experiment/experiment-tabs.test.js
+++ b/js_tests/tardis_portal/view_experiment/experiment-tabs.test.js
@@ -1,10 +1,6 @@
-/* eslint global-strict: 0, strict: 0, no-console: 0, object-shorthand: 0,
-          no-unused-vars: [2, {"vars": "local", "args": "none"}] */
-/* global QUnit, _, experimentabs */
-"use strict";
-require("experimentabs");
-require("bootstrap");
-require("mustache");
+/* global QUnit, _ */
+
+import {populateExperimentTabs} from "../../../assets/js/tardis_portal/view_experiment/experiment-tabs";
 
 QUnit.module("tardis_portal.view_experiment.experiment-tabs", {
     beforeEach: function(assert) {
@@ -64,7 +60,7 @@ QUnit.test("Load experiment tabs", function(assert) {
     var expDatasetTransferDiv = $("#qunit-fixture").find("#experiment-tab-transfer-datasets");
     assert.equal(expDatasetTransferDiv.length, 0);
 
-    experimentabs.populateExperimentTabs();
+    populateExperimentTabs();
     // Ensure that experiment metadata tab pane's content has been loaded:
     expMetadataDiv = $("#qunit-fixture").find("#experiment-tab-metadata");
     assert.equal(expMetadataDiv.html(), "Experiment metadata pane mock content");

--- a/js_tests/tardis_portal/view_experiment/share.test.js
+++ b/js_tests/tardis_portal/view_experiment/share.test.js
@@ -6,9 +6,8 @@
 // Tests for assets/js/tardis_porta/view_experiment/share.js
 // which used to be embedded within
 // tardis/tardis_portal/templates/tardis_portal/ajax/share.html
+
 require("jquery-mockjax/dist/jquery.mockjax")(jQuery, window);
-//require("experimentshare");
-require("mustache");
 
 QUnit.module("tardis_portal.ajax.share", {
     beforeEach: function(assert) {

--- a/tardis/tardis_portal/templates/tardis_portal/index.html
+++ b/tardis/tardis_portal/templates/tardis_portal/index.html
@@ -9,7 +9,6 @@
 {% endblock script %}
 
 {% block content %}
-    {% render_bundle 'tardis_portal' %}
 <div id="content">
   <div class="page-header">
     <h1>{{site_title|default:'MyTardis'}} Data Store</h1>
@@ -135,5 +134,5 @@
   </div> {% comment %}class="row"{% endcomment %}
 </div> {% comment %}id="content"{% endcomment %}
 <input type="hidden" id="exps-expand-accordion" value="{{ exps_expand_accordion }}">
-    {% render_bundle 'main' %}
+{% render_bundle 'tardis_portal_index' %}
 {% endblock content %}

--- a/tardis/tardis_portal/templates/tardis_portal/my_data.html
+++ b/tardis/tardis_portal/templates/tardis_portal/my_data.html
@@ -67,5 +67,4 @@
 
 <input type="hidden" id="exps-expand-accordion" value="{{ exps_expand_accordion }}">
 {% render_bundle 'tardis_portal_my_data' %}
-    {% render_bundle 'main' %}
 {% endblock %}

--- a/tardis/tardis_portal/templates/tardis_portal/shared.html
+++ b/tardis/tardis_portal/templates/tardis_portal/shared.html
@@ -61,7 +61,5 @@
 </div>  <!-- id="content" -->
 
 <input type="hidden" id="exps-expand-accordion" value="{{ exps_expand_accordion }}">
-{% render_bundle 'tardis_portal_my_data' %}
 {% render_bundle 'tardis_portal_shared' %}
-
 {% endblock %}

--- a/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
@@ -348,7 +348,6 @@ margin-top: 20px;
       </div>
   </div>
 </div>
-    {% render_bundle 'main' %}
 {% block finalscript %}
 <input type="hidden" id="upload-method" value="{{ upload_method }}">
 {% if upload_method %}

--- a/test-webpack.config.js
+++ b/test-webpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
         tardis_portal_view_experiment: glob.sync("./assets/js/tardis_portal/view_experiment/*.js"),
         tardis_portal_view_dataset: glob.sync("./assets/js/tardis_portal/view_dataset/**/*.js"),
         tardis_portal_manage_group_members: glob.sync("./assets/js/tardis_portal/manage_group_members/**/*.js"),
+        tardis_portal_index: glob.sync("./assets/js/tardis_portal/index/**/*.js"),
         tardis_portal_my_data: glob.sync("./assets/js/tardis_portal/my_data/**/*.js"),
         tardis_portal_shared: glob.sync("./assets/js/tardis_portal/shared/**/*.js"),
         tardis_portal_facility_view: "./assets/js/tardis_portal/facility_view/index.js",
@@ -71,17 +72,7 @@ module.exports = {
         ),
         new MiniCssExtractPlugin({
             filename: "[name].styles.css",
-        }),
-        new webpack.ProvidePlugin({
-            $: "jquery",
-            jQuery: "jquery",
-            "window.jQuery": "jquery",
-            "async": "async",
-            "main": "main",
-            "backbonemodels": "backbonemodels",
-            "experimentabs": "experimentabs",
-            "experimentshare": "experimentshare",
-        }),
+        })
     ],
     module: {
         rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
         tardis_portal_view_experiment: glob.sync("./assets/js/tardis_portal/view_experiment/*.js"),
         tardis_portal_view_dataset: glob.sync("./assets/js/tardis_portal/view_dataset/**/*.js"),
         tardis_portal_manage_group_members: glob.sync("./assets/js/tardis_portal/manage_group_members/**/*.js"),
+        tardis_portal_index: glob.sync("./assets/js/tardis_portal/index/**/*.js"),
         tardis_portal_my_data: glob.sync("./assets/js/tardis_portal/my_data/**/*.js"),
         tardis_portal_shared: glob.sync("./assets/js/tardis_portal/shared/**/*.js"),
         tardis_portal_facility_view: "./assets/js/tardis_portal/facility_view/index.js",
@@ -70,15 +71,7 @@ module.exports = {
         ),
         new MiniCssExtractPlugin({
             filename: "[name]-[hash].styles.css",
-        }),
-        new webpack.ProvidePlugin({
-            $: "jquery",
-            jQuery: "jquery",
-            "window.jQuery": "jquery",
-            "async": "async",
-            "main": "main",
-            "backbonemodels": "backbonemodels",
-        }),
+        })
     ],
     module: {
         rules: [


### PR DESCRIPTION

Avoid loading multiple jQuery instances via webpack by removing  …
unnecessary loading of main bundle (outside portal_template), and
by not using Webpack's ProvidePlugin.

This fixes an issue where sometimes the user menu wasn't opening
when clicked (or it was opening and immediately closing), which
appeared to be because multiple event listeners were responding
to the same click event.