### PR TITLE
We don't need urllib3 in requirements-base.txt

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -34,5 +34,4 @@ git+https://github.com/mytardis/python-magic.git#egg=python-magic
 pytz==2019.1
 requests==2.21.0
 six==1.12.0
-urllib3==1.24.1
 django-webpack-loader==0.6.0


### PR DESCRIPTION
We don't need urllib3 in requirements-base.txt, better to let pip install requests choose the urllib3 version