### PR TITLE
Remove connection.allow_thread_sharing, which was causing this error:

### DIFF
--- a/tardis/apps/sftp/sftp.py
+++ b/tardis/apps/sftp/sftp.py
@@ -45,7 +45,6 @@ paramiko_log.disabled = True
 
 if getattr(settings, 'SFTP_GEVENT', False):
     from gevent import monkey
-    from django.db import connection
     monkey.patch_all()
 
 # django db related modules must be imported after monkey-patching

--- a/tardis/apps/sftp/sftp.py
+++ b/tardis/apps/sftp/sftp.py
@@ -47,7 +47,6 @@ if getattr(settings, 'SFTP_GEVENT', False):
     from gevent import monkey
     from django.db import connection
     monkey.patch_all()
-    connection.allow_thread_sharing = True
 
 # django db related modules must be imported after monkey-patching
 from django.contrib.sites.models import Site  # noqa


### PR DESCRIPTION
"/app/tardis/apps/sftp/management/commands/sftpd.py", line 6, in <module>
    from tardis.apps.sftp import sftp
  File "/app/tardis/apps/sftp/sftp.py", line 50, in <module>
    connection.allow_thread_sharing = True
  File "/usr/local/lib/python3.6/dist-packages/django/db/__init__.py", line 31, in __setattr__
    return
setattr(connections[DEFAULT_DB_ALIAS], name, value)
AttributeError: can't set attribute