### PR TITLE
Switch back to official version of pyoai.

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -27,7 +27,7 @@ kombu==4.6.5
 lxml==4.4.1
 paramiko==2.6.0
 pillow==6.2.0
-git+https://github.com/mytardis/pyoai.git@v2.5.1-mytardis-py3#egg=pyoai
+pyoai==2.5.0
 pystache==0.5.4
 python-dateutil==2.8.0
 # python-magic


### PR DESCRIPTION
It was forked because I thought it wasn't Python 3 compatible,
but the real problem was http://bugs.python.org/issue19846
which can be resolved by setting ENV LANG C.UTF-8 in our
Dockerfile to ensure that Python 3 has a sensible default encoding.