### PR TITLE
Fix Confirm button in Change Public Access dialog

### DIFF
--- a/assets/js/tardis_portal/view_experiment/share/licenses.js
+++ b/assets/js/tardis_portal/view_experiment/share/licenses.js
@@ -51,14 +51,16 @@ $(document).on("click", "#license-options .use-button", function(evt) {
     // Show confirmation window
     $("#selected-license-text").html($(this).parents(".license-option")
         .find(".col-md-10").html());
-    $("#legal-section").show();
     $("#license-options").hide();
+    $("#legal-section").show();
+    $("#confirm-license-btn-group").show();
 });
 
 $(document).on("click", "#reselect-license", function() {
     $("#selected-license-text").html("");
     $("#license-options").show();
     $("#legal-section").hide();
+    $("#confirm-license-btn-group").hide();
 });
 
 $(document).on("click", "#license-options .use-button", function(evt) {
@@ -78,12 +80,14 @@ $(document).on("click", "#license-options .use-button", function(evt) {
     // Show confirmation window
     $("#selected-license-text").html($(this).parents(".license-option")
         .find(".col-md-10").html());
-    $("#legal-section").show();
     $("#license-options").hide();
+    $("#legal-section").show();
+    $("#confirm-license-btn-group").show();
 });
 
 $(document).on("click", "#reselect-license", function() {
     $("#selected-license-text").html("");
     $("#license-options").show();
     $("#legal-section").hide();
+    $("#confirm-license-btn-group").hide();
 });

--- a/assets/js/tardis_portal/view_experiment/share/public_access_events.js
+++ b/assets/js/tardis_portal/view_experiment/share/public_access_events.js
@@ -8,18 +8,18 @@ import { selectLicenseOption } from "./licenses.js";
 export var addPublicAccessEvents = function() {
     $(document).on("change", "#publishing-consent", function() {
         // (submit disabled) <=> !(consent checked)
-        $("#legal-section .submit-button").prop("disabled", !$(this).prop("checked"));
+        $("form.experiment-rights .submit-button").prop("disabled", !$(this).prop("checked"));
     });
 
     // Disable submit button (as consent checkbox should start unchecked)
-    var changeEvent = new Event("change");
-    $("#publishing-consent")[0].dispatchEvent(changeEvent);
+    $("form.experiment-rights .submit-button").prop("disabled", true);
 
-    $(document).on("click", "#legal-section .submit-button", function() {
+    $(document).on("click", "form.experiment-rights .submit-button", function() {
         // Submit form
         var submitEvent = new Event("submit");
         $("form.experiment-rights")[0].dispatchEvent(submitEvent);
         $("#legal-section").hide();
+        $("#confirm-license-btn-group").hide();
     });
 
     $(document).on("click", "#legal-section .cancel-button", function() {
@@ -72,6 +72,7 @@ export var addPublicAccessEvents = function() {
                 thisModal.html(data);
                 // Show update message
                 $("#legal-section").hide();
+                $("#confirm-license-btn-group").hide();
 
                 $("#choose-rights-message").html(
                     Mustache.to_html(

--- a/assets/js/tardis_portal/view_experiment/share/share.js
+++ b/assets/js/tardis_portal/view_experiment/share/share.js
@@ -27,6 +27,7 @@ export function addChangePublicAccessEventHandlers() {
                 }
 
                 $("#legal-section").hide();
+                $("#confirm-license-btn-group").hide();
 
                 addPublicAccessEvents();
             });

--- a/tardis/tardis_portal/templates/tardis_portal/ajax/choose_rights.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/choose_rights.html
@@ -37,13 +37,13 @@
          style="white-space: pre-wrap; word-break: keep-all;">{{ form.legal_text.value }}</pre>
     <div class="checkbox">
       <label>
-        <input id="publishing-consent" type="checkbox" value="Agree" />
+        <input id="publishing-consent" type="checkbox" required value="Agree" />
         I agree to the above terms
       </label>
     </div>
   </div>
   <br>
-  <div class="form-group text-right">
+  <div id="confirm-license-btn-group" class="form-group text-right">
     <button type="button" class="cancel-button btn btn-outline-secondary"
             data-dismiss="modal">
       <i class="fa fa-close"></i>


### PR DESCRIPTION
Fix Confirm button in Change Public Access dialog whose jQuery selector was broken by moving it out of the legal-section div.

Also ensure Confirm button is hidden when the user hasn't selected a
license and ensure that it is disable when the user hasn't ticked
the checkbox.