### PR TITLE
Experiment sharing dialog fixes

### DIFF
--- a/assets/js/tardis_portal/view_experiment/share/share.js
+++ b/assets/js/tardis_portal/view_experiment/share/share.js
@@ -69,9 +69,9 @@ const userSharingModalLoaded = function() {
     });
     // Load user list and activate field autocompletion
     $.ajax({
-        "dataType": "json",
-        "url": "/ajax/user_list/",
-        "success": function(users) {
+        dataType: "json",
+        url: "/ajax/user_list/",
+        success: function(users) {
             if($("select#id_authMethod option").length === 1) {
                 $("#id_authMethod_label").hide();
                 $("#id_authMethod").hide();
@@ -110,6 +110,7 @@ const userSharingModalLoaded = function() {
             username = enteredUser;
             authMethod = $(this).siblings("#id_authMethod").val();
         }
+        var usersDiv = $(this).parents(".access_list1").children(".users");
         var userMessagesDiv = $("#user-sharing-messages");
         var permissions = $(this).siblings("#id_permission").val();
 
@@ -138,31 +139,42 @@ const userSharingModalLoaded = function() {
             "/access_list/add/user/" + username + permissions;
 
         $.ajax({
-            "global": true,
             type: "GET",
             url: action,
             success: function(data) {
-                userMessagesDiv.hide().html(data).fadeIn();
+                usersDiv.hide().append(data).fadeIn();
+                userMessagesDiv.hide().html("");
                 // todo this is a duplicate function..
                 $(".remove_user").unbind("click");
                 $(".remove_user").click(function() {
                     var href = $(this).attr("href");
                     var removeUser = $(this);
                     $.ajax({
-                        "global": false,
-                        "url": href,
-                        "success": function(data2) {
-                            var val = data2;
-                            if(val === "OK") {
-                                removeUser.fadeOut(300, function() { removeUser.parents(".access_list_user").remove(); });
-                            }
-                            else { alert(val); }
+                        global: false,
+                        url: href,
+                        success: function() {
+                            removeUser.fadeOut(300, function() {
+                                removeUser.parents(".access_list_user").remove();
+                            });
+                        },
+                        error: function(jqXHR, textStatus, errorThrown) {
+                            alert(jqXHR.responseText);
+                        },
+                        complete: function() {
+                            userMessagesDiv.hide().html("");
                         }
                     }); // end ajax
                     return false;
                 }); // end remove user
             },
-            error: function(data) { alert("Error adding user"); }
+            error: function(jqXHR, textStatus, errorThrown) {
+                if (jqXHR.status === 400) {
+                    userMessagesDiv.hide().html(jqXHR.responseText).fadeIn();
+                    return;
+                }
+                userMessagesDiv.hide().html("");
+                alert("Error adding user");
+            }
         });
         return false;
     });
@@ -172,14 +184,18 @@ const userSharingModalLoaded = function() {
         var href = $(this).attr("href");
         var removeUser = $(this);
         $.ajax({
-            "global": false,
-            "url": href,
-            "success": function(data) {
-                var val = data;
-                if(val === "OK") {
-                    removeUser.fadeOut(300, function() { removeUser.parents(".access_list_user").remove(); });
-                }
-                else { alert(val); }
+            global: false,
+            url: href,
+            success: function() {
+                removeUser.fadeOut(300, function() {
+                    removeUser.parents(".access_list_user").remove();
+                });
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                alert(jqXHR.responseText);
+            },
+            complete: function() {
+                $("#user-sharing-messages").hide().html("");
             }
         }); // end ajax
         return false;
@@ -214,9 +230,9 @@ const groupSharingModalLoaded = function() {
     modal.find(".loading-placeholder").hide();
 
     $.ajax({
-        "global": false,
-        "url": "/ajax/group_list/",
-        "success": function(data) {
+        global: false,
+        url: "/ajax/group_list/",
+        success: function(data) {
             var groups = data;
             $(".groupsuggest").typeahead({
                 "source": groups.split(" ~ ")
@@ -253,9 +269,9 @@ const groupSharingModalLoaded = function() {
         userList.load(this.href, function() {
             // Load user list and activate field autocompletion
             $.ajax({
-                "dataType": "json",
-                "url": "/ajax/user_list/",
-                "success": function(users2) {
+                dataType: "json",
+                url: "/ajax/user_list/",
+                success: function(users2) {
                     var autocompleteHandler = function(usersForHandler, query, callback) {
                         return callback(userAutocompleteHandler(query, usersForHandler));
                     };
@@ -278,6 +294,7 @@ const groupSharingModalLoaded = function() {
         event.preventDefault();
 
         var groupsuggest = $(this).parents(".access_list2").find(".groupsuggest").val();
+        var groupsDiv = $(this).parents(".access_list2").children(".groups");
         var groupMessagesDiv = $("#group-sharing-messages");
 
         var action = "/experiment/control_panel/" + $("#experiment-id").val() + "/access_list/add/group/" + groupsuggest;
@@ -311,7 +328,8 @@ const groupSharingModalLoaded = function() {
             type: "GET",
             url: action,
             success: function(data) {
-                groupMessagesDiv.hide().html(data).fadeIn();
+                groupsDiv.hide().append(data).fadeIn();
+                groupMessagesDiv.hide().html("");
 
                 // view group members
                 $(".member_list_user_toggle").unbind("click");
@@ -334,9 +352,9 @@ const groupSharingModalLoaded = function() {
                     userList.load(this.href, function() {
                         // Load user list and activate field autocompletion
                         $.ajax({
-                            "dataType": "json",
-                            "url": "/ajax/user_list/",
-                            "success": function(users2) {
+                            dataType: "json",
+                            url: "/ajax/user_list/",
+                            success: function(users2) {
                                 var autocompleteHandler = function(usersForHandler, query, callback) {
                                     return callback(userAutocompleteHandler(query, usersForHandler));
                                 };
@@ -361,22 +379,31 @@ const groupSharingModalLoaded = function() {
                     var removeGroup = $(this);
 
                     $.ajax({
-                        "global": false,
-                        "url": href,
-                        "success": function(data2) {
-                            var val = data2;
-                            if(val === "OK") {
-                                removeGroup.fadeOut(300, function() {
-                                    removeGroup.parents(".access_list_group").remove();
-                                });
-                            }
-                            else { alert(val); }
+                        global: false,
+                        url: href,
+                        success: function() {
+                            removeGroup.fadeOut(300, function() {
+                                removeGroup.parents(".access_list_group").remove();
+                            });
+                        },
+                        error: function(jqXHR, textStatus, errorThrown) {
+                            alert(jqXHR.responseText);
+                        },
+                        complete: function() {
+                            groupMessagesDiv.hide().html("");
                         }
                     }); // end ajax
                     return false;
                 }); // end remove group
             },
-            error: function(data) { alert("Error adding group!"); }
+            error: function(jqXHR, textStatus, errorThrown) {
+                if (jqXHR.status === 400) {
+                    groupMessagesDiv.hide().html(jqXHR.responseText).fadeIn();
+                    return;
+                }
+                groupMessagesDiv.hide().html("");
+                alert("Error adding group!");
+            }
         });
         return false;
     });
@@ -389,16 +416,18 @@ const groupSharingModalLoaded = function() {
         var removeGroup = $(this);
 
         $.ajax({
-            "global": false,
-            "url": href,
-            "success": function(data) {
-                var val = data;
-                if(val === "OK") {
-                    removeGroup.fadeOut(300, function() {
-                        removeGroup.parents(".access_list_group").remove();
-                    });
-                }
-                else { alert("val"); }
+            global: false,
+            url: href,
+            success: function() {
+                removeGroup.fadeOut(300, function() {
+                    removeGroup.parents(".access_list_group").remove();
+                });
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                alert(jqXHR.responseText);
+            },
+            complete: function() {
+                $("#group-sharing-messages").hide().html("");
             }
         }); // end ajax
 

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/access_list_group.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/access_list_group.html
@@ -10,9 +10,9 @@
   {% include "tardis_portal/ajax/add_group_result.html" %}
   {% endwith %}
 {% endfor %}
-  <div id="group-sharing-messages">
-  </div>
 </div> <!-- groups -->
+<div id="group-sharing-messages">
+</div>
 <form>
   <div class="form-group">
     <label class="control-label" for="id_group">Add group to experiment:</label>

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/access_list_user.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/access_list_user.html
@@ -6,9 +6,9 @@
   {% include "tardis_portal/ajax/add_user_result.html" %}
   {% endwith %}
 {% endfor %}
-  <div id="user-sharing-messages">
-  </div>
 </div> <!-- users -->
+<div id="user-sharing-messages">
+</div>
 <p>
 	<h3>Add new user</h3>
   <br/>

--- a/tardis/tardis_portal/tests/test_authorisation.py
+++ b/tardis/tardis_portal/tests/test_authorisation.py
@@ -155,6 +155,12 @@ class ObjectACLTestCase(TestCase):
                                    % (self.experiment1.id))
         self.assertEqual(response.status_code, 403)
 
+        # create a group and add it to experiment1
+        response = self.client1.get('/experiment/control_panel'
+                                    '/create/group/?group=%s&authMethod=localdb'
+                                    % ('group1'))
+        self.assertEqual(response.status_code, 200)
+
         # make the group1 a full read/write/owner of the experiment1
         response = self.client1.get('/experiment/control_panel/%i'
                                     '/access_list/add/group/%s/?canRead=true'
@@ -272,7 +278,9 @@ class ObjectACLTestCase(TestCase):
                                        non_existent,
                                        localdb_auth_key))
 
-        self.assertContains(response, 'User %s does not exist' % non_existent)
+        self.assertContains(
+            response, 'User %s does not exist' % non_existent,
+            status_code=400)
 
         # test add to non existent experiment
 

--- a/tardis/tardis_portal/views/authorisation.py
+++ b/tardis/tardis_portal/views/authorisation.py
@@ -295,18 +295,19 @@ def remove_user_from_group(request, group_id, username):
     try:
         user = User.objects.get(username=username)
     except User.DoesNotExist:
-        return HttpResponse('User %s does not exist.' % username)
+        return HttpResponse('User %s does not exist.' % username, status=400)
     try:
         group = Group.objects.get(pk=group_id)
     except Group.DoesNotExist:
-        return HttpResponse('Group does not exist.')
+        return HttpResponse('Group does not exist.', status=400)
 
     if user.groups.filter(name=group.name).count() == 0:
         return HttpResponse('User %s is not member of that group.'
-                            % username)
+                            % username, status=400)
 
     if request.user == user:
-        return HttpResponse('You cannot remove yourself from that group.')
+        return HttpResponse(
+            'You cannot remove yourself from that group.', status=400)
 
     user.groups.remove(group)
     user.save()
@@ -350,15 +351,17 @@ def add_experiment_access_user(request, experiment_id, username):
     try:
         user = User.objects.get(username=username)
         if not user.is_active:
-            return HttpResponse('User %s is inactive.' % (username))
+            return HttpResponse(
+                'User %s is inactive.' % (username), status=400)
     except User.DoesNotExist:
-        return HttpResponse('User %s does not exist.' % (username))
+        return HttpResponse('User %s does not exist.' % (username), status=400)
 
     try:
         experiment = Experiment.objects.get(pk=experiment_id)
     except Experiment.DoesNotExist:
-        return HttpResponse('Experiment (id=%d) does not exist.'
-                            % (experiment.id))
+        return HttpResponse(
+            'Experiment (id=%d) does not exist.' % (experiment.id),
+            status=400)
 
     acl = ObjectACL.objects.filter(
         content_type=experiment.get_ct(),
@@ -388,7 +391,7 @@ def add_experiment_access_user(request, experiment_id, username):
             request,
             'tardis_portal/ajax/add_user_result.html', c)
 
-    return HttpResponse('User already has experiment access.')
+    return HttpResponse('User already has experiment access.', status=400)
 
 
 @never_cache
@@ -397,12 +400,12 @@ def remove_experiment_access_user(request, experiment_id, username):
     try:
         user = User.objects.get(username=username)
     except User.DoesNotExist:
-        return HttpResponse('User %s does not exist' % username)
+        return HttpResponse('User %s does not exist' % username, status=400)
 
     try:
         Experiment.objects.get(pk=experiment_id)
     except Experiment.DoesNotExist:
-        return HttpResponse('Experiment does not exist')
+        return HttpResponse('Experiment does not exist', status=400)
 
     expt_acls = Experiment.safe.user_acls(experiment_id)
 
@@ -412,7 +415,7 @@ def remove_experiment_access_user(request, experiment_id, username):
     if target_acl.count() == 0:
         return HttpResponse('The user %s does not have access to this '
                             'experiment.'
-                            % username)
+                            % username, status=400)
 
     if expt_acls.count() >= 1:
         if len(owner_acls) > 1 or \
@@ -422,11 +425,12 @@ def remove_experiment_access_user(request, experiment_id, username):
         return HttpResponse(
             'All experiments must have at least one user as '
             'owner. Add an additional owner first before '
-            'removing this one.')
+            'removing this one.', status=400)
 
     # the user shouldn't really ever see this in normal operation
     return HttpResponse(
-        'Experiment has no permissions (of type OWNER_OWNED) !')
+        'Experiment has no permissions (of type OWNER_OWNED) !',
+        status=400)
 
 
 @transaction.atomic  # too complex # noqa
@@ -508,12 +512,14 @@ def add_experiment_access_group(request, experiment_id, groupname):
         experiment = Experiment.objects.get(pk=experiment_id)
     except Experiment.DoesNotExist:
         return HttpResponse('Experiment (id=%d) does not exist' %
-                            (experiment_id))
+                            (experiment_id),
+                            status=400)
 
     try:
         group = Group.objects.get(name=groupname)
     except Group.DoesNotExist:
-        return HttpResponse('Group %s does not exist' % (groupname))
+        return HttpResponse(
+            'Group %s does not exist' % (groupname), status=400)
 
     acl = ObjectACL.objects.filter(
         content_type=experiment.get_ct(),
@@ -525,8 +531,9 @@ def add_experiment_access_group(request, experiment_id, groupname):
     if acl.count() > 0:
         # An ACL already exists for this experiment/group.
         return HttpResponse('Could not add group %s '
-                            '(It is likely that it already exists)' %
-                            (groupname))
+                            '(It has already been added)' %
+                            (groupname),
+                            status=400)
 
     acl = ObjectACL(content_object=experiment,
                     pluginId='django_group',


### PR DESCRIPTION
The previous commit attempted a minimal patch, retaining the
existing behaviour where even AJAX errors still returned an HTTP
status code of 200 (SUCCESS), but it's better to use different
status codes for success (200) and error (400) when adding/removing
users/groups from ObjectACLs.