### PR TITLE
Make authors font style consistent with exp list view, and use pluralize

### DIFF
--- a/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_datasets.html
+++ b/tardis/tardis_portal/templates/tardis_portal/ajax/experiment_datasets.html
@@ -17,7 +17,7 @@
 {% endcapture %}
 
 <h3 style="display: inline">
-{{experiment.datasets.count}} Dataset{% if experiment.datasets.count|gt:1 %}s{%endif%}
+  {{experiment.datasets.count}} Dataset{{experiment.datasets.count|pluralize}}
 </h3>
 {% if has_download_permissions or has_write_permissions %}
 

--- a/tardis/tardis_portal/templates/tardis_portal/view_experiment.html
+++ b/tardis/tardis_portal/templates/tardis_portal/view_experiment.html
@@ -65,17 +65,14 @@
     {% endif %}
   </div>
   {% endif %}
-  <h1>
-    <span property="dc:title">{{ experiment.title }}</span>
-    <br/>
-    <small>
-        {% for author in experiment.experimentauthor_set.all %}{% capture as creator_span %}<span
-                property="dc:creator"
-                style="white-space: nowrap;">{{ author.author }}</span>{% endcapture %}{% if not forloop.first %}, {% endif %}{% if author.email %}<a
-                href="mailto:{{ author.email }}">{{ creator_span }}</a>{% endif %}{% if author.url %}<a
-                href="{{ author.url }}">{{ creator_span }}</a>{% endif %}{% if not author.email and not author.url %}{{ creator_span }}{% endif %}{% endfor %}
-    </small>
-  </h1>
+  <h1><span property="dc:title">{{ experiment.title }}</span></h1>
+  <span class="text-muted">
+    {% for author in experiment.experimentauthor_set.all %}{% capture as creator_span %}<span
+            property="dc:creator"
+            style="white-space: nowrap;">{{ author.author }}</span>{% endcapture %}{% if not forloop.first %}, {% endif %}{% if author.email %}<a
+            href="mailto:{{ author.email }}">{{ creator_span }}</a>{% endif %}{% if author.url %}<a
+            href="{{ author.url }}">{{ creator_span }}</a>{% endif %}{% if not author.email and not author.url %}{{ creator_span }}{% endif %}{% endfor %}
+  </span>
   <p style="text-align: right">
     {{ experiment|experiment_datasets_badge}}&nbsp;
     {{ experiment|experiment_datafiles_badge }}&nbsp;


### PR DESCRIPTION
Make authors font style consistent with exp list view, and use pluralize to ensure that an experiment with no datasets displays "0 Datasets", rather than "0 Dataset".