### PR TITLE
updating django elasticsearch dsl to 7

### DIFF
--- a/docker-ci/docker-test.yml
+++ b/docker-ci/docker-test.yml
@@ -34,7 +34,7 @@ services:
       MYSQL_ROOT_PASSWORD: mysql
     command: --default-authentication-plugin=mysql_native_password
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.0.1
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -5,7 +5,7 @@ bleach==3.1.0
 boto3==1.9.242
 celery==4.3.0
 django-extensions==2.2.3
-django-elasticsearch-dsl==6.4.2
+django-elasticsearch-dsl==7.0.0
 git+https://github.com/mytardis/django-form-utils.git@django-1.11-upgrade#egg=django-form-utils
 django-jstemplate==1.3.8
 django-registration-redux==2.6

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -5,7 +5,7 @@ bleach==3.1.0
 boto3==1.9.242
 celery==4.3.0
 django-extensions==2.2.3
-django-elasticsearch-dsl==7.1.0
+django-elasticsearch-dsl==7.1.1
 git+https://github.com/mytardis/django-form-utils.git@django-1.11-upgrade#egg=django-form-utils
 django-jstemplate==1.3.8
 django-registration-redux==2.6

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -5,7 +5,7 @@ bleach==3.1.0
 boto3==1.9.242
 celery==4.3.0
 django-extensions==2.2.3
-django-elasticsearch-dsl==7.0.0
+django-elasticsearch-dsl==7.1.0
 git+https://github.com/mytardis/django-form-utils.git@django-1.11-upgrade#egg=django-form-utils
 django-jstemplate==1.3.8
 django-registration-redux==2.6
@@ -14,7 +14,6 @@ git+https://github.com/mytardis/django-tastypie-swagger.git@mytardis-dj2.0#egg=d
 django-user-agents==0.4.0
 django-webpack-loader==0.6.0
 django-widget-tweaks==1.4.5
-elasticsearch==6.4.0 # pyup: <7.0
 django-storages==1.7.2
 gunicorn==19.9.0
 gevent==1.4.0

--- a/tardis/apps/search/api.py
+++ b/tardis/apps/search/api.py
@@ -113,13 +113,13 @@ class SearchAppResource(Resource):
         for item in results:
             for hit in item.hits.hits:
                 if hit["_index"] == "dataset":
-                    result_dict["datasets"].append(hit)
+                    result_dict["datasets"].append(hit.to_dict())
 
                 elif hit["_index"] == "experiments":
-                    result_dict["experiments"].append(hit)
+                    result_dict["experiments"].append(hit.to_dict())
 
                 elif hit["_index"] == "datafile":
-                    result_dict["datafiles"].append(hit)
+                    result_dict["datafiles"].append(hit.to_dict())
 
         return [SearchObject(id=1, hits=result_dict)]
 
@@ -151,13 +151,13 @@ def simple_search_public_data(query_text):
     for item in results:
         for hit in item.hits.hits:
             if hit["_index"] == "dataset":
-                result_dict["datasets"].append(hit)
+                result_dict["datasets"].append(hit.to_dict())
 
             elif hit["_index"] == "experiments":
-                result_dict["experiments"].append(hit)
+                result_dict["experiments"].append(hit.to_dict())
 
             elif hit["_index"] == "datafile":
-                result_dict["datafiles"].append(hit)
+                result_dict["datafiles"].append(hit.to_dict())
     return result_dict
 
 
@@ -276,13 +276,13 @@ class AdvanceSearchAppResource(Resource):
         for item in result:
             for hit in item.hits.hits:
                 if hit["_index"] == "dataset":
-                    result_dict["datasets"].append(hit)
+                    result_dict["datasets"].append(hit.to_dict())
 
                 elif hit["_index"] == "experiments":
-                    result_dict["experiments"].append(hit)
+                    result_dict["experiments"].append(hit.to_dict())
 
                 elif hit["_index"] == "datafile":
-                    result_dict["datafiles"].append(hit)
+                    result_dict["datafiles"].append(hit.to_dict())
 
         if bundle.request.method == 'POST':
             bundle.obj = SearchObject(id=1, hits=result_dict)

--- a/tardis/apps/search/documents.py
+++ b/tardis/apps/search/documents.py
@@ -160,7 +160,7 @@ class DataFileDocument(Document):
     class Django:
         model = DataFile
         related_models = [Dataset, Experiment]
-        queryset_pagination = 100000
+        queryset_pagination = 5000
 
     def get_instances_from_related(self, related_instance):
         if isinstance(related_instance, Dataset):

--- a/tardis/apps/search/documents.py
+++ b/tardis/apps/search/documents.py
@@ -157,7 +157,7 @@ class DataFileDocument(Document):
     class Django:
         model = DataFile
         related_models = [Dataset, Experiment]
