### PR TITLE
Unapproved user should not be able to download api key and manage SSH keys

### DIFF
--- a/tardis/apps/sftp/user_menu_modifiers.py
+++ b/tardis/apps/sftp/user_menu_modifiers.py
@@ -1,5 +1,7 @@
 from django.urls import reverse
 
+from tardis.tardis_portal.templatetags.approved_user_tags import check_if_user_not_approved
+
 
 def add_ssh_keys_menu_item(request, user_menu):
     """Add a 'Manage SSH Keys' item to the user menu
@@ -11,6 +13,8 @@ def add_ssh_keys_menu_item(request, user_menu):
     :return: user_menu list
     :rtype: list
     """
+    if check_if_user_not_approved(request):
+        return user_menu
     ssh_keys_menu_item = dict(
         url=reverse('tardis.apps.sftp:sftp_keys'),
         icon='fa fa-key',

--- a/tardis/tardis_portal/context_processors.py
+++ b/tardis/tardis_portal/context_processors.py
@@ -3,6 +3,8 @@ from importlib import import_module
 from django.conf import settings
 from django.urls import reverse
 
+from tardis.tardis_portal.templatetags.approved_user_tags import check_if_user_not_approved
+
 
 def single_search_processor(request):
 
@@ -79,7 +81,8 @@ def user_menu_processor(request):
             url=reverse('tardis.tardis_portal.views.manage_user_account'),
             icon='fa fa-user',
             label='Manage Account'))
-    if hasattr(request.user, 'api_key') and request.user.api_key.key:
+    if hasattr(request.user, 'api_key') and request.user.api_key.key \
+            and not check_if_user_not_approved(request):
         user_menu.append(dict(
             url=reverse('tardis.tardis_portal.download.download_api_key'),
             icon='fa fa-key',
@@ -95,8 +98,9 @@ def user_menu_processor(request):
             url=reverse('admin:index'),
             icon='fa fa-key',
             label='Admin Interface'))
-    if request.user.has_perm('auth.change_user') or \
-            request.user.has_perm('auth.change_group'):
+    if (request.user.has_perm('auth.change_user') or
+        request.user.has_perm('auth.change_group')) and \
+            not check_if_user_not_approved(request):
         user_menu.append(dict(divider='True'))
         user_menu.append(dict(
             url=reverse('tardis.tardis_portal.views.manage_groups'),


### PR DESCRIPTION
This PR aims to fix issue where a a user pending admin approval was able to download api keys and manage SSH keys 