### PR TITLE
Fix get accessible datafiles for user

### DIFF
--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -176,8 +176,8 @@ class ACLAuthorization(Authorization):
                     if has_dataset_access(bundle.request,
                                           dp.parameterset.dataset.id)]
         if isinstance(bundle.obj, DataFile):
-            return [df for df in object_list
-                    if has_datafile_access(bundle.request, df.id)]
+            all_files = get_accessible_datafiles_for_user(bundle.request)
+            return all_files.filter(id__in=obj_ids)
         if isinstance(bundle.obj, DatafileParameterSet):
             datafiles = get_accessible_datafiles_for_user(bundle.request)
             return DatafileParameterSet.objects.filter(

--- a/tardis/tardis_portal/api.py
+++ b/tardis/tardis_portal/api.py
@@ -176,8 +176,8 @@ class ACLAuthorization(Authorization):
                     if has_dataset_access(bundle.request,
                                           dp.parameterset.dataset.id)]
         if isinstance(bundle.obj, DataFile):
-            all_files = get_accessible_datafiles_for_user(bundle.request)
-            return all_files.filter(id__in=obj_ids)
+            return [df for df in object_list
+                    if has_datafile_access(bundle.request, df.id)]
         if isinstance(bundle.obj, DatafileParameterSet):
             datafiles = get_accessible_datafiles_for_user(bundle.request)
             return DatafileParameterSet.objects.filter(

--- a/tardis/tardis_portal/auth/decorators.py
+++ b/tardis/tardis_portal/auth/decorators.py
@@ -63,19 +63,14 @@ def get_owned_experiments(request):
 
 
 def get_accessible_datafiles_for_user(request):
-
     experiments = get_accessible_experiments(request)
-    if experiments.count() == 0:
+    experiment_ids = list(experiments.values_list('id', flat=True))
+
+    if len(experiment_ids) == 0:
         return DataFile.objects.none()
 
-    queries = [Q(dataset__experiments__id=id)
-        for id in experiments.values_list('id', flat=True)]
-
-    query = queries.pop()
-    for item in queries:
-        query |= item
-
-    return DataFile.objects.filter(query)
+    return DataFile.objects.filter(
+        Q(dataset__experiments__id__in=experiment_ids))
 
 
 def has_experiment_ownership(request, experiment_id):


### PR DESCRIPTION
I have replaced OR clause with IN to reduce query size.

Previously `get_accessible_datafiles_for_user` decorator would produce query similar to:

```
SELECT ... FROM "tardis_portal_datafile"
INNER JOIN "tardis_portal_dataset" ON
("tardis_portal_datafile"."dataset_id" = "tardis_portal_dataset"."id")
INNER JOIN "tardis_portal_dataset_experiments"
ON ("tardis_portal_dataset"."id" = "tardis_portal_dataset_experiments"."dataset_id")
WHERE (
"tardis_portal_dataset_experiments"."experiment_id" = %s OR
"tardis_portal_dataset_experiments"."experiment_id" = %s OR
"tardis_portal_dataset_experiments"."experiment_id" = %s OR
"tardis_portal_dataset_experiments"."experiment_id" = %s OR
"tardis_portal_dataset_experiments"."experiment_id" = %s OR
"tardis_portal_dataset_experiments"."experiment_id" = %s OR
"tardis_portal_dataset_experiments"."experiment_id" = %s OR
"tardis_portal_dataset_experiments"."experiment_id" = %s OR
... and so on forming queries ~150K in size
```

now it should look like:

```
SELECT ... FROM "tardis_portal_datafile"
INNER JOIN "tardis_portal_dataset"
ON ("tardis_portal_datafile"."dataset_id" = "tardis_portal_dataset"."id")
INNER JOIN "tardis_portal_dataset_experiments"
ON ("tardis_portal_dataset"."id" = "tardis_portal_dataset_experiments"."dataset_id")
WHERE (
"tardis_portal_dataset_experiments"."experiment_id" IN (
1, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
) AND "tardis_portal_datafile"."id" IN (
37, 87, 89, 88, 91, 90, 92, 75, 76, 77, 78, 79, 74, 69, 61, 48, 38, 36
)
ORDER BY "tardis_portal_datafile"."filename" ASC  LIMIT 20;
```
