### PR TITLE
use github action to test Mytardis

### DIFF
--- a/.github/workflows/mytardis-matrix-test.yml
+++ b/.github/workflows/mytardis-matrix-test.yml
@@ -31,3 +31,6 @@ jobs:
       run: |
         mkdir -p var/store
         python test.py
+    - name: run pylint
+      run: |
+        pylint --rcfile .pylintrc tardis

--- a/.github/workflows/mytardis-matrix-test.yml
+++ b/.github/workflows/mytardis-matrix-test.yml
@@ -16,6 +16,13 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install prerequisites
+      run: |
+        sudo apt-get update -yqq
+        sudo apt-get -yqq install --no-install-recommends -o=Dpkg::Use-Pty=0 \
+          libldap2-dev libsasl2-dev libmagic-dev libmagickwand-dev \
+          libssl-dev libxml2-dev libxslt1-dev zlib1g-dev \
+          libfreetype6-dev libjpeg-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/mytardis-matrix-test.yml
+++ b/.github/workflows/mytardis-matrix-test.yml
@@ -1,0 +1,26 @@
+name: Test Mytardis
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: [ubuntu-18.04]
+    strategy:
+      matrix:
+        python-version: [ '3.5', '3.6', '3.7', '3.8' ]
+    name: Python ${{ matrix.python-version }}
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -Ur requirements.txt
+    - name: run tests
+      run: |
+        mkdir -p var/store
+        python test.py


### PR DESCRIPTION
Github action will allow us to test Mytardis against different python versions

- Currently this is configured to run tests against python ['3.5', '3.6', '3.7', '3.8'] on [push, pull_requests]
- This will also run pylint