### PR TITLE
The 'sftp/key' resource name was sometimes triggering errors from lxml

### DIFF
--- a/tardis/apps/sftp/api.py
+++ b/tardis/apps/sftp/api.py
@@ -39,7 +39,7 @@ class SFTPPublicKeyAppResource(ModelResource):
         authentication = default_authentication
         authorization = SFTPACLAuthorization()
         validation = key_add_form
-        resource_name = 'sftp/key'
+        resource_name = 'publickey'
         filtering = {
             'id': ('exact',),
             'name': ('exact',),

--- a/tardis/apps/sftp/static/js/sftp/sftp.js
+++ b/tardis/apps/sftp/static/js/sftp/sftp.js
@@ -42,7 +42,7 @@ var sftp = (function() {
         }
 
         $.ajax(
-            "/api/v1/sftp/key/"
+            "/api/v1/sftp_publickey/"
         ).done(function(json, _textStatus, _jqXHR) {
             var objs = json.objects;
             if (objs.length > 0) {
@@ -60,7 +60,7 @@ var sftp = (function() {
 
     function handleKeyDelete(keyId) {
         $.ajax(
-            "/api/v1/sftp/key/" + keyId,
+            "/api/v1/sftp_publickey/" + keyId,
             {
                 method: "DELETE",
                 headers: {
@@ -101,7 +101,7 @@ var sftp = (function() {
                 }, {});
 
             $.ajax(
-                "/api/v1/sftp/key/",
+                "/api/v1/sftp_publickey/",
                 {
                     method: "POST",
                     headers: {
@@ -118,7 +118,7 @@ var sftp = (function() {
             }).fail(function(jqXHR, _textStatus, err) {
                 if (jqXHR.responseJSON !== "undefined") {
                     // eslint-disable-next-line dot-notation
-                    err = jqXHR.responseJSON["sftp/key"]["__all__"][0];
+                    err = jqXHR.responseJSON["sftp_publickey"]["__all__"][0];
                     $("#keyAddAlertMessage").text(err);
                     $("#keyAddAlert").show();
                 } else {

--- a/tardis/tardis_portal/tests/api/test_list_api_endpoints.py
+++ b/tardis/tardis_portal/tests/api/test_list_api_endpoints.py
@@ -1,0 +1,48 @@
+'''
+Testing listing all of the endpoints in MyTardis's Tastypie-based REST API
+
+.. moduleauthor:: James Wettenhall <james.wettenhall@monash.edu>
+'''
+import json
+
+from . import MyTardisResourceTestCase
+
+
+class ListEndpointsTest(MyTardisResourceTestCase):
+
+    def test_list_endpoints(self):
+        expected_output = {
+            'datafileparameter': {'list_endpoint': '/api/v1/datafileparameter/', 'schema': '/api/v1/datafileparameter/schema/'},
+            'datafileparameterset': {'list_endpoint': '/api/v1/datafileparameterset/', 'schema': '/api/v1/datafileparameterset/schema/'},
+            'dataset': {'list_endpoint': '/api/v1/dataset/', 'schema': '/api/v1/dataset/schema/'},
+            'dataset_file': {'list_endpoint': '/api/v1/dataset_file/', 'schema': '/api/v1/dataset_file/schema/'},
+            'datasetparameter': {'list_endpoint': '/api/v1/datasetparameter/', 'schema': '/api/v1/datasetparameter/schema/'},
+            'datasetparameterset': {'list_endpoint': '/api/v1/datasetparameterset/', 'schema': '/api/v1/datasetparameterset/schema/'},
+            'experiment': {'list_endpoint': '/api/v1/experiment/', 'schema': '/api/v1/experiment/schema/'},
+            'experimentauthor': {'list_endpoint': '/api/v1/experimentauthor/', 'schema': '/api/v1/experimentauthor/schema/'},
+            'experimentparameter': {'list_endpoint': '/api/v1/experimentparameter/', 'schema': '/api/v1/experimentparameter/schema/'},
+            'experimentparameterset': {'list_endpoint': '/api/v1/experimentparameterset/', 'schema': '/api/v1/experimentparameterset/schema/'},
+            'facility': {'list_endpoint': '/api/v1/facility/', 'schema': '/api/v1/facility/schema/'},
+            'group': {'list_endpoint': '/api/v1/group/', 'schema': '/api/v1/group/schema/'},
+            'instrument': {'list_endpoint': '/api/v1/instrument/', 'schema': '/api/v1/instrument/schema/'},
+            'location': {'list_endpoint': '/api/v1/location/', 'schema': '/api/v1/location/schema/'},
+            'objectacl': {'list_endpoint': '/api/v1/objectacl/', 'schema': '/api/v1/objectacl/schema/'},
+            'parametername': {'list_endpoint': '/api/v1/parametername/', 'schema': '/api/v1/parametername/schema/'},
+            'replica': {'list_endpoint': '/api/v1/replica/', 'schema': '/api/v1/replica/schema/'},
+            's3utils_replica': {'list_endpoint': '/api/v1/s3utils_replica/', 'schema': '/api/v1/s3utils_replica/schema/'},
+            'schema': {'list_endpoint': '/api/v1/schema/', 'schema': '/api/v1/schema/schema/'},
+            'search_advance-search': {'list_endpoint': '/api/v1/search_advance-search/',
+            'schema': '/api/v1/search_advance-search/schema/'},
+            'search_simple-search': {'list_endpoint': '/api/v1/search_simple-search/', 'schema': '/api/v1/search_simple-search/schema/'},
+            'sftp_publickey': {'list_endpoint': '/api/v1/sftp_publickey/', 'schema': '/api/v1/sftp_publickey/schema/'},
+            'storagebox': {'list_endpoint': '/api/v1/storagebox/', 'schema': '/api/v1/storagebox/schema/'},
+            'storageboxattribute': {'list_endpoint': '/api/v1/storageboxattribute/', 'schema': '/api/v1/storageboxattribute/schema/'},
+            'storageboxoption': {'list_endpoint': '/api/v1/storageboxoption/', 'schema': '/api/v1/storageboxoption/schema/'},
+            'user': {'list_endpoint': '/api/v1/user/', 'schema': '/api/v1/user/schema/'}
+        }
+        response = self.api_client.get('/api/v1/')
+        self.assertHttpOK(response)
+        returned_data = json.loads(response.content.decode())
+        for key, value in expected_output.items():
+            self.assertIn(key, returned_data)
+            self.assertEqual(returned_data[key], value)


### PR DESCRIPTION
The 'sftp/key' resource name was sometimes triggering errors from lxml:

django.request ERROR    Internal Server Error: /api/v1/
Traceback (most recent call last):
  ...
  File "/usr/local/lib/python3.6/dist-packages/tastypie/serializers.py", line 347, in to_etree
    element = Element(name or 'object')
  File "src/lxml/etree.pyx", line 3019, in lxml.etree.Element
  File "src/lxml/apihelpers.pxi", line 101, in lxml.etree._makeElement
  File "src/lxml/apihelpers.pxi", line 1721, in lxml.etree._tagValidOrRaise
ValueError: Invalid tag name 'sftp/key'