### PR TITLE
Switch to an official version of django-tastypie.

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -10,8 +10,7 @@ django-elasticsearch-dsl==6.4.2
 git+https://github.com/mytardis/django-form-utils.git@django-1.11-upgrade#egg=django-form-utils
 django-jstemplate==1.3.8
 django-registration-redux==2.6
-# django-tastypie
-git+https://github.com/mytardis/django-tastypie.git@mytardis-dj1.9#egg=django-tastypie
+django-tastypie==0.14.0
 git+https://github.com/mytardis/django-tastypie-swagger.git@mytardis-dj1.11-py3#egg=django-tastypie-swagger
 django-user-agents==0.4.0
 django-webpack-loader==0.6.0

--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -893,8 +893,7 @@ class DataFileResource(MyTardisModelResource):
             return request.POST
         if format.startswith('multipart'):
             jsondata = request.POST['json_data']
-            data = super(DataFileResource, self).deserialize(
-                request, jsondata, format='application/json')
+            data = json.loads(jsondata)
             data.update(request.FILES)
             return data
         return super(DataFileResource, self).deserialize(request,


### PR DESCRIPTION
We were previously using a fork of v0.14.0, with a small change here:
https://github.com/mytardis/django-tastypie/commit/e97e02bfb48ad4d0150ff94090ec1bc5c8d6851b