### PR TITLE
Avoid loading scripts from AJAX content loaded by experiment view page

### DIFF
--- a/assets/js/tardis_portal/view_experiment/experiment-tabs.js
+++ b/assets/js/tardis_portal/view_experiment/experiment-tabs.js
@@ -1,6 +1,8 @@
 /* eslint global-strict: 0, strict: 0, object-shorthand: 0 */
 /* global s */
 
+import { expSharingAjaxReady } from "./share/share.js";
+
 export function populateExperimentTabs() {
     var loadingHTML = "<img src=\"/static/images/ajax-loader.gif\"/><br />";
     var tabIdPrefix = "experiment-tab-";
@@ -52,6 +54,10 @@ export function populateExperimentTabs() {
                 dataType: "html",
                 success: function(data) {
                     tabPane.html(data);
+                    const tab = url.substring(url.lastIndexOf("/") + 1);
+                    if (tab === "share") {
+                        expSharingAjaxReady();
+                    }
                 }
             });
         });

--- a/assets/js/tardis_portal/view_experiment/share/share.js
+++ b/assets/js/tardis_portal/view_experiment/share/share.js
@@ -435,7 +435,7 @@ export function addGroupSharingEventHandlers() {
     });
 }
 
-$(document).ready(function() {
+export function expSharingAjaxReady() {
 
     // user access list
     var $targetUser = $("#experiment_user_list");
@@ -479,4 +479,4 @@ $(document).ready(function() {
     addChangePublicAccessEventHandlers();
     addUserSharingEventHandlers();
     addGroupSharingEventHandlers();
-});
+}

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_dataset_transfer.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_dataset_transfer.html
@@ -1,5 +1,3 @@
-{% load render_bundle from webpack_loader %}
-{% render_bundle 'tardis_portal' %}
 {% if experiments %}
 <form id="other-experiment-selection" class="form-horizontal">{% csrf_token %}
   <fieldset>

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/share.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/share.html
@@ -1,13 +1,11 @@
 {% load static from staticfiles %}
 {% load experiment_tags %}
-{% load render_bundle from webpack_loader %}
 {% block script %}
 {% endblock %}
 {% block content %}
 
 <!-- Scripts -->
 {% load jstemplate %}
-{% render_bundle 'tardis_portal_view_experiment_share' %}
 {% mustachejs "tardis_portal/license_selector" %}
 {% mustachejs "tardis_portal/rights_update_message" %}
 {% mustachejs "tardis_portal/ajax_error" %}

--- a/tardis/tardis_portal/templates/tardis_portal/view_experiment.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_experiment.html
@@ -20,6 +20,7 @@
 <input type="hidden" id="experiment-id" value="{{ experiment.id }}">
 <input type="hidden" id="csrf-token" value="{{ csrf_token }}">
 {% render_bundle 'tardis_portal_view_experiment_init' %}
+{% render_bundle 'tardis_portal_view_experiment_share' %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Fixes Synchronous XMLHttpRequest warning sometimes seen in experiment view page

This was caused by AJAX content loading scripts.

In ajax/experiment_dataset_transfer.html, render_bundle 'tardis_portal' can be
removed because the 'tardis_portal' bundle has already been loaded in
view_experiment.html

In ajax/share.html, render_bundle 'tardis_portal_view_experiment_share' can be
moved to view_experiment.html, but then we can't use $(document).ready(...) in
share.js.  Instead we call this function expSharingAjaxReady and call it from
experiment-tabs.js after the Sharing tab has been loaded.