### PR TITLE
Fix duplicate dataset metadata form submission

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/ajax/parameteradd.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/parameteradd.html
@@ -34,7 +34,7 @@
 
     <div class="form-group">
       <footer class="col-md-12 text-right">
-        <button type="submit" class="cancel-button btn btn-default"
+        <button type="button" class="cancel-button btn btn-default"
                 data-dismiss="modal">
           <i class="fa fa-close"></i>
           Cancel

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/parameteredit.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/parameteredit.html
@@ -39,7 +39,7 @@
 
     <div class="form-group">
       <footer class="col-md-12 text-right">
-        <button type="submit" class="cancel-button btn btn-default"
+        <button type="button" class="cancel-button btn btn-default"
                 data-dismiss="modal">
           <i class="fa fa-close"></i>
           Cancel

--- a/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_dataset.html
@@ -30,11 +30,6 @@
 <div id="upload_button_code" style="display: none"></div>
 
 <input type="hidden" id="dataset-id" value="{{ dataset.id }}">
-<script type="text/javascript">
-$(document).on('click', '#modal-metadata .submit-button', function() {
-  $('#modal-metadata .modal-body form').submit();
-});
-</script>
 
 <div class="modal" id="modal-metadata" role="dialog" tabindex="-1">
   <div class="modal-dialog" role="document">


### PR DESCRIPTION
Now that the Add/Save submit button is inside the form, we don't
need Javascript code to submit the form.