### PR TITLE
Tree view fixes

### DIFF
--- a/assets/js/apps/tree_view/components/TreeView.jsx
+++ b/assets/js/apps/tree_view/components/TreeView.jsx
@@ -10,7 +10,7 @@ import Cookies from "js-cookie";
 import PropTypes from "prop-types";
 
 
-const TreeView = ({datasetId}) => {
+const TreeView = ({datasetId, modified}) => {
 
     const [cursor, setCursor] = useState(false);
     const [baseData, setBaseData] = useState([]);
@@ -27,7 +27,9 @@ const TreeView = ({datasetId}) => {
         .then((data) => { setBaseData(data); setData(data)  })
     };
     const fetchChildDirs = (dirName) => {
-      fetch('/api/v1/dataset/'+datasetId+'/child-dirs/?dir_name='+dirName+'&data='+JSON.stringify(data),{
+      const encodedDir = encodeURIComponent(dirName);
+      const encodedData = encodeURIComponent(JSON.stringify(data));
+      fetch(`/api/v1/dataset/${datasetId}/child-dirs/?dir_name=${encodedDir}&data=${encodedData}`,{
         method: 'get',
         headers: {
             "Accept": "application/json", // eslint-disable-line quote-props
@@ -39,10 +41,10 @@ const TreeView = ({datasetId}) => {
     };
     useEffect(() => {
       fetchBaseDirs('')
-    },[]);
+    },[datasetId, modified]);
     const onToggle = (node, toggled) => {
       //fetch children
-      if (toggled && node.children.length === 0){
+      if (toggled && node.children && node.children.length === 0){
         fetchChildDirs(node.name);
       }else {
         node.toggled = toggled;
@@ -97,11 +99,16 @@ const TreeView = ({datasetId}) => {
           />
         </div>
       </Fragment>
-
     )
 };
 
 TreeView.propTypes = {
-    datasetId: PropTypes.string,
+  datasetId: PropTypes.string.isRequired,
+  modified: PropTypes.string,
 };
+
+TreeView.defaultProps = {
+  modified: "",
+};
+
 export default TreeView;

--- a/assets/js/tardis_portal/view_dataset/file-upload.js
+++ b/assets/js/tardis_portal/view_dataset/file-upload.js
@@ -1,4 +1,9 @@
 /* global showMsg */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import TreeView from "../../apps/tree_view/components/TreeView";
+
 require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/vendor/jquery.ui.widget");
 require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.fileupload");
 require("imports-loader?define=>false&exports=>false!blueimp-file-upload/js/jquery.iframe-transport");
@@ -40,6 +45,15 @@ $(function() {
             setTimeout(function() {
                 var reloadEvent = new Event("reload");
                 $("#datafiles-pane")[0].dispatchEvent(reloadEvent);
+                ReactDOM.render(
+                    React.createElement(
+                        TreeView, {
+                            datasetId: $("#dataset-id").val(),
+                            modified: String(Date.now())
+                        }, null
+                    ),
+                    $("#tree_view")[0]
+                );
             }, 500);
         }
     });


### PR DESCRIPTION
1. Encode URI components when fetching child dirs.
2. Check if node.children is defined before evaluating node.children.length
3. Add a "modified" prop and use it to trigger re-rendering after each file upload