### PR TITLE
Underscores in API resource names shouldn't prevent getting resource's schema

### DIFF
--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -226,7 +226,7 @@ class ACLAuthorization(Authorization):
         if bundle.request.user.is_authenticated and \
            bundle.request.user.is_superuser:
             return True
-        if re.match("^/api/v1/[a-z]+/schema/$", bundle.request.path):
+        if re.match("^/api/v1/[a-z_]+/schema/$", bundle.request.path):
             return True
         if isinstance(bundle.obj, Experiment):
             return has_experiment_access(bundle.request, bundle.obj.id)


### PR DESCRIPTION
Underscores are allowed in resource names, so this code was behaving strangely for URLs like /api/v1/dataset_file/schema/