-        queryset_pagination = 100000
+        queryset_pagination = 10000
 
     def get_instances_from_related(self, related_instance):
         if isinstance(related_instance, Dataset):

--- a/tardis/apps/search/documents.py
+++ b/tardis/apps/search/documents.py
@@ -42,15 +42,13 @@ class ExperimentDocument(Document):
     start_time = fields.DateField()
     end_time = fields.DateField()
     update_time = fields.DateField()
-    institution_name = fields.StringField()
+    institution_name = fields.KeywordField()
     created_by = fields.ObjectField(properties={
-        'username': fields.StringField(
-            fields={'raw': fields.KeywordField()},
-        )
+        'username': fields.KeywordField()
     })
     objectacls = fields.ObjectField(properties={
-        'pluginId': fields.StringField(),
-        'entityId': fields.StringField()
+        'pluginId': fields.KeywordField(),
+        'entityId': fields.KeywordField()
     }
     )
 
@@ -85,8 +83,8 @@ class DatasetDocument(Document):
                     }
         ),
         'objectacls': fields.ObjectField(properties={
-            'pluginId': fields.StringField(),
-            'entityId': fields.StringField()
+            'pluginId': fields.KeywordField(),
+            'entityId': fields.KeywordField()
         }
         ),
         'public_access': fields.IntegerField()
@@ -116,6 +114,9 @@ class DatasetDocument(Document):
 
 @registry.register_document
 class DataFileDocument(Document):
+    def parallel_bulk(self, actions, **kwargs):
+        Document.parallel_bulk(self, actions=actions, chunk_size=10000, thread_count=8)
+
     class Index:
         name = 'datafile'
         settings = {'number_of_shards': 1,
@@ -131,8 +132,8 @@ class DataFileDocument(Document):
         'experiments': fields.NestedField(properties={
             'id': fields.IntegerField(),
             'objectacls': fields.ObjectField(properties={
-                'pluginId': fields.StringField(),
-                'entityId': fields.StringField()
+                'pluginId': fields.KeywordField(),
+                'entityId': fields.KeywordField()
             }
             ),
             'public_access': fields.IntegerField()

--- a/tardis/apps/search/documents.py
+++ b/tardis/apps/search/documents.py
@@ -61,13 +61,15 @@ class ExperimentDocument(Document):
 
     class Django:
         model = Experiment
-        related_models = [User, ObjectACL]
+        related_models = [User, ObjectACL, DataFile]
 
     def get_instances_from_related(self, related_instance):
         if isinstance(related_instance, User):
             return related_instance.experiment_set.all()
         if isinstance(related_instance, ObjectACL):
             return related_instance.content_object
+        if isinstance(related_instance, DataFile):
+            related_instance.dataset.experiments.all()
         return None
 
 
@@ -165,4 +167,6 @@ class DataFileDocument(Document):
     def get_instances_from_related(self, related_instance):
         if isinstance(related_instance, Dataset):
             return related_instance.datafile_set.all()
+        if isinstance(related_instance, Experiment):
+            return DataFile.objects.filter(dataset__experiments=related_instance)
         return None

--- a/tardis/apps/search/tests/test_index.py
+++ b/tardis/apps/search/tests/test_index.py
@@ -77,7 +77,7 @@ class IndexExperimentTestCase(TestCase):
         search = DatasetDocument.search()
         query = search.query("match", description='test_dataset')
         result = query.execute(ignore_cache=True)
-        self.assertEqual(result.hits.total, 1)
+        self.assertEqual(result.hits.total.value, 1)
         # search on datafile
         settings.REQUIRE_DATAFILE_SIZES = False
         settings.REQUIRE_DATAFILE_CHECKSUMS = False

--- a/tardis/default_settings/search.py
+++ b/tardis/default_settings/search.py
@@ -18,6 +18,16 @@ ELASTICSEARCH_DSL_INDEX_SETTINGS = {
 }
 '''
 
+ELASTICSEARCH_PARALLEL_INDEX_SETTINGS = {
+    'chunk_size': 500,
+    'thread_count': 4
+}
+'''
+Setting for running elastic search index in parallel mode to get indexing speed boost while indexing
+https://django-elasticsearch-dsl.readthedocs.io/en/latest/settings.html#elasticsearch-dsl-parallel
+'''
+
+
 MAX_SEARCH_RESULTS = 100
 '''
 Limits the maximum number of search results for each model (Experiment, Dataset and DataFile).


### PR DESCRIPTION
This PR :

- Provides support for Elasticsearch version 7.x in Mytardis
- Replaces deprecated field type with supported field types
- Provides support for parallel bulk indexing to speed up indexing time
- Normalizes Datafile document to speed up datafile indexing
- Provides support for latest version(7.1.1) of django-elasticsearch-dsl library.