### PR TITLE
Unauthenticated users don't need to be able to list storage box resources

### DIFF
--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -219,12 +219,17 @@ class ACLAuthorization(Authorization):
             if bundle.request.user.is_authenticated:
                 return object_list
         if isinstance(bundle.obj, StorageBox):
-            return object_list
+            if bundle.request.user.is_authenticated:
+                return object_list
         if isinstance(bundle.obj, StorageBoxOption):
-            return [option for option in object_list
-                    if option.key in StorageBoxOptionResource.accessible_keys]
+            if bundle.request.user.is_authenticated:
+                return [
+                    option for option in object_list
+                    if option.key in StorageBoxOptionResource.accessible_keys
+                ]
         if isinstance(bundle.obj, StorageBoxAttribute):
-            return object_list
+            if bundle.request.user.is_authenticated:
+                return object_list
         return []
 
     def read_detail(self, object_list, bundle):  # noqa # too complex


### PR DESCRIPTION
Unauthenticated users don't need to be able to list storage box resources

We were already hiding the sensitive options - everything except "location",
and we were already requiring authentication for read_detail.