### PR TITLE
Run npm audit in CI tests and include js-yaml in devDependencies,

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "grunt-contrib-qunit": "^3.1.0",
     "grunt-webpack": "^3.1.3",
     "jquery-mockjax": "^2.5.0",
+    "js-yaml": "^3.13.1",
     "qunit": "^2.9.2"
   },
   "scripts": {

--- a/test.sh
+++ b/test.sh
@@ -42,7 +42,7 @@ case "$TEST_TYPE" in
 	(( exit_status = exit_status || $? ))
     ;;
     behave)
-        npm install && npm run-script build && \
+        npm install && npm audit && npm run-script build && \
         npm test && python test.py behave
 	(( exit_status = exit_status || $? ))
     ;;


### PR DESCRIPTION
so we don't get an old insecure js-yaml version installed as a
downstream dependency of another dev dependency.