### PR TITLE
Only use jQuery ESLint config for files with '.js' extension.

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react-test-renderer": "^16.10.2"
   },
   "scripts": {
-    "eslint.jquery": "eslint -c .eslintrc assets/js/tardis_portal js_tests/tardis_portal/ tardis/apps/sftp/static/js/sftp/sftp.js tardis/apps/openid_migration/static/js/openid_migration/migrate_accounts.js",
+    "eslint.jquery": "eslint -c .eslintrc --ext .js assets/js/tardis_portal js_tests/tardis_portal/ tardis/apps/sftp/static/js/sftp/sftp.js tardis/apps/openid_migration/static/js/openid_migration/migrate_accounts.js",
     "eslint.angular": "eslint -c .eslintrc.angular assets/js/tardis_portal/facility_view/facility_view.js",
     "eslint.react": "eslint -c .eslintrc.react --ext .js,.jsx assets/js/apps/search/",
     "test-build": "webpack --config test-webpack.config.js --progress --colors --mode production",


### PR DESCRIPTION
React components will have a '.jsx' extension and be linted with
a different ESLint config, based on
https://github.com/airbnb/javascript/tree/master/react