### PR TITLE
Experiment tabs fixes

### DIFF
--- a/assets/js/tardis_portal/view_experiment/init/init.js
+++ b/assets/js/tardis_portal/view_experiment/init/init.js
@@ -6,6 +6,8 @@ jQuery(document).on("click", ".dataset_selector_none", function() {
     $(this).parents(".datafiles").find(".datafile_checkbox").removeAttr("checked");
 });
 
+import { loadExpTabPane } from "../experiment-tabs.js";
+
 function getNewParameterName(name)
 {
     var newName = name;
@@ -72,9 +74,8 @@ $(document).on("click", "#add_new_parameter", function() {
     }
 });
 
-var refreshMetadataDisplay = function(hash) {
-    var expChangeEvent = new Event("experiment-change");
-    $("#experiment-tab-metadata")[0].dispatchEvent(expChangeEvent);
+var refreshMetadataDisplay = function() {
+    loadExpTabPane("metadata");
 };
 
 $(document).on("submit", "#add_metadata_form", function(e) {

--- a/assets/js/tardis_portal/view_experiment/share/share.js
+++ b/assets/js/tardis_portal/view_experiment/share/share.js
@@ -3,6 +3,8 @@
 
 import {userAutocompleteHandler} from "../../main";
 
+import { loadExpTabPane } from "../experiment-tabs.js";
+
 var loadingHTML = "<img src=\"/static/images/ajax-loader.gif\"/><br />";
 
 export function addChangePublicAccessEventHandlers() {
@@ -28,8 +30,7 @@ export function addChangePublicAccessEventHandlers() {
     });
 
     $("#modal-public-access").bind("hidden.bs.modal", function() {
-        var expChangeEvent = new Event("experiment-change");
-        $(this).parents(".tab-pane")[0].dispatchEvent(expChangeEvent);
+        loadExpTabPane("sharing");
     });
 }
 
@@ -203,8 +204,7 @@ export function addUserSharingEventHandlers() {
     });
 
     $("#modal-share").bind("hidden.bs.modal", function() {
-        var expChangeEvent = new Event("experiment-change");
-        $(this).parents(".tab-pane")[0].dispatchEvent(expChangeEvent);
+        loadExpTabPane("sharing");
     });
 }
 
@@ -430,8 +430,7 @@ export function addGroupSharingEventHandlers() {
     });
 
     $("#modal-share-group").bind("hidden.bs.modal", function() {
-        var expChangeEvent = new Event("experiment-change");
-        $(this).parents(".tab-pane")[0].dispatchEvent(expChangeEvent);
+        loadExpTabPane("sharing");
     });
 }
 

--- a/js_tests/tardis_portal/view_experiment/experiment-tabs.test.js
+++ b/js_tests/tardis_portal/view_experiment/experiment-tabs.test.js
@@ -14,10 +14,10 @@ QUnit.test("Load experiment tabs", function(assert) {
 
     $("#qunit-fixture").append(
         "<ul id=\"experiment-tabs\" class=\"nav nav-pills\">\n" +
-        "  <li><a data-toggle=\"tab\" title=\"Description\" href=\"/ajax/experiment/1/description\">Description</a></li>\n" +
-        "  <li><a data-toggle=\"tab\" title=\"Metadata\" href=\"/ajax/experiment_metadata/1/\">Metadata</a></li>\n" +
-        "  <li><a data-toggle=\"tab\" title=\"Sharing\" href=\"/ajax/experiment/1/share\">Sharing</a></li>\n" +
-        "  <li><a data-toggle=\"tab\" title=\"Transfer Datasets\" href=\"/ajax/experiment/1/dataset-transfer\">Transfer Datasets</a></li>\n" +
+        "  <li><a data-toggle=\"tab\" title=\"Description\" data-url=\"/ajax/experiment/1/description\">Description</a></li>\n" +
+        "  <li><a data-toggle=\"tab\" title=\"Metadata\" data-url=\"/ajax/experiment_metadata/1/\">Metadata</a></li>\n" +
+        "  <li><a data-toggle=\"tab\" title=\"Sharing\" data-url=\"/ajax/experiment/1/share\">Sharing</a></li>\n" +
+        "  <li><a data-toggle=\"tab\" title=\"Transfer Datasets\" data-url=\"/ajax/experiment/1/dataset-transfer\">Transfer Datasets</a></li>\n" +
         "</ul>\n" +
         "<div class=\"tab-content\">\n" +
         "  <div id=\"experiment-tab-description\">\n" +

--- a/tardis/tardis_portal/templates/tardis_portal/view_experiment.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_experiment.html
@@ -101,7 +101,7 @@
     <!-- Tab buttons -->
     <ul id="experiment-tabs" class="nav nav-pills">
       {% for appurl, appname in apps %}
-      <li><a data-toggle="tab" title="{{appname}}" href="{{ appurl }}">{{ appname }}</a></li>
+      <li><a data-toggle="tab" title="{{appname}}" data-url="{{ appurl }}">{{ appname }}</a></li>
       {% endfor %}
     </ul>
     <div class="tab-content">


### PR DESCRIPTION
Directly call a function to load tab pane content instead of using
Javascript events.  Use event.preventDefault() anchor click handlers.
Use data-url rather than href to store AJAX URL. Previously one href
(AJAX URL) was being overwritten by another one.