### PR TITLE
Add missing btn-default, required in Bootstrap v3 to ensure that

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/ajax/parameters.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/parameters.html
@@ -14,7 +14,7 @@
 
     <div class="btn-group pull-right">
       {% if has_download_permissions and datafile.is_online %}
-      <a  class="btn"
+      <a  class="btn btn-default"
           href="{{ datafile.get_download_url }}"
           title="Download">
           <i class="fa fa-download fa-lg"></i>


### PR DESCRIPTION
the button has a border.