### PR TITLE
Revert "Merge pull request #2275 from jameswettenhall/avoid-creating-df-without-dfos"

### DIFF
--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -15,7 +15,7 @@ from django.conf.urls import url
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.auth.models import User
 from django.contrib.auth.models import Group
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError
 from django.http import HttpResponse, HttpResponseForbidden, \
     StreamingHttpResponse, HttpResponseNotFound, JsonResponse
 from django.shortcuts import redirect
@@ -965,7 +965,6 @@ class DataFileResource(MyTardisModelResource):
             del(bundle.data['attached_file'])
         return bundle
 
-    @transaction.atomic
     def obj_create(self, bundle, **kwargs):
         '''
         Creates a new DataFile object from the provided bundle.data dict.

--- a/tardis/tardis_portal/tests/api/__init__.py
+++ b/tardis/tardis_portal/tests/api/__init__.py
@@ -5,7 +5,7 @@ Testing the tastypie-based mytardis api
 .. moduleauthor:: James Wettenhall <james.wettenhall@monash.edu>
 '''
 from django.contrib.auth.models import User, Group, Permission
-from django.test import TransactionTestCase
+from django.test import TestCase
 
 from tastypie.test import ResourceTestCaseMixin
 
@@ -17,7 +17,7 @@ from ...models.facility import Facility
 from ...models.instrument import Instrument
 
 
-class MyTardisResourceTestCase(ResourceTestCaseMixin, TransactionTestCase):
+class MyTardisResourceTestCase(ResourceTestCaseMixin, TestCase):
     '''
     abstract class without tests to combine common settings in one place
     '''

--- a/tardis/tardis_portal/tests/api/test_datafile_resource.py
+++ b/tardis/tardis_portal/tests/api/test_datafile_resource.py
@@ -9,9 +9,6 @@ import json
 import os
 import tempfile
 
-import mock
-
-from django.db.utils import DatabaseError
 from django.test.client import Client
 
 import magic
@@ -202,45 +199,3 @@ class DataFileResourceTest(MyTardisResourceTestCase):
             authentication=self.get_credentials())
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.getvalue(), b"123test\n")
-
-    def test_failed_dfo_creation(self):
-        """Ensure we roll back DataFile creation if DataFileObject creation fails
-
-        The DataFile creation should be rolled back because of the @transaction.atomic
-        decorator before api.py's DataFileAppResource class's obj_create method.
-        """
-        ds_id = Dataset.objects.first().id
-        post_data = {
-            "dataset": "/api/v1/dataset/%d/" % ds_id,
-            "filename": "mytestfile.txt",
-            "md5sum": "930e419034038dfad994f0d2e602146c",
-            "size": "8",
-            "mimetype": "text/plain",
-            "parameter_sets": [],
-        }
-
-        datafile_count = DataFile.objects.count()
-        dfo_count = DataFileObject.objects.count()
-
-        with mock.patch(
-            "tardis.tardis_portal.models.datafile.DataFileObject.save"
-        ) as dfo_save_mock:
-            dfo_save_mock.side_effect = DatabaseError("database connection error")
-            # If we used the default SERVER_NAME of "testserver" below,
-            # Tastypie would re-raise the exception, rather than returning
-            # a 500 error in JSON format, which would then generate a 500.html
-            # response which would expect the webpack bundle to be available.
-            # We just want to test the case where Tastypie returns a JSON response
-            # with 500 status, so we change the SERVER_NAME:
-            with self.assertRaises(DatabaseError):
-                response = self.django_client.post(
-                    "/api/v1/dataset_file/",
-                    json.dumps(post_data),
-                    content_type="application/json",
-                    SERVER_NAME="not-testserver"
-                )
-                self.assertHttpApplicationError(response)
-
-        # Ensure that we haven't created a DataFile or a DataFileObject:
-        self.assertEqual(datafile_count, DataFile.objects.count())
-        self.assertEqual(dfo_count, DataFileObject.objects.count())


### PR DESCRIPTION
The `@transaction.atomic` decorator was doing more harm than good.  A better approach is to do something like this: https://github.com/mytardis/mytardis-app-mydata/commit/e45c68ea17b664280efdbd6ab09928d7bc5ae3a8 but we don't need this change in the core `api.py` so urgently, because its `obj_create` method is not used by MyData, i.e. MyData uses the `mytardis-app-mydata` repository's `api.py` instead.  The DataFile endpoint in the core `api.py` is used when creating DataFile records for indexing data already copied to the permanent storage location, so it may be worth re-looking at this after we roll back the `@transaction.atomic` change.

This reverts commit 0a3dc4d1fbe50792d0ccce4c6f698b96502cc991, reversing
changes made to 5fe42d99d4f052c29da6117ed89027a227296ba8.