### PR TITLE
Remove gevent support from MyTardis SFTP

### DIFF
--- a/tardis/apps/sftp/default_settings.py
+++ b/tardis/apps/sftp/default_settings.py
@@ -1,7 +1,6 @@
 from tardis.default_settings import USER_MENU_MODIFIERS
 
 SFTP_PORT = 2200
-SFTP_GEVENT = False
 # SFTP_HOST_KEY = (
 #     "-----BEGIN RSA PRIVATE KEY-----\n"
 #     "...\n"

--- a/tardis/apps/sftp/sftp.py
+++ b/tardis/apps/sftp/sftp.py
@@ -43,10 +43,6 @@ paramiko_log = logging.getLogger('paramiko.transport')
 paramiko_log.disabled = True
 
 
-if getattr(settings, 'SFTP_GEVENT', False):
-    from gevent import monkey
-    monkey.patch_all()
-
 # django db related modules must be imported after monkey-patching
 from django.contrib.sites.models import Site  # noqa
 from django.contrib.auth.models import AnonymousUser  # noqa


### PR DESCRIPTION
Remove gevent support from MyTardis SFTP due to issues with DB connection sharing across threads